### PR TITLE
Proto: Add Async State Hashing

### DIFF
--- a/bin/deku_node.re
+++ b/bin/deku_node.re
@@ -40,6 +40,10 @@ let print_error = err => {
     eprintf("Invalid_address_on_main_operation")
   | `Invalid_signature_author => eprintf("Invalid_signature_author")
   | `Failed_to_verify_payload => eprintf("Failed to verify payload signature")
+  | `State_root_hash_update_is_early =>
+    eprintf("State_root_hash_update_is_early")
+  | `State_root_hash_update_is_late =>
+    eprintf("State_root_hash_update_is_late")
   };
   eprintf("\n%!");
 };

--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -488,7 +488,7 @@ let produce_block = node_folder => {
   let block =
     Block.produce(
       ~state,
-      ~next_state_root_hash=None,
+      ~next_hashes=None,
       ~author=address,
       ~main_chain_ops=[],
       ~side_chain_ops=[],

--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -488,6 +488,7 @@ let produce_block = node_folder => {
   let block =
     Block.produce(
       ~state,
+      ~next_state_root_hash=None,
       ~author=address,
       ~main_chain_ops=[],
       ~side_chain_ops=[],

--- a/node/building_blocks.re
+++ b/node/building_blocks.re
@@ -184,12 +184,21 @@ let produce_block = state => {
       Unix.time(),
     );
   let next_hashes =
-    start_new_epoch
-      ? Some(Block.({
-          state_root: state.Node.next_state_root_hash,
-          validators: Validators.hash(state.Node.protocol.validators),
-      }))
-      : None;
+    if (start_new_epoch) {
+      // We can only produce a block in the next epoch
+      // if we've finished the state root hash for that 
+      // epoch.
+      let.some state_root = State.Int_map.find_opt(
+          state.current_epoch + 1,
+          state.finished_state_root_hashes,
+        );
+      Some(Block.{
+            state_root,
+            validators: Validators.hash(state.Node.protocol.validators),
+          });
+    } else {
+      None;
+    };
   Block.produce(
     ~state=state.Node.protocol,
     ~next_hashes,

--- a/node/building_blocks.re
+++ b/node/building_blocks.re
@@ -183,11 +183,16 @@ let produce_block = state => {
       state.Node.protocol.last_state_root_update,
       Unix.time(),
     );
-  let next_state_root_hash =
-    start_new_epoch ? Some(state.Node.next_state_root_hash) : None;
+  let next_hashes =
+    start_new_epoch
+      ? Some(Block.({
+          state_root: state.Node.next_state_root_hash,
+          validators: Validators.hash(state.Node.protocol.validators),
+      }))
+      : None;
   Block.produce(
     ~state=state.Node.protocol,
-    ~next_state_root_hash,
+    ~next_hashes,
     ~author=state.identity.t,
     ~main_chain_ops=state.pending_main_ops,
     ~side_chain_ops=state.pending_side_ops,

--- a/node/flows.re
+++ b/node/flows.re
@@ -36,6 +36,8 @@ let received_block':
         | `Invalid_state_root_hash
         | `Not_current_block_producer
         | `Pending_blocks
+        | `State_root_hash_update_is_early
+        | `State_root_hash_update_is_late
       ],
     ),
   ) =
@@ -51,6 +53,8 @@ let block_added_to_the_pool':
         | `Invalid_block_when_applying
         | `Invalid_state_root_hash
         | `Not_current_block_producer
+        | `State_root_hash_update_is_early
+        | `State_root_hash_update_is_late
       ],
     ),
   ) =
@@ -183,6 +187,12 @@ let rec try_to_apply_block = (state, update_state, block) => {
     `Block_not_signed_enough_to_apply,
     Block_pool.is_signed(~hash=block.Block.hash, state.Node.block_pool),
   );
+  let.assert () = (
+    `Invalid_state_root_hash,
+    state.protocol.state_root_hash == block.state_root_hash
+    || state.next_state_root_hash == block.state_root_hash,
+  );
+
   let.ok state = apply_block(state, update_state, block);
   reset_timeout^();
   let state = clean(state, update_state, block);

--- a/node/state.rei
+++ b/node/state.rei
@@ -20,6 +20,7 @@ type t = {
   block_pool: Block_pool.t,
   protocol: Protocol.t,
   snapshots: Snapshots.t,
+  next_state_root_hash: BLAKE2B.t,
   // networking
   uri_state: Uri_map.t(string),
   validators_uri: Address_map.t(Uri.t),

--- a/node/state.rei
+++ b/node/state.rei
@@ -10,6 +10,8 @@ type identity = {
 
 module Address_map: Map.S with type key = Address.t;
 module Uri_map: Map.S with type key = Uri.t;
+module Int_map: Map.S with type key = int;
+
 type t = {
   identity,
   trusted_validator_membership_change: Trusted_validators_membership_change.Set.t,
@@ -21,6 +23,12 @@ type t = {
   protocol: Protocol.t,
   snapshots: Snapshots.t,
   next_state_root_hash: BLAKE2B.t,
+  // A list of state root hashes paired with their
+  // respective epoch.
+  finished_state_root_hashes: Int_map.t(BLAKE2B.t),
+  // The current state root epoch. See notes in
+  // [Building_blocks.should_start_new_epoch].
+  current_epoch: int,
   // networking
   uri_state: Uri_map.t(string),
   validators_uri: Address_map.t(Uri.t),

--- a/protocol/block.re
+++ b/protocol/block.re
@@ -156,30 +156,14 @@ let genesis =
     ~author=Address.genesis_address,
   );
 
-// TODO: move this to a global module
-let state_root_hash_epoch = 60.0;
-/** to prevent changing the validator just because of network jittering
-    this introduce a delay between can receive a block with new state
-    root hash and can produce that block
-
-    1s choosen here but any reasonable time will make it */
-let avoid_jitter = 1.0;
-let _can_update_state_root_hash = state =>
-  Unix.time() -. state.State.last_state_root_update >= state_root_hash_epoch;
-let can_produce_with_new_state_root_hash = state =>
-  Unix.time()
-  -. state.State.last_state_root_update
-  -. avoid_jitter >= state_root_hash_epoch;
-let produce = (~state) => {
-  let update_state_hashes = can_produce_with_new_state_root_hash(state);
+let produce = (~state, ~next_state_root_hash) => {
+  let state_root_hash =
+    Option.value(~default=state.State.state_root_hash, next_state_root_hash);
   make(
     ~previous_hash=state.State.last_block_hash,
-    ~state_root_hash=
-      update_state_hashes ? fst(State.hash(state)) : state.state_root_hash,
+    ~state_root_hash,
     ~handles_hash=Ledger.handles_root_hash(state.ledger),
-    ~validators_hash=
-      update_state_hashes
-        ? Validators.hash(state.validators) : state.validators_hash,
+    ~validators_hash=state.validators_hash,
     ~block_height=Int64.add(state.block_height, 1L),
   );
 };

--- a/protocol/block.re
+++ b/protocol/block.re
@@ -156,14 +156,25 @@ let genesis =
     ~author=Address.genesis_address,
   );
 
-let produce = (~state, ~next_state_root_hash) => {
-  let state_root_hash =
-    Option.value(~default=state.State.state_root_hash, next_state_root_hash);
+type next_hashes = {
+  state_root: BLAKE2B.t,
+  validators: BLAKE2B.t,
+};
+
+let produce = (~state, ~next_hashes) => {
+  let next_hashes =
+    Option.value(
+      ~default={
+        state_root: state.State.state_root_hash,
+        validators: state.State.validators_hash,
+      },
+      next_hashes,
+    );
   make(
     ~previous_hash=state.State.last_block_hash,
-    ~state_root_hash,
+    ~state_root_hash=next_hashes.state_root,
     ~handles_hash=Ledger.handles_root_hash(state.ledger),
-    ~validators_hash=state.validators_hash,
+    ~validators_hash=next_hashes.validators,
     ~block_height=Int64.add(state.block_height, 1L),
   );
 };

--- a/protocol/block.rei
+++ b/protocol/block.rei
@@ -22,6 +22,7 @@ let genesis: t;
 let produce:
   (
     ~state: State.t,
+    ~next_state_root_hash: option(BLAKE2B.t),
     ~author: Address.t,
     ~main_chain_ops: list(Main_chain.t),
     ~side_chain_ops: list(Side_chain.t)

--- a/protocol/block.rei
+++ b/protocol/block.rei
@@ -19,10 +19,16 @@ type t =
 let sign: (~key: Address.key, t) => Signature.t;
 let verify: (~signature: Signature.t, t) => bool;
 let genesis: t;
+
+type next_hashes = {
+  state_root: BLAKE2B.t,
+  validators: BLAKE2B.t
+}
+
 let produce:
   (
     ~state: State.t,
-    ~next_state_root_hash: option(BLAKE2B.t),
+    ~next_hashes: option(next_hashes),
     ~author: Address.t,
     ~main_chain_ops: list(Main_chain.t),
     ~side_chain_ops: list(Side_chain.t)

--- a/protocol/protocol.re
+++ b/protocol/protocol.re
@@ -181,7 +181,7 @@ let make = (~initial_block) => {
   };
   apply_block(empty, initial_block) |> fst;
 };
-let apply_block = (state, block) => {
+let apply_block = (~next_state_root, state, block) => {
   let.assert () = (`Invalid_block_when_applying, is_next(state, block));
   let hash =
     if (block.state_root_hash == state.state_root_hash) {
@@ -191,7 +191,8 @@ let apply_block = (state, block) => {
       // hash the new state to determine what the state
       // root hash of the next epoch will be, which we set
       // appropriately in the resulting state.
-      let (next_state_root_hash, next_state_root_data) = State.hash(state);
+      let (next_state_root_hash, next_state_root_data) =
+        Option.value(~default=State.hash(state), next_state_root);
       Some((next_state_root_hash, next_state_root_data));
     };
   let (state, result) = apply_block(state, block);

--- a/protocol/state.re
+++ b/protocol/state.re
@@ -16,6 +16,7 @@ type t = {
   // shared consensus
   block_height: int64,
   last_block_hash: BLAKE2B.t,
+  // The state root hash of the most recent block.
   state_root_hash: BLAKE2B.t,
   /* TODO: I really don't like this field here, as it means protocol
      state data will be different across nodes, of course we can just

--- a/tests/test_protocol.re
+++ b/tests/test_protocol.re
@@ -46,6 +46,7 @@ describe("protocol state", ({test, _}) => {
     let block =
       Block.produce(
         ~state,
+        ~next_state_root_hash=None,
         ~author,
         ~main_chain_ops=main,
         ~side_chain_ops=side,

--- a/tests/test_protocol.re
+++ b/tests/test_protocol.re
@@ -46,7 +46,7 @@ describe("protocol state", ({test, _}) => {
     let block =
       Block.produce(
         ~state,
-        ~next_state_root_hash=None,
+        ~next_hashes=None,
         ~author,
         ~main_chain_ops=main,
         ~side_chain_ops=side,


### PR DESCRIPTION
### Depends on #222 

## Problem

This PR addresses async state hashing initially described in #147 and more fully specified and designed in #218.

To reduce the scope, this PR adds async hashing to the block producer only.

## Solution

See block producer section of #218 for details on the whole design. We'll address a truncated version of it here.

Currently the node stores its state, which includes the current state root hash and a timestamp of the last update to that hash. Additionally, nodes assert that a bloc's state root hash is valid before applying it, which means either:
  - the block's state root hash is equal to the current state root hash
  - or else it is equal to the next state root hash (generated synchronously on the spot). 

We'll extend this state with a field `next_state_root_hash : BLAKE2B.t`. This will store the result of asynchronously hashing a state.

The design is as follows:
1. After a node applies a block, it checks to see if the block's state root hash is equal to the current state root hash. If it is, it begins hashing it's new state.
2. When the hashing job is done, `next_state_root_hash` is set to the result.
3. When producing a block, use the `last_state_root_hash_update` field to determine if sufficient time has passed to include a new state root hash. If it has, use `next_state_root_hash` as the state root of the block; otherwise use the `current_state_root_hash`.
4. When applying a block, we change the meaning of valid to mean one of the following:
  - 1. The block's state root hash is equal to the current state root hash (unchanged)
  - 2. or else it is equal to the next state root hash (which was generated previously). Additionally,
    synchronously generate the next state root hash and update `next_state_root_hash`.
    
 You can see that the last case is defined inductively. We therefore need to define a base case: initially, the `current_state_root_hash` and `next_state_root_hash` are set to be pre-determined (distinct) hashes. 
 
 So when the genesis block is applied, we enter rule 4.2, setting the `current_state_root_hash` to the value of `next_state_root_hash`, and generating a new `next_state_root_hash`.