### PR TITLE
proto: move amount and ticket to operation kind

### DIFF
--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -181,9 +181,7 @@ let create_transaction =
       ~nonce=0l,
       ~block_height=block_level,
       ~source=wallet.address,
-      ~amount,
-      ~ticket,
-      ~kind=Transaction({destination: received_address}),
+      ~kind=Transaction({destination: received_address, amount, ticket}),
     );
   let file = folder_node ++ "/identity.json";
   let.await identity = Files.Identity.read(~file);
@@ -279,9 +277,7 @@ let withdraw =
       ~nonce=0l,
       ~block_height=block_level,
       ~source=wallet.address,
-      ~amount,
-      ~ticket,
-      ~kind=Withdraw({owner: tezos_address}),
+      ~kind=Withdraw({owner: tezos_address, amount, ticket}),
     );
 
   // Broadcast transaction

--- a/protocol/operation.re
+++ b/protocol/operation.re
@@ -54,8 +54,16 @@ module Side_chain = {
   // TODO: I don't like this structure model
   [@deriving yojson]
   type kind =
-    | Transaction({destination: Wallet.t})
-    | Withdraw({owner: Tezos_interop.Address.t})
+    | Transaction({
+        destination: Wallet.t,
+        amount: Amount.t,
+        ticket: Ticket.t,
+      })
+    | Withdraw({
+        owner: Tezos_interop.Address.t,
+        amount: Amount.t,
+        ticket: Ticket.t,
+      })
     | Add_validator(Validators.validator)
     | Remove_validator(Validators.validator);
 
@@ -66,8 +74,6 @@ module Side_chain = {
     nonce: int32,
     block_height: int64,
     source: Wallet.t,
-    amount: Amount.t,
-    ticket: Ticket.t,
     kind,
   };
   let compare = (a, b) => BLAKE2B.compare(a.hash, b.hash);
@@ -75,12 +81,9 @@ module Side_chain = {
   let (hash, verify) = {
     /* TODO: this is bad name, it exists like this to prevent
        duplicating all this name parameters */
-    let apply = (f, ~nonce, ~block_height, ~source, ~amount, ~ticket, ~kind) => {
-      let to_yojson = [%to_yojson:
-        (int32, int64, Wallet.t, Amount.t, Ticket.t, kind)
-      ];
-      let json =
-        to_yojson((nonce, block_height, source, amount, ticket, kind));
+    let apply = (f, ~nonce, ~block_height, ~source, ~kind) => {
+      let to_yojson = [%to_yojson: (int32, int64, Wallet.t, kind)];
+      let json = to_yojson((nonce, block_height, source, kind));
       let payload = Yojson.Safe.to_string(json);
       f(payload);
     };
@@ -89,19 +92,9 @@ module Side_chain = {
     (hash, verify);
   };
 
-  let verify =
-      (
-        ~hash,
-        ~signature,
-        ~nonce,
-        ~block_height,
-        ~source,
-        ~amount,
-        ~ticket,
-        ~kind,
-      ) => {
+  let verify = (~hash, ~signature, ~nonce, ~block_height, ~source, ~kind) => {
     let.ok () =
-      verify(~hash, ~nonce, ~block_height, ~source, ~amount, ~ticket, ~kind)
+      verify(~hash, ~nonce, ~block_height, ~source, ~kind)
         ? Ok() : Error("Side operation invalid hash");
     let.ok () =
       Signature.verify(~signature, hash)
@@ -110,37 +103,18 @@ module Side_chain = {
            source,
          )
         ? Ok() : Error("Side operation invalid signature");
-    Ok({hash, signature, nonce, block_height, source, amount, ticket, kind});
+    Ok({hash, signature, nonce, block_height, source, kind});
   };
 
-  let sign =
-      (~secret, ~nonce, ~block_height, ~source, ~amount, ~ticket, ~kind) => {
-    let hash = hash(~nonce, ~block_height, ~source, ~amount, ~ticket, ~kind);
+  let sign = (~secret, ~nonce, ~block_height, ~source, ~kind) => {
+    let hash = hash(~nonce, ~block_height, ~source, ~kind);
     let signature = Signature.sign(~key=secret, hash);
-    {hash, signature, nonce, block_height, source, amount, ticket, kind};
+    {hash, signature, nonce, block_height, source, kind};
   };
 
   let of_yojson = json => {
-    let.ok {
-      hash,
-      signature,
-      nonce,
-      block_height,
-      source,
-      amount,
-      ticket,
-      kind,
-    } =
+    let.ok {hash, signature, nonce, block_height, source, kind} =
       of_yojson(json);
-    verify(
-      ~hash,
-      ~signature,
-      ~nonce,
-      ~block_height,
-      ~source,
-      ~kind,
-      ~ticket,
-      ~amount,
-    );
+    verify(~hash, ~signature, ~nonce, ~block_height, ~source, ~kind);
   };
 };

--- a/protocol/operation.rei
+++ b/protocol/operation.rei
@@ -40,8 +40,16 @@ module Side_chain: {
   // TODO: I don't like this structure model
   [@deriving yojson]
   type kind =
-    | Transaction({destination: Wallet.t})
-    | Withdraw({owner: Tezos_interop.Address.t})
+    | Transaction({
+        destination: Wallet.t,
+        amount: Amount.t,
+        ticket: Ticket.t,
+      })
+    | Withdraw({
+        owner: Tezos_interop.Address.t,
+        amount: Amount.t,
+        ticket: Ticket.t,
+      })
     | Add_validator(Validators.validator)
     | Remove_validator(Validators.validator);
 
@@ -53,8 +61,6 @@ module Side_chain: {
       nonce: int32,
       block_height: int64,
       source: Wallet.t,
-      amount: Amount.t,
-      ticket: Ticket.t,
       kind,
     };
 
@@ -64,8 +70,6 @@ module Side_chain: {
       ~nonce: int32,
       ~block_height: int64,
       ~source: Wallet.t,
-      ~amount: Amount.t,
-      ~ticket: Ticket.t,
       ~kind: kind
     ) =>
     t;
@@ -77,8 +81,6 @@ module Side_chain: {
       ~nonce: int32,
       ~block_height: int64,
       ~source: Wallet.t,
-      ~amount: Amount.t,
-      ~ticket: Ticket.t,
       ~kind: kind
     ) =>
     result(t, string);

--- a/protocol/protocol.re
+++ b/protocol/protocol.re
@@ -60,17 +60,17 @@ let apply_side_chain = (state: t, operation) => {
   let included_operations = Set.add(operation, state.included_operations);
   let state = {...state, included_operations};
 
-  let {source, amount, ticket, _} = operation;
+  let {source, _} = operation;
   let update_validators = validators => {
     let last_seen_membership_change_timestamp = Unix.time();
     {...state, validators, last_seen_membership_change_timestamp};
   };
   switch (operation.kind) {
-  | Transaction({destination}) =>
+  | Transaction({destination, amount, ticket}) =>
     let.ok ledger =
       Ledger.transfer(~source, ~destination, amount, ticket, state.ledger);
     Ok(({...state, ledger}, `Transaction));
-  | Withdraw({owner}) =>
+  | Withdraw({owner, amount, ticket}) =>
     let.ok (ledger, handle) =
       Ledger.withdraw(
         ~source,

--- a/tests/test_protocol.re
+++ b/tests/test_protocol.re
@@ -106,9 +106,8 @@ describe("protocol state", ({test, _}) => {
             ~nonce=0l,
             ~block_height=0L,
             ~source,
-            ~amount=Amount.of_int(7),
-            ~ticket,
-            ~kind=Transaction({destination: destination}),
+            ~kind=
+              Transaction({destination, amount: Amount.of_int(7), ticket}),
           ),
         );
       assert(result == `Transaction);
@@ -127,9 +126,13 @@ describe("protocol state", ({test, _}) => {
           ~nonce=0l,
           ~block_height=0L,
           ~source,
-          ~amount=Amount.of_int(501),
-          ~ticket,
-          ~kind=Transaction({destination: destination}),
+          ~kind=
+            Transaction({
+              destination,
+
+              amount: Amount.of_int(501),
+              ticket,
+            }),
         ),
       );
     assert(result == `Transaction);


### PR DESCRIPTION
## Problem

Every operation is currently associated with an amount and a ticket. This is no longer true after #182 - some sidechain operations, `Add_validator`, `Remove_validator` etc don't need these properties.

## Solution

This PR move these fields to `Withdraw` and `Transaction` operations only where they are needed