### PR TITLE
add github PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+<!---
+  if some of the following sections doesn't apply,
+  delete the section.
+
+  Also feel free to delete the comments.
+--->
+
+## Depends
+
+<!--- All PR or issues that are required to be closed / merged before this can be merged --->
+- [ ] #100
+
+## Problem
+
+<!--- Restate the problem addressed by the PR here --->
+
+## Solution
+
+<!--- Restate the basic ideas behind your solution --->
+<!--- Here it is also a good space to put details of your implementation --->
+
+## Related
+
+<!--- add here all the related issues to your PR --->
+- #99
+ 


### PR DESCRIPTION
## Problem

All PRs should have some basic elements so that writing a PR doesn't involve taking too many decisions, this is currently a recommendation on the README, but that is not really discoverable, also there is some details in the github flavored markdown which improves the PR description layout.

## Solution

This adds a simple PR template for future use.

## Related

- closes #161 