### PR TITLE
Add an OCaml Style Guide

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -17,7 +17,7 @@ An identifier named t on a module will always have type t, so under `Validators.
 ## OCaml Style Guide
 
 ### OCaml Basics
-- Never use the `ignore` function. Instead prefer `let _ = ...`
+- Never use the `ignore` function. Instead prefer `let (_: typ) = ...`
 - Never use the `@@` operator.
 - Never add extraneous type annotations.
 - Never use infix operators to chain monads together. Instead use `let` syntax.

--- a/HACKING.md
+++ b/HACKING.md
@@ -20,7 +20,8 @@ An identifier named t on a module will always have type t, so under `Validators.
 - Never use the `ignore` function. Instead prefer `let _ = ...`
 - Never use the `@@` operator.
 - Never add extraneous type annotations.
+- Never use infix operators to chain monads together. Instead use `let` syntax.
 
 ### LWT
-- Never use `Lwt`'s infix operators. Instead use the `let` syntax.
-- Never ignore the result of an `Lwt` promise. Instead (FIXME: what to do instead?)
+- Never ignore the result of an `Lwt` promise. Instead, if a promise is
+  executed for side-effects only, use `Lwt.async` or just return the `Lwt.t`.

--- a/HACKING.md
+++ b/HACKING.md
@@ -13,3 +13,14 @@ Sometimes you will see it being used even for single cases `v |> f`, this is mor
 A type named t means the main type of a module so, `Validators.t` can be read as `validators` and `Wallet.t` as `wallet`.
 
 An identifier named t on a module will always have type t, so under `Validators.re` `let t = empty` is the same as `let validators = empty`
+
+## OCaml Style Guide
+
+### OCaml Basics
+- Never use the `ignore` function. Instead prefer `let _ = ...`
+- Never use the `@@` operator.
+- Never add extraneous type annotations.
+
+### LWT
+- Never use `Lwt`'s infix operators. Instead use the `let` syntax.
+- Never ignore the result of an `Lwt` promise. Instead (FIXME: what to do instead?)


### PR DESCRIPTION
## Problem

We currently don't have a place to aggregate style requirements. We need one so as to not slow down PR's with things that could be easily addressed ahead of time. 

## Solution

Adds a section to the HACKING.md document.

Note I don't know what the preference is for handling promises that invoked purely for side effects, so we need to address the `FIXME:` before merging.