### PR TITLE
Add explicit equal fn to Tezos_interop

### DIFF
--- a/helpers/BLAKE2B.re
+++ b/helpers/BLAKE2B.re
@@ -12,6 +12,7 @@ module Make =
          /** this is a leaky abstraction */
          let of_raw_string: string => option(t);
          let to_raw_string: t => string;
+         let equal: (t, t) => bool;
          let compare: (t, t) => int;
 
          let hash: string => t;
@@ -37,6 +38,7 @@ module Make =
     let.ok hex = [%of_yojson: string](json);
     of_string(hex) |> Option.to_result(~none="Invalid hex");
   };
+  let equal = equal;
   // TODO: check the unsafe here
   let compare = unsafe_compare;
 

--- a/tests/test_tezos_interop.re
+++ b/tests/test_tezos_interop.re
@@ -23,8 +23,7 @@ describe("key", ({test, _}) => {
       of_string("edpkvDqjL7aXdsXSiK5ChCMAfqaqmCFWCv7DaT3dK1egJt136WBiT6"),
     ).
       toBe(
-      // TODO: proper equals
-      ~equals=(==),
+      ~equals=Key.equal,
       Some(edpk),
     )
   });
@@ -65,8 +64,7 @@ describe("key_hash", ({test, _}) => {
   });
   test("of_string", ({expect, _}) => {
     expect.option(of_string("tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC")).toBe(
-      // TODO: proper equals
-      ~equals=(==),
+      ~equals=Key_hash.equal,
       Some(tz1),
     )
   });
@@ -94,8 +92,7 @@ describe("secret", ({test, _}) => {
       of_string("edsk4bfbFdb4s2BdkW3ipfB23i9u82fgji6KT3oj2SCWTeHUthbSVd"),
     ).
       toBe(
-      // TODO: proper equals
-      ~equals=(==),
+      ~equals=Secret.equal,
       Some(edsk),
     )
   });
@@ -155,8 +152,7 @@ describe("signature", ({test, _}) => {
       ),
     ).
       toBe(
-      // TODO: proper equals
-      ~equals=(==),
+      ~equals=Signature.equal,
       Some(edsig),
     )
   });
@@ -195,8 +191,7 @@ describe("contract_hash", ({test, _}) => {
   });
   test("of_string", ({expect, _}) => {
     expect.option(of_string("KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc")).toBe(
-      // TODO: proper equals
-      ~equals=(==),
+      ~equals=Contract_hash.equal,
       Some(kt1),
     )
   });
@@ -230,26 +225,23 @@ describe("address", ({test, _}) => {
   });
   test("of_string", ({expect, _}) => {
     expect.option(of_string("tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC")).toBe(
-      // TODO: proper equals
-      ~equals=(==),
+      ~equals=Address.equal,
       Some(tz1),
     );
     // TODO: should we accept tz1 with entrypoint?
     // expect.option(of_string("tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC%tuturu")).
     //   toBe(
-    //   // TODO: proper equals
+    //
     //   ~equals=(==),
     //   Some(tz1),
     // );
     expect.option(of_string("KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc")).toBe(
-      // TODO: proper equals
-      ~equals=(==),
+      ~equals=Address.equal,
       Some(kt1),
     );
     expect.option(of_string("KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc%tuturu")).
       toBe(
-      // TODO: proper equals
-      ~equals=(==),
+      ~equals=Address.equal,
       Some(kt1_tuturu),
     );
     expect.option(of_string("KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc%default")).
@@ -281,7 +273,7 @@ describe("ticket", ({test, _}) => {
       of_string({|(Pair "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc" 0x61)|}),
     ).
       toBe(
-      ~equals=(==),
+      ~equals=Ticket.equal,
       Some(ticket),
     )
   });
@@ -315,7 +307,7 @@ describe("operation_hash", ({test, _}) => {
       of_string({|opCAkifFMh1Ya2J4WhRHskaXc297ELtx32wnc2WzeNtdQHp7DW4|}),
     ).
       toBe(
-      ~equals=(==),
+      ~equals=Operation_hash.equal,
       Some(op),
     )
   });

--- a/tezos_interop/dune
+++ b/tezos_interop/dune
@@ -2,7 +2,7 @@
  (name tezos_interop)
  (libraries helpers lwt.unix mirage-crypto-ec tezos-micheline)
  (preprocess
-  (pps ppx_deriving_yojson ppx_blob))
+  (pps ppx_deriving_yojson ppx_deriving.eq ppx_blob))
  (preprocessor_deps
   (file ./run_entrypoint.bundle.js)
   (file ./fetch_storage.bundle.js)

--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -29,7 +29,10 @@ module Ed25519 = {
   open Ed25519;
 
   type t = pub_;
-
+  let equal = (a, b) => {
+    let (a, b) = (pub_to_cstruct(a), pub_to_cstruct(b));
+    Cstruct.equal(a, b);
+  };
   let size = 32;
   let prefix = Base58.Prefix.ed25519_public_key;
   let encoding = {
@@ -47,6 +50,7 @@ module Ed25519 = {
   let of_string = Base58.simple_decode(~prefix, ~of_raw);
 
   module Hash = {
+    [@deriving eq]
     type t = BLAKE2B_20.t;
 
     let hash_key = t =>
@@ -69,6 +73,10 @@ module Ed25519 = {
     type t = priv;
 
     let _size = 32;
+    let equal = (a, b) => {
+      let (a, b) = (priv_to_cstruct(a), priv_to_cstruct(b));
+      Cstruct.equal(a, b);
+    };
     let prefix = Base58.Prefix.ed25519_seed;
     let to_raw = t => Cstruct.to_string(Ed25519.priv_to_cstruct(t));
     let of_raw = string =>
@@ -78,6 +86,7 @@ module Ed25519 = {
     let of_string = Base58.simple_decode(~prefix, ~of_raw);
   };
   module Signature = {
+    [@deriving eq]
     type t = string;
     let sign = (secret, message) => {
       // double hash because tezos always uses blake2b on CHECK_SIGNATURE
@@ -107,6 +116,7 @@ module Ed25519 = {
 };
 
 module Key = {
+  [@deriving eq]
   type t =
     | Ed25519(Ed25519.t);
 
@@ -131,6 +141,7 @@ module Key = {
     // TODO: move this to a functor
     obj1(req(name, raw_encoding));
   };
+
   let to_string =
     fun
     | Ed25519(key) => Ed25519.to_string(key);
@@ -144,6 +155,7 @@ module Key = {
 };
 
 module Key_hash = {
+  [@deriving eq]
   type t =
     | Ed25519(Ed25519.Hash.t);
 
@@ -172,7 +184,6 @@ module Key_hash = {
     switch (t) {
     | Key.Ed25519(pub_) => Ed25519(Ed25519.Hash.hash_key(pub_))
     };
-
   let to_string =
     fun
     | Ed25519(hash) => Ed25519.Hash.to_string(hash);
@@ -185,9 +196,9 @@ module Key_hash = {
   };
 };
 module Secret = {
+  [@deriving eq]
   type t =
     | Ed25519(Ed25519.Secret.t);
-
   let to_string =
     fun
     | Ed25519(secret) => Ed25519.Secret.to_string(secret);
@@ -200,8 +211,8 @@ module Secret = {
   };
 };
 module Contract_hash = {
+  [@deriving eq]
   type t = BLAKE2B_20.t;
-
   let name = "Contract_hash";
   let encoding = Data_encoding.(obj1(req(name, blake2b_20_encoding)));
   let to_raw = BLAKE2B_20.to_raw_string;
@@ -212,6 +223,7 @@ module Contract_hash = {
 };
 
 module Address = {
+  [@deriving eq]
   type t =
     | Implicit(Key_hash.t)
     | Originated({
@@ -312,9 +324,9 @@ module Address = {
 };
 
 module Signature = {
+  [@deriving eq]
   type t =
     | Ed25519(Ed25519.Signature.t);
-
   let sign = (secret, message) =>
     switch (secret) {
     | Secret.Ed25519(secret) =>
@@ -344,6 +356,7 @@ module Signature = {
 module Ticket = {
   open Tezos_micheline;
 
+  [@deriving eq]
   type t = {
     // TODO: should we allow implicit contracts here?
     ticketer: Address.t,
@@ -389,6 +402,7 @@ module Ticket = {
 };
 
 module Operation_hash = {
+  [@deriving eq]
   type t = BLAKE2B.t;
 
   let prefix = Base58.Prefix.operation_hash;

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -4,7 +4,7 @@ module Base58 = Base58;
 module Key: {
   type t =
     | Ed25519(Mirage_crypto_ec.Ed25519.pub_);
-
+  let equal: (t, t) => bool;
   let to_string: t => string;
   let of_string: string => option(t);
 };
@@ -14,7 +14,7 @@ module Key_hash: {
     | Ed25519(Helpers.BLAKE2B_20.t);
 
   let of_key: Key.t => t;
-
+  let equal: (t, t) => bool;
   let to_string: t => string;
   let of_string: string => option(t);
 };
@@ -22,13 +22,15 @@ module Key_hash: {
 module Secret: {
   type t =
     | Ed25519(Mirage_crypto_ec.Ed25519.priv);
-
+  let equal: (t, t) => bool;
   let to_string: t => string;
   let of_string: string => option(t);
 };
 
 module Signature: {
   type t = pri | Ed25519(string);
+
+  let equal: (t, t) => bool;
 
   let sign: (Secret.t, string) => t;
   let check: (Key.t, t, string) => bool;
@@ -42,7 +44,7 @@ module Signature: {
 
 module Contract_hash: {
   type t = BLAKE2B_20.t;
-
+  let equal: (t, t) => bool;
   let to_string: t => string;
   let of_string: string => option(t);
 };
@@ -55,6 +57,7 @@ module Address: {
         entrypoint: option(string),
       });
 
+  let equal: (t, t) => bool;
   let to_string: t => string;
   let of_string: string => option(t);
 
@@ -67,14 +70,14 @@ module Ticket: {
     ticketer: Address.t,
     data: bytes,
   };
-
+  let equal: (t, t) => bool;
   let to_string: t => string;
   let of_string: string => option(t);
 };
 
 module Operation_hash: {
   type t = BLAKE2B.t;
-
+  let equal: (t, t) => bool;
   let to_string: t => string;
   let of_string: string => option(t);
 };


### PR DESCRIPTION
## Problem

We use polymorphic equality operators on tezos interop now

## Solution

This PR adds specialized equal fn to modules in Tezos_interop.