### PR TITLE
Correct conceptual addresses/wallet mixup

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -10,6 +10,6 @@ Sometimes you will see it being used even for single cases `v |> f`, this is mor
 
 ### t
 
-A type named t means the main type of a module so, `Validators.t` can be read as `validators` and `Wallet.t` as `wallet`.
+A type named t means the main type of a module so, `Validators.t` can be read as `validators` and `Address.t` as `wallet`.
 
 An identifier named t on a module will always have type t, so under `Validators.re` `let t = empty` is the same as `let validators = empty`

--- a/HACKING.md
+++ b/HACKING.md
@@ -10,6 +10,6 @@ Sometimes you will see it being used even for single cases `v |> f`, this is mor
 
 ### t
 
-A type named t means the main type of a module so, `Validators.t` can be read as `validators` and `Address.t` as `wallet`.
+A type named t means the main type of a module so, `Validators.t` can be read as `validators` and `Wallet.t` as `wallet`.
 
 An identifier named t on a module will always have type t, so under `Validators.re` `let t = empty` is the same as `let validators = empty`

--- a/bin/genesis_helper.re
+++ b/bin/genesis_helper.re
@@ -39,7 +39,7 @@ let gen_credentials = () => {
 
   let make_identity_file = (~file, ~uri) => {
     let uri = Uri.of_string(uri);
-    let (key, t) = Wallet.make_pair();
+    let (key, t) = Wallet.make_wallet();
     let identity = {key, t, uri};
     identity_to_yojson(identity)
     |> Yojson.Safe.pretty_to_string

--- a/bin/genesis_helper.re
+++ b/bin/genesis_helper.re
@@ -18,7 +18,7 @@ let read_validators = file => {
       module T = {
         [@deriving of_yojson]
         type t = {
-          address: Address.t,
+          address: Wallet.pub_,
           uri: Uri.t,
         };
       };
@@ -52,7 +52,7 @@ let gen_credentials = () => {
     module T = {
       [@deriving to_yojson]
       type t = {
-        address: Address.t,
+        address: Wallet.pub_,
         uri: Uri.t,
       };
     };

--- a/bin/genesis_helper.re
+++ b/bin/genesis_helper.re
@@ -38,9 +38,8 @@ let gen_credentials = () => {
   };
 
   let make_identity_file = (~file, ~uri) => {
-    open Mirage_crypto_ec;
     let uri = Uri.of_string(uri);
-    let (key, t) = Ed25519.generate();
+    let (key, t) = Wallet.make_pair();
     let identity = {key, t, uri};
     identity_to_yojson(identity)
     |> Yojson.Safe.pretty_to_string
@@ -122,7 +121,9 @@ let inject_genesis = () => {
       state.validators
       |> Validators.to_list
       |> List.map(validator =>
-           Tezos_interop.Key.Ed25519(validator.Validators.address)
+           Tezos_interop.Key.Ed25519(
+             validator.Validators.address |> Wallet.pub_to_Ed25519pub,
+           )
          )
       |> List.map(Tezos_interop.Key.to_string)
       |> String.concat(","),

--- a/bin/genesis_helper.re
+++ b/bin/genesis_helper.re
@@ -18,7 +18,7 @@ let read_validators = file => {
       module T = {
         [@deriving of_yojson]
         type t = {
-          address: Wallet.pub_,
+          address: Wallet.key,
           uri: Uri.t,
         };
       };
@@ -51,7 +51,7 @@ let gen_credentials = () => {
     module T = {
       [@deriving to_yojson]
       type t = {
-        address: Wallet.pub_,
+        address: Wallet.key,
         uri: Uri.t,
       };
     };
@@ -122,7 +122,7 @@ let inject_genesis = () => {
       |> Validators.to_list
       |> List.map(validator =>
            Tezos_interop.Key.Ed25519(
-             validator.Validators.address |> Wallet.pub_to_Ed25519pub,
+             validator.Validators.address |> Wallet.key_to_Ed25519pub,
            )
          )
       |> List.map(Tezos_interop.Key.to_string)

--- a/bin/http_server.re
+++ b/bin/http_server.re
@@ -194,7 +194,7 @@ module Utils = {
         module T = {
           [@deriving of_yojson]
           type t = {
-            address: Address.t,
+            address: Wallet.pub_,
             uri: Uri.t,
           };
         };

--- a/bin/http_server.re
+++ b/bin/http_server.re
@@ -133,16 +133,16 @@ let handle_data_to_smart_contract =
         |> Signatures.to_list
         |> List.map(Signature.signature_to_b58check_by_address)
         |> List.to_seq
-        |> State.Address_map.of_seq;
+        |> State.Pubkey_map.of_seq;
       let (validators, signatures) =
         state.protocol.validators
         |> Validators.to_list
         |> List.map(validator => validator.Validators.address)
         |> List.map(address =>
              (
-               Tezos_interop.Key.Ed25519(address)
+               Tezos_interop.Key.Ed25519(address |> Wallet.pub_to_Ed25519pub)
                |> Tezos_interop.Key.to_string,
-               State.Address_map.find_opt(address, signatures_map),
+               State.Pubkey_map.find_opt(address, signatures_map),
              )
            )
         |> List.split;
@@ -217,8 +217,8 @@ let node = {
   let initial_validators_uri =
     List.fold_left(
       (validators_uri, (address, uri)) =>
-        State.Address_map.add(address, uri, validators_uri),
-      State.Address_map.empty,
+        State.Pubkey_map.add(address, uri, validators_uri),
+      State.Pubkey_map.empty,
       validators,
     );
   let node =

--- a/bin/http_server.re
+++ b/bin/http_server.re
@@ -133,7 +133,7 @@ let handle_data_to_smart_contract =
         |> Signatures.to_list
         |> List.map(Signature.signature_to_b58check_by_address)
         |> List.to_seq
-        |> State.Pubkey_map.of_seq;
+        |> State.Key_map.of_seq;
       let (validators, signatures) =
         state.protocol.validators
         |> Validators.to_list
@@ -142,7 +142,7 @@ let handle_data_to_smart_contract =
              (
                Tezos_interop.Key.Ed25519(address |> Wallet.key_to_Ed25519pub)
                |> Tezos_interop.Key.to_string,
-               State.Pubkey_map.find_opt(address, signatures_map),
+               State.Key_map.find_opt(address, signatures_map),
              )
            )
         |> List.split;
@@ -217,8 +217,8 @@ let node = {
   let initial_validators_uri =
     List.fold_left(
       (validators_uri, (address, uri)) =>
-        State.Pubkey_map.add(address, uri, validators_uri),
-      State.Pubkey_map.empty,
+        State.Key_map.add(address, uri, validators_uri),
+      State.Key_map.empty,
       validators,
     );
   let node =

--- a/bin/http_server.re
+++ b/bin/http_server.re
@@ -140,7 +140,7 @@ let handle_data_to_smart_contract =
         |> List.map(validator => validator.Validators.address)
         |> List.map(address =>
              (
-               Tezos_interop.Key.Ed25519(address |> Wallet.pub_to_Ed25519pub)
+               Tezos_interop.Key.Ed25519(address |> Wallet.key_to_Ed25519pub)
                |> Tezos_interop.Key.to_string,
                State.Pubkey_map.find_opt(address, signatures_map),
              )
@@ -194,7 +194,7 @@ module Utils = {
         module T = {
           [@deriving of_yojson]
           type t = {
-            address: Wallet.pub_,
+            address: Wallet.key,
             uri: Uri.t,
           };
         };

--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -240,10 +240,7 @@ let sign_block = (key, block_hash) =>
   switch (load_wallet_file(key)) {
   | Ok(wallet) =>
     let signature =
-      Signature.sign(
-        ~key=wallet.wallet |> Wallet.wallet_to_privkey,
-        block_hash,
-      );
+      Signature.sign(~key=wallet.wallet |> Wallet.to_privkey, block_hash);
     let.await () =
       Networking.(
         broadcast_to_list(
@@ -283,7 +280,7 @@ let produce_block = (key, state_bin) =>
   | Ok(wallet) =>
     let.await state: Protocol.t =
       Lwt_io.with_file(~mode=Input, state_bin, Lwt_io.read_value);
-    let address = wallet.wallet |> Wallet.pubkey_of_wallet;
+    let address = wallet.wallet |> Wallet.to_key;
     let block =
       Block.produce(
         ~state,

--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -63,7 +63,7 @@ let info_create_wallet = {
 };
 
 let create_wallet = () => {
-  let (wallet, pubkey) = Wallet.make_pair();
+  let (wallet, pubkey) = Wallet.make_wallet();
   let address = pubkey |> Address.of_pubkey;
 
   let wallet_json = Serializable.wallet_file_to_yojson({wallet, address});

--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -39,8 +39,8 @@ let make_filename_from_address = wallet_addr_str => {
 module Serializable = {
   [@deriving yojson]
   type wallet_file = {
-    address: Wallet.t,
-    priv_key: Address.key,
+    address: Address.t,
+    priv_key: Wallet.t,
   };
 };
 
@@ -103,7 +103,7 @@ let amount = {
     Format.fprintf(fmt, "%d", Amount.to_int(amount));
   Arg.(conv(~docv="A positive amount", (parser, printer)));
 };
-// TODO: Wallet.t
+// TODO: Address.t
 let wallet = {
   let parser = file => {
     let non_dir_file = Arg.(conv_parser(non_dir_file));

--- a/node/block_pool.re
+++ b/node/block_pool.re
@@ -15,7 +15,7 @@ type block_and_signatures = {
 
 // TODO: clean all blocks older than the current state root hash
 type t = {
-  self_key: Wallet.pub_,
+  self_key: Wallet.key,
   available: Hash_map.t(block_and_signatures),
   available_by_previous: Hash_map.t(block_and_signatures),
   signed: Hash_map.t(block_and_signatures),

--- a/node/block_pool.re
+++ b/node/block_pool.re
@@ -15,7 +15,7 @@ type block_and_signatures = {
 
 // TODO: clean all blocks older than the current state root hash
 type t = {
-  self_key: Address.t,
+  self_key: Wallet.pub_,
   available: Hash_map.t(block_and_signatures),
   available_by_previous: Hash_map.t(block_and_signatures),
   signed: Hash_map.t(block_and_signatures),

--- a/node/block_pool.rei
+++ b/node/block_pool.rei
@@ -10,7 +10,7 @@ type block_and_signatures =
 
 type t;
 
-let make: (~self_key: Wallet.pub_) => t;
+let make: (~self_key: Wallet.key) => t;
 let append_block: (Block.t, t) => t;
 let append_signature:
   (~signatures_required: int, ~hash: BLAKE2B.t, Signature.t, t) => t;

--- a/node/block_pool.rei
+++ b/node/block_pool.rei
@@ -10,7 +10,7 @@ type block_and_signatures =
 
 type t;
 
-let make: (~self_key: Address.t) => t;
+let make: (~self_key: Wallet.pub_) => t;
 let append_block: (Block.t, t) => t;
 let append_signature:
   (~signatures_required: int, ~hash: BLAKE2B.t, Signature.t, t) => t;

--- a/node/building_blocks.re
+++ b/node/building_blocks.re
@@ -142,9 +142,7 @@ let find_random_validator_uri = state => {
       safe_validator_uri();
     } else {
       // TODO: this blown up if there is no validator uri registered
-      switch (
-        Node.Pubkey_map.find_opt(validator.address, state.validators_uri)
-      ) {
+      switch (Node.Key_map.find_opt(validator.address, state.validators_uri)) {
       | Some(uri) => uri
       | None => safe_validator_uri()
       };

--- a/node/building_blocks.re
+++ b/node/building_blocks.re
@@ -143,7 +143,7 @@ let find_random_validator_uri = state => {
     } else {
       // TODO: this blown up if there is no validator uri registered
       switch (
-        Node.Address_map.find_opt(validator.address, state.validators_uri)
+        Node.Pubkey_map.find_opt(validator.address, state.validators_uri)
       ) {
       | Some(uri) => uri
       | None => safe_validator_uri()

--- a/node/flows.re
+++ b/node/flows.re
@@ -342,7 +342,7 @@ let register_uri = (state, update_state, ~uri, ~signature) => {
     update_state({
       ...state,
       validators_uri:
-        Node.Address_map.add(
+        Node.Pubkey_map.add(
           Signature.public_key(signature),
           uri,
           state.validators_uri,

--- a/node/flows.re
+++ b/node/flows.re
@@ -342,7 +342,7 @@ let register_uri = (state, update_state, ~uri, ~signature) => {
     update_state({
       ...state,
       validators_uri:
-        Node.Pubkey_map.add(
+        Node.Key_map.add(
           Signature.public_key(signature),
           uri,
           state.validators_uri,

--- a/node/networking.re
+++ b/node/networking.re
@@ -69,7 +69,7 @@ let broadcast_to_list = (endpoint, uris, data) =>
 let broadcast_to_validators = (endpoint, state, data) =>
   Validators.to_list(state.protocol.validators)
   |> List.filter_map((Validators.{address, _}) =>
-       State.Address_map.find_opt(address, state.validators_uri)
+       State.Pubkey_map.find_opt(address, state.validators_uri)
      )
   |> (uris => broadcast_to_list(endpoint, uris, data));
 

--- a/node/networking.re
+++ b/node/networking.re
@@ -69,7 +69,7 @@ let broadcast_to_list = (endpoint, uris, data) =>
 let broadcast_to_validators = (endpoint, state, data) =>
   Validators.to_list(state.protocol.validators)
   |> List.filter_map((Validators.{address, _}) =>
-       State.Pubkey_map.find_opt(address, state.validators_uri)
+       State.Key_map.find_opt(address, state.validators_uri)
      )
   |> (uris => broadcast_to_list(endpoint, uris, data));
 

--- a/node/signatures.re
+++ b/node/signatures.re
@@ -8,7 +8,7 @@ module Signature_set =
   });
 // TODO: what if I think it is signed, but other nodes disagree on this?
 type t = {
-  self_key: Wallet.pub_,
+  self_key: Wallet.key,
   self_signed: bool,
   signed: bool,
   length: int,

--- a/node/signatures.re
+++ b/node/signatures.re
@@ -8,7 +8,7 @@ module Signature_set =
   });
 // TODO: what if I think it is signed, but other nodes disagree on this?
 type t = {
-  self_key: Address.t,
+  self_key: Wallet.pub_,
   self_signed: bool,
   signed: bool,
   length: int,

--- a/node/signatures.rei
+++ b/node/signatures.rei
@@ -2,7 +2,7 @@ open Protocol;
 
 type t;
 // self_key should be the node public key
-let make: (~self_key: Address.t) => t;
+let make: (~self_key: Wallet.pub_) => t;
 let is_self_signed: t => bool;
 let is_signed: t => bool;
 let set_signed: t => t;

--- a/node/signatures.rei
+++ b/node/signatures.rei
@@ -2,7 +2,7 @@ open Protocol;
 
 type t;
 // self_key should be the node public key
-let make: (~self_key: Wallet.pub_) => t;
+let make: (~self_key: Wallet.key) => t;
 let is_self_signed: t => bool;
 let is_signed: t => bool;
 let set_signed: t => t;

--- a/node/state.re
+++ b/node/state.re
@@ -3,8 +3,8 @@ open Protocol;
 
 [@deriving yojson]
 type identity = {
-  key: Address.key,
-  t: Address.t,
+  key: Wallet.t,
+  t: Wallet.pub_,
   uri: Uri.t,
 };
 

--- a/node/state.re
+++ b/node/state.re
@@ -8,7 +8,12 @@ type identity = {
   uri: Uri.t,
 };
 
-module Address_map = Map.Make(Address);
+module Pub_mod = {
+  type t = Wallet.pub_;
+  let compare = Wallet.compare_pub;
+};
+
+module Pubkey_map = Map.Make(Pub_mod);
 module Uri_map = Map.Make(Uri);
 
 type t = {
@@ -25,7 +30,7 @@ type t = {
   // TODO: clean this once in a while
   // TODO: clean after nonce is used
   uri_state: Uri_map.t(string),
-  validators_uri: Address_map.t(Uri.t),
+  validators_uri: Pubkey_map.t(Uri.t),
 };
 
 let make = (~identity, ~data_folder, ~initial_validators_uri) => {

--- a/node/state.re
+++ b/node/state.re
@@ -13,7 +13,7 @@ module Pub_mod = {
   let compare = Wallet.compare_key;
 };
 
-module Pubkey_map = Map.Make(Pub_mod);
+module Key_map = Map.Make(Pub_mod);
 module Uri_map = Map.Make(Uri);
 
 type t = {
@@ -30,7 +30,7 @@ type t = {
   // TODO: clean this once in a while
   // TODO: clean after nonce is used
   uri_state: Uri_map.t(string),
-  validators_uri: Pubkey_map.t(Uri.t),
+  validators_uri: Key_map.t(Uri.t),
 };
 
 let make = (~identity, ~data_folder, ~initial_validators_uri) => {

--- a/node/state.re
+++ b/node/state.re
@@ -4,13 +4,13 @@ open Protocol;
 [@deriving yojson]
 type identity = {
   key: Wallet.t,
-  t: Wallet.pub_,
+  t: Wallet.key,
   uri: Uri.t,
 };
 
 module Pub_mod = {
-  type t = Wallet.pub_;
-  let compare = Wallet.compare_pub;
+  type t = Wallet.key;
+  let compare = Wallet.compare_key;
 };
 
 module Pubkey_map = Map.Make(Pub_mod);

--- a/node/state.rei
+++ b/node/state.rei
@@ -8,7 +8,7 @@ type identity = {
   uri: Uri.t,
 };
 
-module Address_map: Map.S with type key = Wallet.pub_;
+module Pubkey_map: Map.S with type key = Wallet.pub_;
 module Uri_map: Map.S with type key = Uri.t;
 type t = {
   identity,
@@ -20,14 +20,14 @@ type t = {
   snapshots: Snapshots.t,
   // networking
   uri_state: Uri_map.t(string),
-  validators_uri: Address_map.t(Uri.t),
+  validators_uri: Pubkey_map.t(Uri.t),
 };
 
 let make:
   (
     ~identity: identity,
     ~data_folder: string,
-    ~initial_validators_uri: Address_map.t(Uri.t)
+    ~initial_validators_uri: Pubkey_map.t(Uri.t)
   ) =>
   t;
 let apply_block:

--- a/node/state.rei
+++ b/node/state.rei
@@ -4,11 +4,11 @@ open Protocol;
 [@deriving yojson]
 type identity = {
   key: Wallet.t,
-  t: Wallet.pub_,
+  t: Wallet.key,
   uri: Uri.t,
 };
 
-module Pubkey_map: Map.S with type key = Wallet.pub_;
+module Pubkey_map: Map.S with type key = Wallet.key;
 module Uri_map: Map.S with type key = Uri.t;
 type t = {
   identity,

--- a/node/state.rei
+++ b/node/state.rei
@@ -3,12 +3,12 @@ open Protocol;
 
 [@deriving yojson]
 type identity = {
-  key: Address.key,
-  t: Address.t,
+  key: Wallet.t,
+  t: Wallet.pub_,
   uri: Uri.t,
 };
 
-module Address_map: Map.S with type key = Address.t;
+module Address_map: Map.S with type key = Wallet.pub_;
 module Uri_map: Map.S with type key = Uri.t;
 type t = {
   identity,

--- a/node/state.rei
+++ b/node/state.rei
@@ -8,7 +8,7 @@ type identity = {
   uri: Uri.t,
 };
 
-module Pubkey_map: Map.S with type key = Wallet.key;
+module Key_map: Map.S with type key = Wallet.key;
 module Uri_map: Map.S with type key = Uri.t;
 type t = {
   identity,
@@ -20,14 +20,14 @@ type t = {
   snapshots: Snapshots.t,
   // networking
   uri_state: Uri_map.t(string),
-  validators_uri: Pubkey_map.t(Uri.t),
+  validators_uri: Key_map.t(Uri.t),
 };
 
 let make:
   (
     ~identity: identity,
     ~data_folder: string,
-    ~initial_validators_uri: Pubkey_map.t(Uri.t)
+    ~initial_validators_uri: Key_map.t(Uri.t)
   ) =>
   t;
 let apply_block:

--- a/protocol/address.re
+++ b/protocol/address.re
@@ -27,8 +27,8 @@ let make_wallet = () => {
 let address_to_blake = t => t;
 let address_of_blake = t => t;
 
-let address_to_string = wallet =>
-  wallet |> address_to_blake |> BLAKE2B.to_string;
+let address_to_string = address =>
+  address |> address_to_blake |> BLAKE2B.to_string;
 
 let make_address = () => {
   snd(make_wallet());

--- a/protocol/address.re
+++ b/protocol/address.re
@@ -5,11 +5,11 @@ open Helpers;
 type t = BLAKE2B.t;
 
 let of_pubkey = pubkey => {
-  let to_yojson = [%to_yojson: Wallet.pub_];
+  let to_yojson = [%to_yojson: Wallet.key];
   pubkey |> to_yojson |> Yojson.Safe.to_string |> BLAKE2B.hash;
 };
 let of_wallet = privkey => {
-  let pubkey = Wallet.pubkey_of_wallet(privkey);
+  let pubkey = Wallet.to_key(privkey);
   of_pubkey(pubkey);
 };
 
@@ -34,7 +34,7 @@ let make_address = () => {
   snd(make_wallet());
 };
 
-let genesis_address = of_wallet(Wallet.genesis_key);
+let genesis_address = of_wallet(Wallet.genesis_secret);
 
 let compare = (a, b) =>
   String.compare(BLAKE2B.to_string(a), BLAKE2B.to_string(b));

--- a/protocol/address.re
+++ b/protocol/address.re
@@ -1,59 +1,40 @@
-open Mirage_crypto_ec;
-
-type key = Ed25519.priv;
+open Helpers;
 
 // TODO: both functions are duplicated
-let to_hex = str => {
-  let `Hex(str) = Hex.of_string(str);
-  str;
-};
-let of_hex = hex => Hex.to_string(`Hex(hex));
-let key_to_yojson = t =>
-  `String(Ed25519.priv_to_cstruct(t) |> Cstruct.to_string |> to_hex);
-let key_of_yojson =
-  fun
-  | `String(key) =>
-    // TODO: this raises an exception
-    try(
-      of_hex(key)
-      |> Cstruct.of_string
-      |> Ed25519.priv_of_cstruct
-      |> Result.map_error(Format.asprintf("%a", Mirage_crypto_ec.pp_error))
-    ) {
-    | _ => Error("failed to parse")
-    }
-  | _ => Error("invalid type");
+[@deriving yojson]
+type t = BLAKE2B.t;
 
-type t = Ed25519.pub_; // TODO: is okay to have this public
-
-let make_pubkey = () => {
-  let (_priv, pub_) = Ed25519.generate();
-  pub_;
+let of_pubkey = pubkey => {
+  let to_yojson = [%to_yojson: Wallet.pub_];
+  pubkey |> to_yojson |> Yojson.Safe.to_string |> BLAKE2B.hash;
 };
+let of_wallet = privkey => {
+  let pubkey = Wallet.pubkey_of_wallet(privkey);
+  of_pubkey(pubkey);
+};
+
+let address_matches_pubkey = (address, pubkey) => {
+  of_pubkey(pubkey) == address;
+};
+
+let make_wallet = () => {
+  let (key, pub_) = Wallet.make_pair();
+  let address = of_pubkey(pub_);
+
+  (key, address);
+};
+
+let address_to_blake = t => t;
+let address_of_blake = t => t;
+
+let address_to_string = wallet =>
+  wallet |> address_to_blake |> BLAKE2B.to_string;
+
+let make_address = () => {
+  snd(make_wallet());
+};
+
+let genesis_address = of_wallet(Wallet.genesis_key);
 
 let compare = (a, b) =>
-  Cstruct.compare(Ed25519.pub_to_cstruct(a), Ed25519.pub_to_cstruct(b));
-let to_yojson = t =>
-  `String(Ed25519.pub_to_cstruct(t) |> Cstruct.to_string |> to_hex);
-let of_yojson =
-  fun
-  | `String(key) =>
-    try(
-      of_hex(key)
-      |> Cstruct.of_string
-      |> Ed25519.pub_of_cstruct
-      |> Result.map_error(Format.asprintf("%a", Mirage_crypto_ec.pp_error))
-    ) {
-    | _ => Error("failed to parse")
-    }
-  | _ => Error("invalid type");
-
-let of_key = Ed25519.pub_of_priv;
-
-let genesis_key = {|fdc6199df66d421df1496785497b3974b36862beac7c543a9c77b99ccf168f02|};
-let genesis_key =
-  switch (key_of_yojson(`String(genesis_key))) {
-  | Ok(key) => key
-  | Error(error) => failwith(error)
-  };
-let genesis_address = Ed25519.pub_of_priv(genesis_key);
+  String.compare(BLAKE2B.to_string(a), BLAKE2B.to_string(b));

--- a/protocol/address.re
+++ b/protocol/address.re
@@ -18,7 +18,7 @@ let address_matches_pubkey = (address, pubkey) => {
 };
 
 let make_wallet = () => {
-  let (key, pub_) = Wallet.make_pair();
+  let (key, pub_) = Wallet.make_wallet();
   let address = of_pubkey(pub_);
 
   (key, address);

--- a/protocol/address.rei
+++ b/protocol/address.rei
@@ -4,7 +4,7 @@ open Helpers;
 type t;
 
 let of_wallet: Wallet.t => t;
-let of_pubkey: Wallet.pub_ => t;
+let of_pubkey: Wallet.key => t;
 
 let make_wallet: unit => (Wallet.t, t);
 
@@ -15,7 +15,7 @@ let address_of_blake: BLAKE2B.t => t;
 
 let address_to_string: t => string;
 
-let address_matches_pubkey: (t, Wallet.pub_) => bool;
+let address_matches_pubkey: (t, Wallet.key) => bool;
 
 let make_address: unit => t;
 

--- a/protocol/address.rei
+++ b/protocol/address.rei
@@ -6,6 +6,8 @@ type t;
 let of_wallet: Wallet.t => t;
 let of_pubkey: Wallet.pub_ => t;
 
+let make_wallet: unit => (Wallet.t, t);
+
 let genesis_address: t;
 
 let address_to_blake: t => BLAKE2B.t;

--- a/protocol/address.rei
+++ b/protocol/address.rei
@@ -1,14 +1,20 @@
-open Mirage_crypto_ec;
+open Helpers;
 
 [@deriving yojson]
-type key = Ed25519.priv;
+type t;
 
-[@deriving (yojson, ord)]
-type t = Ed25519.pub_;
+let of_wallet: Wallet.t => t;
+let of_pubkey: Wallet.pub_ => t;
 
-let of_key: key => t;
-
-let genesis_key: key;
 let genesis_address: t;
 
-let make_pubkey: unit => t;
+let address_to_blake: t => BLAKE2B.t;
+let address_of_blake: BLAKE2B.t => t;
+
+let address_to_string: t => string;
+
+let address_matches_pubkey: (t, Wallet.pub_) => bool;
+
+let make_address: unit => t;
+
+let compare: (t, t) => int;

--- a/protocol/block.re
+++ b/protocol/block.re
@@ -15,7 +15,7 @@ type t = {
   validators_hash: BLAKE2B.t,
   previous_hash: BLAKE2B.t,
   // block data
-  author: Address.t,
+  author: Wallet.pub_,
   // TODO: do we need a block_height? What is the tradeoffs?
   // TODO: maybe it should be only for internal pagination and stuff like this
   block_height: int64,
@@ -44,7 +44,7 @@ let (hash, verify) = {
         BLAKE2B.t,
         BLAKE2B.t,
         // block data
-        Address.t,
+        Wallet.pub_,
         int64,
         list(Main_chain.t),
         list(Side_chain.Self_signed.t),

--- a/protocol/block.re
+++ b/protocol/block.re
@@ -143,7 +143,7 @@ let genesis =
     ~block_height=0L,
     ~main_chain_ops=[],
     ~side_chain_ops=[],
-    ~author=Address.genesis_address,
+    ~author=Wallet.genesis_pubkey,
   );
 
 // TODO: move this to a global module
@@ -179,5 +179,6 @@ open Signature.Make({
        let hash = t => t.hash;
      });
 
-let sign = (~key, t) => sign(~key, t).signature;
+let sign = (~key, t) =>
+  sign(~key=key |> Wallet.wallet_to_privkey, t).signature;
 let verify = (~signature, t) => verify(~signature, t);

--- a/protocol/block.re
+++ b/protocol/block.re
@@ -15,7 +15,7 @@ type t = {
   validators_hash: BLAKE2B.t,
   previous_hash: BLAKE2B.t,
   // block data
-  author: Wallet.pub_,
+  author: Wallet.key,
   // TODO: do we need a block_height? What is the tradeoffs?
   // TODO: maybe it should be only for internal pagination and stuff like this
   block_height: int64,
@@ -44,7 +44,7 @@ let (hash, verify) = {
         BLAKE2B.t,
         BLAKE2B.t,
         // block data
-        Wallet.pub_,
+        Wallet.key,
         int64,
         list(Main_chain.t),
         list(Side_chain.Self_signed.t),
@@ -143,7 +143,7 @@ let genesis =
     ~block_height=0L,
     ~main_chain_ops=[],
     ~side_chain_ops=[],
-    ~author=Wallet.genesis_pubkey,
+    ~author=Wallet.genesis_key,
   );
 
 // TODO: move this to a global module
@@ -179,6 +179,5 @@ open Signature.Make({
        let hash = t => t.hash;
      });
 
-let sign = (~key, t) =>
-  sign(~key=key |> Wallet.wallet_to_privkey, t).signature;
+let sign = (~key, t) => sign(~key=key |> Wallet.to_privkey, t).signature;
 let verify = (~signature, t) => verify(~signature, t);

--- a/protocol/block.rei
+++ b/protocol/block.rei
@@ -9,19 +9,19 @@ type t =
     state_root_hash: BLAKE2B.t,
     validators_hash: BLAKE2B.t,
     previous_hash: BLAKE2B.t,
-    author: Address.t,
+    author: Wallet.pub_,
     block_height: int64,
     main_chain_ops: list(Main_chain.t),
     side_chain_ops: list(Side_chain.Self_signed.t),
   };
 
-let sign: (~key: Address.key, t) => Signature.t;
+let sign: (~key: Wallet.t, t) => Signature.t;
 let verify: (~signature: Signature.t, t) => bool;
 let genesis: t;
 let produce:
   (
     ~state: State.t,
-    ~author: Address.t,
+    ~author: Wallet.pub_,
     ~main_chain_ops: list(Main_chain.t),
     ~side_chain_ops: list(Side_chain.Self_signed.t)
   ) =>

--- a/protocol/block.rei
+++ b/protocol/block.rei
@@ -9,7 +9,7 @@ type t =
     state_root_hash: BLAKE2B.t,
     validators_hash: BLAKE2B.t,
     previous_hash: BLAKE2B.t,
-    author: Wallet.pub_,
+    author: Wallet.key,
     block_height: int64,
     main_chain_ops: list(Main_chain.t),
     side_chain_ops: list(Side_chain.Self_signed.t),
@@ -21,7 +21,7 @@ let genesis: t;
 let produce:
   (
     ~state: State.t,
-    ~author: Wallet.pub_,
+    ~author: Wallet.key,
     ~main_chain_ops: list(Main_chain.t),
     ~side_chain_ops: list(Side_chain.Self_signed.t)
   ) =>

--- a/protocol/ledger.rei
+++ b/protocol/ledger.rei
@@ -1,14 +1,14 @@
 [@deriving yojson]
 type t;
 let empty: t;
-let get_free: (Wallet.t, t) => Amount.t;
-let get_frozen: (Wallet.t, t) => Amount.t;
+let get_free: (Address.t, t) => Amount.t;
+let get_frozen: (Address.t, t) => Amount.t;
 let transfer:
-  (~source: Wallet.t, ~destination: Wallet.t, ~amount: Amount.t, t) => t;
+  (~source: Address.t, ~destination: Address.t, ~amount: Amount.t, t) => t;
 
-let freeze: (~wallet: Wallet.t, ~amount: Amount.t, t) => t;
-let unfreeze: (~wallet: Wallet.t, ~amount: Amount.t, t) => t;
+let freeze: (~wallet: Address.t, ~amount: Amount.t, t) => t;
+let unfreeze: (~wallet: Address.t, ~amount: Amount.t, t) => t;
 
 // on chain ops
-let deposit: (~destination: Wallet.t, ~amount: Amount.t, t) => t;
-let withdraw: (~source: Wallet.t, ~amount: Amount.t, t) => t;
+let deposit: (~destination: Address.t, ~amount: Amount.t, t) => t;
+let withdraw: (~source: Address.t, ~amount: Amount.t, t) => t;

--- a/protocol/ledger.rei
+++ b/protocol/ledger.rei
@@ -6,8 +6,8 @@ let get_frozen: (Address.t, t) => Amount.t;
 let transfer:
   (~source: Address.t, ~destination: Address.t, ~amount: Amount.t, t) => t;
 
-let freeze: (~wallet: Address.t, ~amount: Amount.t, t) => t;
-let unfreeze: (~wallet: Address.t, ~amount: Amount.t, t) => t;
+let freeze: (~address: Address.t, ~amount: Amount.t, t) => t;
+let unfreeze: (~address: Address.t, ~amount: Amount.t, t) => t;
 
 // on chain ops
 let deposit: (~destination: Address.t, ~amount: Amount.t, t) => t;

--- a/protocol/operation.re
+++ b/protocol/operation.re
@@ -4,11 +4,11 @@ module Main_chain = {
   [@deriving (ord, yojson)]
   type t =
     | Deposit({
-        destination: Wallet.t,
+        destination: Address.t,
         amount: Amount.t,
       })
     | Withdraw({
-        source: Wallet.t,
+        source: Address.t,
         amount: Amount.t,
       })
     // TODO: can a validator uses the same key in different nodes?
@@ -21,7 +21,7 @@ module Side_chain = {
   // TODO: I don't like this structure model
   [@deriving (ord, yojson)]
   type kind =
-    | Transaction({destination: Wallet.t})
+    | Transaction({destination: Address.t})
     | Freeze
     | Unfreeze;
   [@deriving (ord, yojson)]
@@ -29,7 +29,7 @@ module Side_chain = {
     hash: BLAKE2B.t,
     nonce: int32,
     block_height: int64,
-    source: Wallet.t,
+    source: Address.t,
     amount: Amount.t,
     kind,
   };
@@ -38,7 +38,7 @@ module Side_chain = {
     /* TODO: this is bad name, it exists like this to prevent
        duplicating all this name parameters */
     let apply = (f, ~nonce, ~block_height, ~source, ~kind, ~amount) => {
-      let to_yojson = [%to_yojson: (int32, int64, Wallet.t, Amount.t, kind)];
+      let to_yojson = [%to_yojson: (int32, int64, Address.t, Amount.t, kind)];
       let json = to_yojson((nonce, block_height, source, amount, kind));
       let payload = Yojson.Safe.to_string(json);
       f(payload);

--- a/protocol/operation.re
+++ b/protocol/operation.re
@@ -70,7 +70,7 @@ module Side_chain = {
       let to_yojson = to_yojson;
       let of_yojson = of_yojson;
       let verify = (~key, ~signature as _, data) =>
-        Wallet.of_address(key) == data.source;
+        Address.of_pubkey(key) == data.source;
     });
 };
 

--- a/protocol/operation.rei
+++ b/protocol/operation.rei
@@ -3,11 +3,11 @@ module Main_chain: {
   [@deriving (ord, yojson)]
   type t =
     | Deposit({
-        destination: Wallet.t,
+        destination: Address.t,
         amount: Amount.t,
       })
     | Withdraw({
-        source: Wallet.t,
+        source: Address.t,
         amount: Amount.t,
       })
     // TODO: can a validator uses the same key in different nodes?
@@ -20,7 +20,7 @@ module Side_chain: {
   // TODO: I don't like this structure model
   [@deriving (ord, yojson)]
   type kind =
-    | Transaction({destination: Wallet.t})
+    | Transaction({destination: Address.t})
     | Freeze
     | Unfreeze;
   [@deriving (ord, yojson)]
@@ -29,7 +29,7 @@ module Side_chain: {
       hash: BLAKE2B.t,
       nonce: int32,
       block_height: int64,
-      source: Wallet.t,
+      source: Address.t,
       amount: Amount.t,
       kind,
     };
@@ -38,7 +38,7 @@ module Side_chain: {
     (
       ~nonce: int32,
       ~block_height: int64,
-      ~source: Wallet.t,
+      ~source: Address.t,
       ~amount: Amount.t,
       ~kind: kind
     ) =>
@@ -48,5 +48,4 @@ module Side_chain: {
   module Self_signed: Signed.S with type data = t;
 };
 
-let self_sign_side:
-  (~key: Address.key, Side_chain.t) => Side_chain.Self_signed.t;
+let self_sign_side: (~key: Wallet.t, Side_chain.t) => Side_chain.Self_signed.t;

--- a/protocol/protocol.re
+++ b/protocol/protocol.re
@@ -54,7 +54,7 @@ let apply_side_chain = (state: t, signed_operation) => {
     raise(Noop("really old operation"));
   };
 
-  if (!Wallet.pubkey_matches_wallet(signed_operation.key, operation.source)) {
+  if (!Address.address_matches_pubkey(operation.source, signed_operation.key)) {
     raise(Noop("invalid key signed the operation"));
   };
 
@@ -70,8 +70,8 @@ let apply_side_chain = (state: t, signed_operation) => {
     switch (operation.kind) {
     | Transaction({destination}) =>
       Ledger.transfer(~source, ~destination, ~amount, state.ledger)
-    | Freeze => Ledger.freeze(~wallet=source, ~amount, state.ledger)
-    | Unfreeze => Ledger.unfreeze(~wallet=source, ~amount, state.ledger)
+    | Freeze => Ledger.freeze(~address=source, ~amount, state.ledger)
+    | Unfreeze => Ledger.unfreeze(~address=source, ~amount, state.ledger)
     };
 
   {...state, ledger, included_operations};

--- a/protocol/signature.re
+++ b/protocol/signature.re
@@ -5,7 +5,7 @@ open Mirage_crypto_ec;
 type t = {
   // TODO: what is the name of a signature?
   signature: string,
-  public_key: Wallet.pub_,
+  public_key: Wallet.key,
 };
 // TODO: is it safe to compare only the signature?
 let compare = (a, b) => String.compare(a.signature, b.signature);
@@ -19,7 +19,7 @@ let sign = (~key, hash) => {
     |> Ed25519.sign(~key)
     |> Cstruct.to_string;
   let public_key = Ed25519.pub_of_priv(key);
-  {signature, public_key: public_key |> Wallet.pub_of_Ed25519pub};
+  {signature, public_key: public_key |> Wallet.key_of_Ed25519pub};
 };
 let signature_to_b58check = t => {
   open Tezos_interop;
@@ -33,7 +33,7 @@ let signature_to_b58check_by_address = t => {
 let verify = (~signature, hash) => {
   let hash = BLAKE2B.to_raw_string(hash) |> BLAKE2B.hash;
   Ed25519.verify(
-    ~key=signature.public_key |> Wallet.pub_to_Ed25519pub,
+    ~key=signature.public_key |> Wallet.key_to_Ed25519pub,
     ~msg=Cstruct.of_string(BLAKE2B.to_raw_string(hash)),
     Cstruct.of_string(signature.signature),
   );

--- a/protocol/signature.re
+++ b/protocol/signature.re
@@ -19,7 +19,7 @@ let sign = (~key, hash) => {
     |> Ed25519.sign(~key)
     |> Cstruct.to_string;
   let public_key = Ed25519.pub_of_priv(key);
-  {signature, public_key};
+  {signature, public_key: public_key |> Wallet.pub_of_Ed25519pub};
 };
 let signature_to_b58check = t => {
   open Tezos_interop;
@@ -33,7 +33,7 @@ let signature_to_b58check_by_address = t => {
 let verify = (~signature, hash) => {
   let hash = BLAKE2B.to_raw_string(hash) |> BLAKE2B.hash;
   Ed25519.verify(
-    ~key=signature.public_key,
+    ~key=signature.public_key |> Wallet.pub_to_Ed25519pub,
     ~msg=Cstruct.of_string(BLAKE2B.to_raw_string(hash)),
     Cstruct.of_string(signature.signature),
   );

--- a/protocol/signature.re
+++ b/protocol/signature.re
@@ -5,7 +5,7 @@ open Mirage_crypto_ec;
 type t = {
   // TODO: what is the name of a signature?
   signature: string,
-  public_key: Address.t,
+  public_key: Wallet.pub_,
 };
 // TODO: is it safe to compare only the signature?
 let compare = (a, b) => String.compare(a.signature, b.signature);

--- a/protocol/signature.rei
+++ b/protocol/signature.rei
@@ -4,13 +4,13 @@ open Mirage_crypto_ec;
 [@deriving yojson]
 type t;
 let compare: (t, t) => int;
-let public_key: t => Address.t;
+let public_key: t => Wallet.pub_;
 
 let sign: (~key: Ed25519.priv, BLAKE2B.t) => t;
 let verify: (~signature: t, BLAKE2B.t) => bool;
 
 let signature_to_b58check: t => string;
-let signature_to_b58check_by_address: t => (Address.t, string);
+let signature_to_b58check_by_address: t => (Wallet.pub_, string);
 module type S = {
   type value;
   type signature = t;

--- a/protocol/signature.rei
+++ b/protocol/signature.rei
@@ -4,13 +4,13 @@ open Mirage_crypto_ec;
 [@deriving yojson]
 type t;
 let compare: (t, t) => int;
-let public_key: t => Wallet.pub_;
+let public_key: t => Wallet.key;
 
 let sign: (~key: Ed25519.priv, BLAKE2B.t) => t;
 let verify: (~signature: t, BLAKE2B.t) => bool;
 
 let signature_to_b58check: t => string;
-let signature_to_b58check_by_address: t => (Wallet.pub_, string);
+let signature_to_b58check_by_address: t => (Wallet.key, string);
 module type S = {
   type value;
   type signature = t;

--- a/protocol/signed.re
+++ b/protocol/signed.re
@@ -3,7 +3,7 @@ open Mirage_crypto_ec;
 
 [@deriving (yojson, ord)]
 type t('a) = {
-  key: Wallet.pub_, // TODO: rename to pubkey
+  key: Wallet.key, // TODO: rename to pubkey
   signature: string,
   data: 'a,
 };
@@ -14,16 +14,15 @@ type signed('a) = t('a);
 let sign = (~key, data) => {
   let message = Cstruct.of_string(Marshal.to_string(data, []));
   let `Hex(signature) =
-    Ed25519.sign(~key=key |> Wallet.wallet_to_privkey, message)
-    |> Hex.of_cstruct;
-  let pubkey = key |> Wallet.pubkey_of_wallet;
+    Ed25519.sign(~key=key |> Wallet.to_privkey, message) |> Hex.of_cstruct;
+  let pubkey = key |> Wallet.to_key;
   {key: pubkey, signature, data};
 };
 let verify = (~key, ~signature, data) => {
   let.assert () = (
     "invalid signature",
     Ed25519.verify(
-      ~key=key |> Wallet.pub_to_Ed25519pub,
+      ~key=key |> Wallet.key_to_Ed25519pub,
       ~msg=Cstruct.of_string(Marshal.to_string(data, [])),
       `Hex(signature) |> Hex.to_cstruct,
     ),
@@ -44,26 +43,26 @@ module type S = {
   [@deriving (yojson, ord)]
   type t =
     pri {
-      key: Wallet.pub_,
+      key: Wallet.key,
       signature: string,
       data,
     };
   let verify:
-    (~key: Wallet.pub_, ~signature: string, data) => result(t, string);
+    (~key: Wallet.key, ~signature: string, data) => result(t, string);
 };
 module Make =
        (
          F: {
            [@deriving (yojson, ord)]
            type t;
-           let verify: (~key: Wallet.pub_, ~signature: string, t) => bool;
+           let verify: (~key: Wallet.key, ~signature: string, t) => bool;
          },
        ) => {
   [@deriving (yojson, ord)]
   type data = F.t;
   [@deriving (yojson, ord)]
   type t = {
-    key: Wallet.pub_,
+    key: Wallet.key,
     signature: string,
     data,
   };

--- a/protocol/signed.re
+++ b/protocol/signed.re
@@ -3,7 +3,7 @@ open Mirage_crypto_ec;
 
 [@deriving (yojson, ord)]
 type t('a) = {
-  key: Address.t,
+  key: Wallet.pub_,
   signature: string,
   data: 'a,
 };
@@ -41,26 +41,26 @@ module type S = {
   [@deriving (yojson, ord)]
   type t =
     pri {
-      key: Address.t,
+      key: Wallet.pub_,
       signature: string,
       data,
     };
   let verify:
-    (~key: Address.t, ~signature: string, data) => result(t, string);
+    (~key: Wallet.pub_, ~signature: string, data) => result(t, string);
 };
 module Make =
        (
          F: {
            [@deriving (yojson, ord)]
            type t;
-           let verify: (~key: Address.t, ~signature: string, t) => bool;
+           let verify: (~key: Wallet.pub_, ~signature: string, t) => bool;
          },
        ) => {
   [@deriving (yojson, ord)]
   type data = F.t;
   [@deriving (yojson, ord)]
   type t = {
-    key: Address.t,
+    key: Wallet.pub_,
     signature: string,
     data,
   };

--- a/protocol/signed.rei
+++ b/protocol/signed.rei
@@ -1,7 +1,7 @@
 [@deriving (yojson, ord)]
 type t('a) =
   pri {
-    key: Wallet.pub_,
+    key: Wallet.key,
     signature: string,
     data: 'a,
   };
@@ -10,7 +10,7 @@ type signed('a) = t('a);
 // TODO: accept a hash function
 let sign: (~key: Wallet.t, 'a) => t('a);
 let verify:
-  (~key: Wallet.pub_, ~signature: string, 'a) => result(t('a), string);
+  (~key: Wallet.key, ~signature: string, 'a) => result(t('a), string);
 
 module type S = {
   [@deriving (yojson, ord)]
@@ -18,19 +18,19 @@ module type S = {
   [@deriving (yojson, ord)]
   type t =
     pri {
-      key: Wallet.pub_,
+      key: Wallet.key,
       signature: string,
       data,
     };
   let verify:
-    (~key: Wallet.pub_, ~signature: string, data) => result(t, string);
+    (~key: Wallet.key, ~signature: string, data) => result(t, string);
 };
 module Make:
   (
     F: {
       [@deriving (yojson, ord)]
       type t;
-      let verify: (~key: Wallet.pub_, ~signature: string, t) => bool;
+      let verify: (~key: Wallet.key, ~signature: string, t) => bool;
     },
   ) =>
    S with type data = F.t;

--- a/protocol/signed.rei
+++ b/protocol/signed.rei
@@ -1,16 +1,16 @@
 [@deriving (yojson, ord)]
 type t('a) =
   pri {
-    key: Address.t,
+    key: Wallet.pub_,
     signature: string,
     data: 'a,
   };
 [@deriving (yojson, ord)]
 type signed('a) = t('a);
 // TODO: accept a hash function
-let sign: (~key: Address.key, 'a) => t('a);
+let sign: (~key: Wallet.t, 'a) => t('a);
 let verify:
-  (~key: Address.t, ~signature: string, 'a) => result(t('a), string);
+  (~key: Wallet.pub_, ~signature: string, 'a) => result(t('a), string);
 
 module type S = {
   [@deriving (yojson, ord)]
@@ -18,19 +18,19 @@ module type S = {
   [@deriving (yojson, ord)]
   type t =
     pri {
-      key: Address.t,
+      key: Wallet.pub_,
       signature: string,
       data,
     };
   let verify:
-    (~key: Address.t, ~signature: string, data) => result(t, string);
+    (~key: Wallet.pub_, ~signature: string, data) => result(t, string);
 };
 module Make:
   (
     F: {
       [@deriving (yojson, ord)]
       type t;
-      let verify: (~key: Address.t, ~signature: string, t) => bool;
+      let verify: (~key: Wallet.pub_, ~signature: string, t) => bool;
     },
   ) =>
    S with type data = F.t;

--- a/protocol/validators.re
+++ b/protocol/validators.re
@@ -2,7 +2,7 @@ open Helpers;
 
 // TODO: we should avoid dead validators to avoid double timeout, A(dead) -> B(dead) -> C
 [@deriving (yojson, ord)]
-type validator = {address: Wallet.pub_};
+type validator = {address: Wallet.pub_}; // TODO: rename `address` to `pubkey`
 
 [@deriving yojson]
 type t = {
@@ -54,6 +54,10 @@ let remove = (validator, t) => {
 
 let hash = t => {
   open Tezos_interop;
-  let validators = List.map(t => Key.Ed25519(t.address), t.validators);
+  let validators =
+    List.map(
+      t => Key.Ed25519(Wallet.pub_to_Ed25519pub(t.address)),
+      t.validators,
+    );
   Consensus.hash_validators(validators);
 };

--- a/protocol/validators.re
+++ b/protocol/validators.re
@@ -2,7 +2,7 @@ open Helpers;
 
 // TODO: we should avoid dead validators to avoid double timeout, A(dead) -> B(dead) -> C
 [@deriving (yojson, ord)]
-type validator = {address: Address.t};
+type validator = {address: Wallet.pub_};
 
 [@deriving yojson]
 type t = {

--- a/protocol/validators.re
+++ b/protocol/validators.re
@@ -2,7 +2,7 @@ open Helpers;
 
 // TODO: we should avoid dead validators to avoid double timeout, A(dead) -> B(dead) -> C
 [@deriving (yojson, ord)]
-type validator = {address: Wallet.pub_}; // TODO: rename `address` to `pubkey`
+type validator = {address: Wallet.key}; // TODO: rename `address` to `pubkey`
 
 [@deriving yojson]
 type t = {
@@ -56,7 +56,7 @@ let hash = t => {
   open Tezos_interop;
   let validators =
     List.map(
-      t => Key.Ed25519(Wallet.pub_to_Ed25519pub(t.address)),
+      t => Key.Ed25519(Wallet.key_to_Ed25519pub(t.address)),
       t.validators,
     );
   Consensus.hash_validators(validators);

--- a/protocol/validators.rei
+++ b/protocol/validators.rei
@@ -1,7 +1,7 @@
 open Helpers;
 
 [@deriving (yojson, ord)]
-type validator = {address: Wallet.pub_};
+type validator = {address: Wallet.key};
 
 [@deriving yojson]
 type t;
@@ -16,7 +16,7 @@ let length: t => int;
   best: O(1)
   worst: O(n) */
 let after_current: (int, t) => option(validator);
-let update_current: (Wallet.pub_, t) => t;
+let update_current: (Wallet.key, t) => t;
 
 let empty: t;
 let add: (validator, t) => t;

--- a/protocol/validators.rei
+++ b/protocol/validators.rei
@@ -1,7 +1,7 @@
 open Helpers;
 
 [@deriving (yojson, ord)]
-type validator = {address: Address.t};
+type validator = {address: Wallet.pub_};
 
 [@deriving yojson]
 type t;
@@ -16,7 +16,7 @@ let length: t => int;
   best: O(1)
   worst: O(n) */
 let after_current: (int, t) => option(validator);
-let update_current: (Address.t, t) => t;
+let update_current: (Wallet.pub_, t) => t;
 
 let empty: t;
 let add: (validator, t) => t;

--- a/protocol/wallet.re
+++ b/protocol/wallet.re
@@ -1,15 +1,15 @@
 open Mirage_crypto_ec;
 
 type t = Ed25519.priv;
-type pub_ = Ed25519.pub_;
+type key = Ed25519.pub_;
 
-let wallet_of_privkey = priv => priv;
-let wallet_to_privkey = priv => priv;
+let of_privkey = priv => priv;
+let to_privkey = priv => priv;
 
-let pub_of_Ed25519pub = pub_ => pub_;
-let pub_to_Ed25519pub = pub_ => pub_;
+let key_of_Ed25519pub = pub_ => pub_;
+let key_to_Ed25519pub = pub_ => pub_;
 
-let pubkey_of_wallet = Ed25519.pub_of_priv;
+let to_key = Ed25519.pub_of_priv;
 
 let make_pair = () => Ed25519.generate();
 let make_pubkey = () => make_pair() |> snd;
@@ -35,9 +35,9 @@ let of_yojson =
     | _ => Error("failed to parse")
     }
   | _ => Error("invalid type");
-let pub_to_yojson = t =>
+let key_to_yojson = t =>
   `String(Ed25519.pub_to_cstruct(t) |> Cstruct.to_string |> to_hex);
-let pub_of_yojson =
+let key_of_yojson =
   fun
   | `String(key) =>
     try(
@@ -50,16 +50,16 @@ let pub_of_yojson =
     }
   | _ => Error("invalid type");
 
-let genesis_key = {|fdc6199df66d421df1496785497b3974b36862beac7c543a9c77b99ccf168f02|};
-let genesis_key =
-  switch (of_yojson(`String(genesis_key))) {
+let genesis_secret = {|fdc6199df66d421df1496785497b3974b36862beac7c543a9c77b99ccf168f02|};
+let genesis_secret =
+  switch (of_yojson(`String(genesis_secret))) {
   | Ok(key) => key
   | Error(error) => failwith(error)
   };
 
-let genesis_pubkey = pubkey_of_wallet(genesis_key);
+let genesis_key = to_key(genesis_secret);
 
-let compare_pub = (a, b) =>
+let compare_key = (a, b) =>
   Cstruct.compare(Ed25519.pub_to_cstruct(a), Ed25519.pub_to_cstruct(b));
 
 let compare = (a, b) =>

--- a/protocol/wallet.re
+++ b/protocol/wallet.re
@@ -11,8 +11,8 @@ let key_to_Ed25519pub = pub_ => pub_;
 
 let to_key = Ed25519.pub_of_priv;
 
-let make_pair = () => Ed25519.generate();
-let make_pubkey = () => make_pair() |> snd;
+let make_wallet = () => Ed25519.generate();
+let make_key = () => make_wallet() |> snd;
 
 let to_hex = str => {
   let `Hex(str) = Hex.of_string(str);

--- a/protocol/wallet.re
+++ b/protocol/wallet.re
@@ -12,6 +12,7 @@ let pub_to_Ed25519pub = pub_ => pub_;
 let pubkey_of_wallet = Ed25519.pub_of_priv;
 
 let make_pair = () => Ed25519.generate();
+let make_pubkey = () => make_pair() |> snd;
 
 let to_hex = str => {
   let `Hex(str) = Hex.of_string(str);
@@ -55,6 +56,8 @@ let genesis_key =
   | Ok(key) => key
   | Error(error) => failwith(error)
   };
+
+let genesis_pubkey = pubkey_of_wallet(genesis_key);
 
 let compare_pub = (a, b) =>
   Cstruct.compare(Ed25519.pub_to_cstruct(a), Ed25519.pub_to_cstruct(b));

--- a/protocol/wallet.rei
+++ b/protocol/wallet.rei
@@ -3,24 +3,19 @@ open Mirage_crypto_ec;
 [@deriving (ord, yojson)]
 type t;
 [@deriving (ord, yojson)]
-type pub_;
+type key;
 
-let genesis_key: t;
-let genesis_pubkey: pub_;
+let genesis_secret: t;
+let genesis_key: key;
 
-let wallet_of_privkey: Ed25519.priv => t;
-let wallet_to_privkey: t => Ed25519.priv;
-let pub_of_Ed25519pub: Ed25519.pub_ => pub_;
-let pub_to_Ed25519pub: pub_ => Ed25519.pub_;
+let of_privkey: Ed25519.priv => t;
+let to_privkey: t => Ed25519.priv;
+let key_of_Ed25519pub: Ed25519.pub_ => key;
+let key_to_Ed25519pub: key => Ed25519.pub_;
 
-let pubkey_of_wallet: t => pub_;
-let make_pair: unit => (t, pub_);
-let make_pubkey: unit => pub_;
+let to_key: t => key;
+let make_pair: unit => (t, key);
+let make_pubkey: unit => key;
 
 let to_hex: string => string;
 let of_hex: string => string;
-
-/*
- let compare_pub: (pub_, pub_) => int;
- let compare: (t, t) => int;
- */

--- a/protocol/wallet.rei
+++ b/protocol/wallet.rei
@@ -14,5 +14,5 @@ let key_of_Ed25519pub: Ed25519.pub_ => key;
 let key_to_Ed25519pub: key => Ed25519.pub_;
 
 let to_key: t => key;
-let make_pair: unit => (t, key);
-let make_pubkey: unit => key;
+let make_wallet: unit => (t, key);
+let make_key: unit => key;

--- a/protocol/wallet.rei
+++ b/protocol/wallet.rei
@@ -1,14 +1,19 @@
 open Mirage_crypto_ec;
-open Helpers;
 
 [@deriving (ord, yojson)]
 type t;
+[@deriving (ord, yojson)]
+type pub_;
 
-let of_address: Address.t => t;
-let pubkey_matches_wallet: (Address.t, t) => bool;
-let get_pub_key: Address.key => Address.t;
-let make_wallet: unit => (Ed25519.priv, t);
-let make_address: unit => t;
-let address_to_blake: t => BLAKE2B.t;
-let address_of_blake: BLAKE2B.t => t;
-let address_to_string: t => string;
+let genesis_key: t;
+
+let wallet_of_privkey: Ed25519.priv => t;
+let wallet_to_privkey: t => Ed25519.priv;
+let pub_of_Ed25519pub: Ed25519.pub_ => pub_;
+let pub_to_Ed25519pub: pub_ => Ed25519.pub_;
+
+let pubkey_of_wallet: t => pub_;
+let make_pair: unit => (t, pub_);
+
+let to_hex: string => string;
+let of_hex: string => string /*let compare_pub: pub_ => pub_ => bool*/;

--- a/protocol/wallet.rei
+++ b/protocol/wallet.rei
@@ -1,9 +1,9 @@
 open Mirage_crypto_ec;
 
 [@deriving (ord, yojson)]
-type t;
+type t = pri Ed25519.priv;
 [@deriving (ord, yojson)]
-type key;
+type key = pri Ed25519.pub_;
 
 let genesis_secret: t;
 let genesis_key: key;
@@ -16,6 +16,3 @@ let key_to_Ed25519pub: key => Ed25519.pub_;
 let to_key: t => key;
 let make_pair: unit => (t, key);
 let make_pubkey: unit => key;
-
-let to_hex: string => string;
-let of_hex: string => string;

--- a/protocol/wallet.rei
+++ b/protocol/wallet.rei
@@ -6,6 +6,7 @@ type t;
 type pub_;
 
 let genesis_key: t;
+let genesis_pubkey: pub_;
 
 let wallet_of_privkey: Ed25519.priv => t;
 let wallet_to_privkey: t => Ed25519.priv;
@@ -14,6 +15,12 @@ let pub_to_Ed25519pub: pub_ => Ed25519.pub_;
 
 let pubkey_of_wallet: t => pub_;
 let make_pair: unit => (t, pub_);
+let make_pubkey: unit => pub_;
 
 let to_hex: string => string;
-let of_hex: string => string /*let compare_pub: pub_ => pub_ => bool*/;
+let of_hex: string => string;
+
+/*
+ let compare_pub: (pub_, pub_) => int;
+ let compare: (t, t) => int;
+ */

--- a/tests/test_protocol.re
+++ b/tests/test_protocol.re
@@ -222,7 +222,7 @@ describe("protocol state", ({test, _}) => {
     let validators = state.validators;
     expect.option(Validators.current(validators)).toBeNone();
     expect.list(Validators.to_list(validators)).toBeEmpty();
-    let new_validator = Validators.{address: Wallet.make_pubkey()};
+    let new_validator = Validators.{address: Wallet.make_key()};
     let state =
       apply_main_chain(
         state,
@@ -243,7 +243,7 @@ describe("protocol state", ({test, _}) => {
       toBeTrue();
     expect.list(Validators.to_list(validators)).toEqual([new_validator]);
     // additional shouldn't move current
-    let another_validator = Validators.{address: Wallet.make_pubkey()};
+    let another_validator = Validators.{address: Wallet.make_key()};
     let state =
       apply_main_chain(
         state,

--- a/tests/test_protocol.re
+++ b/tests/test_protocol.re
@@ -15,8 +15,7 @@ describe("protocol state", ({test, _}) => {
     let validators = {
       open Helpers;
       let.default () =
-        state.validators
-        |> Validators.add({address: wallet |> Wallet.pubkey_of_wallet});
+        state.validators |> Validators.add({address: wallet |> Wallet.to_key});
       validators;
     };
     let state = {...state, validators};

--- a/tests/test_tezos_interop.re
+++ b/tests/test_tezos_interop.re
@@ -9,7 +9,7 @@ describe("key", ({test, _}) => {
 
   // TODO: test encoding
 
-  let edpk = Ed25519(Wallet.genesis_pubkey |> Wallet.pub_to_Ed25519pub);
+  let edpk = Ed25519(Wallet.genesis_key |> Wallet.key_to_Ed25519pub);
   test("to_string", ({expect, _}) => {
     expect.string(to_string(edpk)).toEqual(
       "edpkvDqjL7aXdsXSiK5ChCMAfqaqmCFWCv7DaT3dK1egJt136WBiT6",
@@ -54,8 +54,7 @@ describe("key_hash", ({test, _}) => {
   open Key_hash;
 
   // TODO: proper test of_key
-  let tz1 =
-    of_key(Ed25519(Wallet.genesis_pubkey |> Wallet.pub_to_Ed25519pub));
+  let tz1 = of_key(Ed25519(Wallet.genesis_key |> Wallet.key_to_Ed25519pub));
   test("to_string", ({expect, _}) => {
     expect.string(to_string(tz1)).toEqual(
       "tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC",
@@ -81,7 +80,7 @@ describe("key_hash", ({test, _}) => {
 describe("secret", ({test, _}) => {
   open Secret;
 
-  let edsk = Ed25519(Wallet.genesis_key |> Wallet.wallet_to_privkey);
+  let edsk = Ed25519(Wallet.genesis_secret |> Wallet.to_privkey);
   test("to_string", ({expect, _}) => {
     expect.string(to_string(edsk)).toEqual(
       "edsk4bfbFdb4s2BdkW3ipfB23i9u82fgji6KT3oj2SCWTeHUthbSVd",
@@ -119,8 +118,8 @@ describe("secret", ({test, _}) => {
 describe("signature", ({test, _}) => {
   open Signature;
 
-  let edpk = Key.Ed25519(Wallet.genesis_pubkey |> Wallet.pub_to_Ed25519pub);
-  let edsk = Secret.Ed25519(Wallet.genesis_key |> Wallet.wallet_to_privkey);
+  let edpk = Key.Ed25519(Wallet.genesis_key |> Wallet.key_to_Ed25519pub);
+  let edsk = Secret.Ed25519(Wallet.genesis_secret |> Wallet.to_privkey);
 
   // TODO: proper test for sign
   let edsig = sign(edsk, "tuturu");
@@ -217,7 +216,7 @@ describe("pack", ({test, _}) => {
   );
   test(
     "key(\"edpkvDqjL7aXdsXSiK5ChCMAfqaqmCFWCv7DaT3dK1egJt136WBiT6\")",
-    key(Ed25519(Wallet.genesis_pubkey |> Wallet.pub_to_Ed25519pub)),
+    key(Ed25519(Wallet.genesis_key |> Wallet.key_to_Ed25519pub)),
     "050a0000002100d00725159de904a28aaed9adb2320f95bd2117959e41c1c2377ac11045d18bd7",
   );
 });
@@ -267,7 +266,7 @@ describe("consensus", ({test, _}) => {
 describe("discovery", ({test, _}) => {
   open Discovery;
 
-  let secret = Secret.Ed25519(Wallet.genesis_key |> Wallet.wallet_to_privkey);
+  let secret = Secret.Ed25519(Wallet.genesis_secret |> Wallet.to_privkey);
   test("sign", ({expect, _}) => {
     let signature =
       sign(secret, ~nonce=1L, Uri.of_string("http://localhost"));

--- a/tests/test_tezos_interop.re
+++ b/tests/test_tezos_interop.re
@@ -9,7 +9,7 @@ describe("key", ({test, _}) => {
 
   // TODO: test encoding
 
-  let edpk = Ed25519(Address.genesis_address);
+  let edpk = Ed25519(Wallet.genesis_pubkey |> Wallet.pub_to_Ed25519pub);
   test("to_string", ({expect, _}) => {
     expect.string(to_string(edpk)).toEqual(
       "edpkvDqjL7aXdsXSiK5ChCMAfqaqmCFWCv7DaT3dK1egJt136WBiT6",
@@ -54,7 +54,8 @@ describe("key_hash", ({test, _}) => {
   open Key_hash;
 
   // TODO: proper test of_key
-  let tz1 = of_key(Ed25519(Address.genesis_address));
+  let tz1 =
+    of_key(Ed25519(Wallet.genesis_pubkey |> Wallet.pub_to_Ed25519pub));
   test("to_string", ({expect, _}) => {
     expect.string(to_string(tz1)).toEqual(
       "tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC",
@@ -80,7 +81,7 @@ describe("key_hash", ({test, _}) => {
 describe("secret", ({test, _}) => {
   open Secret;
 
-  let edsk = Ed25519(Address.genesis_key);
+  let edsk = Ed25519(Wallet.genesis_key |> Wallet.wallet_to_privkey);
   test("to_string", ({expect, _}) => {
     expect.string(to_string(edsk)).toEqual(
       "edsk4bfbFdb4s2BdkW3ipfB23i9u82fgji6KT3oj2SCWTeHUthbSVd",
@@ -118,8 +119,8 @@ describe("secret", ({test, _}) => {
 describe("signature", ({test, _}) => {
   open Signature;
 
-  let edpk = Key.Ed25519(Address.genesis_address);
-  let edsk = Secret.Ed25519(Address.genesis_key);
+  let edpk = Key.Ed25519(Wallet.genesis_pubkey |> Wallet.pub_to_Ed25519pub);
+  let edsk = Secret.Ed25519(Wallet.genesis_key |> Wallet.wallet_to_privkey);
 
   // TODO: proper test for sign
   let edsig = sign(edsk, "tuturu");
@@ -216,7 +217,7 @@ describe("pack", ({test, _}) => {
   );
   test(
     "key(\"edpkvDqjL7aXdsXSiK5ChCMAfqaqmCFWCv7DaT3dK1egJt136WBiT6\")",
-    key(Ed25519(Address.genesis_address)),
+    key(Ed25519(Wallet.genesis_pubkey |> Wallet.pub_to_Ed25519pub)),
     "050a0000002100d00725159de904a28aaed9adb2320f95bd2117959e41c1c2377ac11045d18bd7",
   );
 });
@@ -266,7 +267,7 @@ describe("consensus", ({test, _}) => {
 describe("discovery", ({test, _}) => {
   open Discovery;
 
-  let secret = Secret.Ed25519(Address.genesis_key);
+  let secret = Secret.Ed25519(Wallet.genesis_key |> Wallet.wallet_to_privkey);
   test("sign", ({expect, _}) => {
     let signature =
       sign(secret, ~nonce=1L, Uri.of_string("http://localhost"));

--- a/tests/test_validators.re
+++ b/tests/test_validators.re
@@ -4,7 +4,7 @@ open Validators;
 
 describe("validators", ({test, _}) => {
   let make_validator = () => {
-    let (_key, address) = Wallet.make_pair();
+    let (_key, address) = Wallet.make_wallet();
     Validators.{address: address};
   };
   let setup_two = () => {

--- a/tests/test_validators.re
+++ b/tests/test_validators.re
@@ -4,8 +4,7 @@ open Validators;
 
 describe("validators", ({test, _}) => {
   let make_validator = () => {
-    open Mirage_crypto_ec;
-    let (_key, address) = Ed25519.generate();
+    let (_key, address) = Wallet.make_pair();
     Validators.{address: address};
   };
   let setup_two = () => {


### PR DESCRIPTION
Before, Wallet.t referred to a hash, while Address.t referred to a public key. This is a conceptual mixup - Wallet.t should really be a private key, and Address.t should really be a hash of a public key. This hopefully resolves that issue. 

Draft for now because I'm going to give it another look tomorrow to make sure I didn't miss anything/there's nothing in this PR that should be separated.