### PR TITLE
fix ticket comparison

### DIFF
--- a/protocol/ticket.re
+++ b/protocol/ticket.re
@@ -9,7 +9,16 @@ type t =
 
 // TODO: should we expose to_yojson here?
 let compare = (a, b) => {
-  let to_string = a =>
-    Bytes.to_string(a.data) ++ Tezos_interop.Address.to_string(b.ticketer);
-  String.compare(to_string(a), to_string(b));
+  module T = {
+    [@deriving ord]
+    type t = {
+      ticketer: string,
+      data: bytes,
+    };
+    let of_t = (Ticket.{ticketer, data}) => {
+      ticketer: Address.to_string(ticketer),
+      data,
+    };
+  };
+  T.(compare(of_t(a), of_t(b)));
 };

--- a/tests/test_ledger.re
+++ b/tests/test_ledger.re
@@ -5,22 +5,26 @@ open Ledger;
 
 describe("ledger", ({test, _}) => {
   // TODO: maybe have a "total amount" function to ensure invariant?
-  let make_ticket = (~data=?, ()) => {
+  let make_ticket = (~ticketer=?, ~data=?, ()) => {
     open Tezos_interop;
-    let random_hash =
-      Mirage_crypto_rng.generate(20)
-      |> Cstruct.to_string
-      |> BLAKE2B_20.of_raw_string
-      |> Option.get;
+
+    let ticketer =
+      switch (ticketer) {
+      | Some(ticketer) => ticketer
+      | None =>
+        let random_hash =
+          Mirage_crypto_rng.generate(20)
+          |> Cstruct.to_string
+          |> BLAKE2B_20.of_raw_string
+          |> Option.get;
+        Address.Originated({contract: random_hash, entrypoint: None});
+      };
     let data =
       switch (data) {
       | Some(data) => data
       | None => Mirage_crypto_rng.generate(256) |> Cstruct.to_bytes
       };
-    Ticket.{
-      ticketer: Originated({contract: random_hash, entrypoint: None}),
-      data,
-    };
+    Ticket.{ticketer, data};
   };
   let make_wallet = () => {
     open Mirage_crypto_ec;
@@ -108,14 +112,7 @@ describe("ledger", ({test, _}) => {
     expect_balance(c, t1, 0, t);
     expect_balance(c, t2, 5, t);
 
-    let t =
-      transfer(
-        ~source=a,
-        ~destination=c,
-        Amount.of_int(99),
-        make_ticket(~data=t1.data, ()),
-        t,
-      );
+    let t = transfer(~source=a, ~destination=c, Amount.of_int(99), t1, t);
     expect.result(t).toBeOk();
     let t = Result.get_ok(t);
     expect_balance(a, t1, 0, t);
@@ -209,6 +206,25 @@ describe("ledger", ({test, _}) => {
 
       let t = withdraw(~source=c, ~destination, Amount.of_int(1), t1, t);
       expect.result(t).toBeError();
+    };
+    ();
+  });
+  test("compare", (expect, _) => {
+    let (t, (t1, _), (a, b)) = setup_two();
+
+    {
+      // two tickets with same data
+      let t1' = make_ticket(~data=t1.data, ());
+      let t = transfer(~source=a, ~destination=b, Amount.of_int(1), t1', t);
+      expect.result(t).toBeError();
+      expect.equal(Result.get_error(t), `Not_enough_funds);
+    };
+    {
+      // two tickets with same ticketer
+      let t1' = make_ticket(~ticketer=t1.ticketer, ());
+      let t = transfer(~source=a, ~destination=b, Amount.of_int(1), t1', t);
+      expect.result(t).toBeError();
+      expect.equal(Result.get_error(t), `Not_enough_funds);
     };
     ();
   });


### PR DESCRIPTION
## Problem

There is a subtle bug on the `compare` function for tickets, which lead to it always being `== 0` even if the ticketer was different. Making so that one could get one unit of a ticket, make another ticket with the same data and that would fuse with the first ticket, allowing essentially to multiply it's own ticket amount and then essentially withdraw someone else ticket from the consensus contract.

## Solution

Fix the comparison and implement some tests to avoid any regression, after implementing I noticed that a test was actually broken but it was not triggering due to the bug above.