### PR TITLE
introduce past_state_root_hashes to track if node is in sync

### DIFF
--- a/node/state.re
+++ b/node/state.re
@@ -235,6 +235,7 @@ let load_snapshot =
 
   // TODO: this is clearly an abstraction leak
 
+  let past_state_root_hashes = [];
   let protocol =
     Protocol.{
       ledger,
@@ -244,6 +245,7 @@ let load_snapshot =
       validators_hash,
       block_height,
       last_block_hash,
+      past_state_root_hashes,
       state_root_hash,
       last_state_root_update: 0.0,
       last_applied_block_timestamp: 0.0,

--- a/protocol/protocol.re
+++ b/protocol/protocol.re
@@ -147,6 +147,12 @@ let apply_block = (state, block) => {
         block.state_root_hash != state.state_root_hash
           ? Unix.time() : state.last_state_root_update,
       last_applied_block_timestamp: Unix.time(),
+      past_state_root_hashes:
+        if (state.state_root_hash != block.state_root_hash) {
+          [state.state_root_hash, ...state.past_state_root_hashes];
+        } else {
+          state.past_state_root_hashes;
+        },
       state_root_hash: block.state_root_hash,
       validators_hash: block.validators_hash,
     },
@@ -167,6 +173,7 @@ let make = (~initial_block) => {
        are in the right place, otherwise invariants
        can be broken */
     last_block_hash: initial_block.Block.previous_hash,
+    past_state_root_hashes: [],
     state_root_hash: initial_block.Block.state_root_hash,
     last_state_root_update: 0.0,
     last_applied_block_timestamp: 0.0,

--- a/protocol/state.re
+++ b/protocol/state.re
@@ -16,6 +16,9 @@ type t = {
   // shared consensus
   block_height: int64,
   last_block_hash: BLAKE2B.t,
+  // List of state_root_hash'es computed by this node from a last known good state
+  // This will later be validated against the main chain
+  past_state_root_hashes: list(BLAKE2B.t),
   state_root_hash: BLAKE2B.t,
   /* TODO: I really don't like this field here, as it means protocol
      state data will be different across nodes, of course we can just
@@ -36,6 +39,7 @@ let hash = t => {
       BLAKE2B.t,
       int64,
       BLAKE2B.t,
+      list(BLAKE2B.t),
       BLAKE2B.t,
     )
   ];
@@ -48,6 +52,7 @@ let hash = t => {
       t.validators_hash,
       t.block_height,
       t.last_block_hash,
+      t.past_state_root_hashes,
       t.state_root_hash,
     ));
 


### PR DESCRIPTION
**Problem**
We don't have a way to know if the node is in sync with the mainchain

**Solution**
This PR (along with follow up PRs), introduce routine checks that make sure newly published state_root_hash on the mainchain are a part of the node's history of computed state_root_hashes. Specifically, this PR introduces a rolling list of such hashes that are looked into.