### PR TITLE
cli: adds commands to propose adding/removing validators  

### DIFF
--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -732,7 +732,7 @@ let address_t = {
 let validator_address = {
   let docv = "validator_address";
   let doc = "The validator address to be added/removed as trusted";
-  Arg.(required & pos(2, some(address_t), None) & info([], ~docv, ~doc));
+  Arg.(required & pos(1, some(address_t), None) & info([], ~docv, ~doc));
 };
 
 let add_trusted_validator = {


### PR DESCRIPTION
## Depends

- [x] #205
- [x] #228 
- [x] #325 
- [ ] #333 (for network participation of the new validator)
- [x] #334  

## Problem

We don't have a way to issue protocol operations that add or remove validators from the network

## Solution

This PR adds two CLI commands to allow validators to propose adding and removing validators from the network

