### PR TITLE
add a dependency on secp256k1 library for tz2 interop

### DIFF
--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "49e075f2bf75c9ff6f1b8f5c8dd98d7b",
+  "checksum": "c9e532bc2397bb9be7ec641c7ae6e68d",
   "root": "sidechain@link-dev:./package.json",
   "node": {
     "yocto-queue@0.1.0@d41d8cd9": {
@@ -116,7 +116,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "webpack-merge@5.8.0@d41d8cd9", "webpack@5.57.0@d41d8cd9",
+        "webpack-merge@5.8.0@d41d8cd9", "webpack@5.57.1@d41d8cd9",
         "v8-compile-cache@2.3.0@d41d8cd9", "rechoir@0.7.1@d41d8cd9",
         "interpret@2.2.0@d41d8cd9", "import-local@3.0.3@d41d8cd9",
         "fastest-levenshtein@1.0.12@d41d8cd9", "execa@5.1.1@d41d8cd9",
@@ -128,14 +128,14 @@
       ],
       "devDependencies": []
     },
-    "webpack@5.57.0@d41d8cd9": {
-      "id": "webpack@5.57.0@d41d8cd9",
+    "webpack@5.57.1@d41d8cd9": {
+      "id": "webpack@5.57.1@d41d8cd9",
       "name": "webpack",
-      "version": "5.57.0",
+      "version": "5.57.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/webpack/-/webpack-5.57.0.tgz#sha1:3f79e1388cf746b4ec53af9ae61466c453bac4d9"
+          "archive:https://registry.npmjs.org/webpack/-/webpack-5.57.1.tgz#sha1:ead5ace2c17ecef2ae8126f143bfeaa7f55eab44"
         ]
       },
       "overrides": [],
@@ -269,7 +269,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "webpack@5.57.0@d41d8cd9", "terser@5.9.0@d41d8cd9",
+        "webpack@5.57.1@d41d8cd9", "terser@5.9.0@d41d8cd9",
         "source-map@0.6.1@d41d8cd9", "serialize-javascript@6.0.0@d41d8cd9",
         "schema-utils@3.1.1@d41d8cd9", "p-limit@3.1.0@d41d8cd9",
         "jest-worker@27.2.4@d41d8cd9"
@@ -474,11 +474,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "webpack-cli@4.8.0@d41d8cd9", "webpack@5.57.0@d41d8cd9",
+        "webpack-cli@4.8.0@d41d8cd9", "webpack@5.57.1@d41d8cd9",
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
         "@taquito/taquito@9.2.0@d41d8cd9", "@taquito/signer@9.2.0@d41d8cd9",
         "@taquito/rpc@9.2.0@d41d8cd9",
         "@opam/tezos-micheline@opam:8.3@3d86363d",
+        "@opam/secp256k1-internal@opam:0.2.0@54945e35",
         "@opam/ppx_deriving_yojson@opam:3.6.1@faf11a7c",
         "@opam/ppx_deriving@opam:5.2.1@089e5dd3",
         "@opam/ppx_blob@opam:0.7.2@f89ed130",
@@ -2656,7 +2657,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "webpack-cli@4.8.0@d41d8cd9", "webpack@5.57.0@d41d8cd9"
+        "webpack-cli@4.8.0@d41d8cd9", "webpack@5.57.1@d41d8cd9"
       ],
       "devDependencies": []
     },
@@ -3999,6 +4000,40 @@
       ],
       "devDependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9"
+      ]
+    },
+    "@opam/secp256k1-internal@opam:0.2.0@54945e35": {
+      "id": "@opam/secp256k1-internal@opam:0.2.0@54945e35",
+      "name": "@opam/secp256k1-internal",
+      "version": "opam:0.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/56/56a12978d13058761ae495068ad683f1da837b2e280c70b2042c4325926a12f1#sha256:56a12978d13058761ae495068ad683f1da837b2e280c70b2042c4325926a12f1",
+          "archive:https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal/-/archive/v0.2/ocaml-secp256k1-internal-v0.2.tar.bz2#sha256:56a12978d13058761ae495068ad683f1da837b2e280c70b2042c4325926a12f1"
+        ],
+        "opam": {
+          "name": "secp256k1-internal",
+          "version": "0.2.0",
+          "path": "esy.lock/opam/secp256k1-internal.0.2.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/dune-configurator@opam:2.9.1@b7cf7a02",
+        "@opam/dune@opam:2.9.1@1e504822",
+        "@opam/cstruct@opam:6.0.1@69eae449",
+        "@opam/conf-gmp@opam:3@a623586f",
+        "@opam/bigstring@opam:0.3@3fa3c6dc",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/dune-configurator@opam:2.9.1@b7cf7a02",
+        "@opam/dune@opam:2.9.1@1e504822",
+        "@opam/cstruct@opam:6.0.1@69eae449",
+        "@opam/bigstring@opam:0.3@3fa3c6dc"
       ]
     },
     "@opam/rresult@opam:0.6.0@4b185e72": {
@@ -7151,6 +7186,37 @@
         "@opam/bigarray-compat@opam:1.0.0@951830c6"
       ]
     },
+    "@opam/bigstring@opam:0.3@3fa3c6dc": {
+      "id": "@opam/bigstring@opam:0.3@3fa3c6dc",
+      "name": "@opam/bigstring",
+      "version": "opam:0.3",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/df/dff09605881c7f6efd4a8a1a71790889#md5:dff09605881c7f6efd4a8a1a71790889",
+          "archive:https://github.com/c-cube/ocaml-bigstring/archive/0.3.tar.gz#md5:dff09605881c7f6efd4a8a1a71790889"
+        ],
+        "opam": {
+          "name": "bigstring",
+          "version": "0.3",
+          "path": "esy.lock/opam/bigstring.0.3"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/dune@opam:2.9.1@1e504822",
+        "@opam/base-bytes@opam:base@19d0c2ff",
+        "@opam/base-bigarray@opam:base@b03491b0",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/dune@opam:2.9.1@1e504822",
+        "@opam/base-bytes@opam:base@19d0c2ff",
+        "@opam/base-bigarray@opam:base@b03491b0"
+      ]
+    },
     "@opam/bigarray-overlap@opam:0.2.0@d8a38f4a": {
       "id": "@opam/bigarray-overlap@opam:0.2.0@d8a38f4a",
       "name": "@opam/bigarray-overlap",
@@ -7289,6 +7355,23 @@
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
         "@opam/ocamlfind@opam:1.9.1@b748edf6"
       ]
+    },
+    "@opam/base-bigarray@opam:base@b03491b0": {
+      "id": "@opam/base-bigarray@opam:base@b03491b0",
+      "name": "@opam/base-bigarray",
+      "version": "opam:base",
+      "source": {
+        "type": "install",
+        "source": [ "no-source:" ],
+        "opam": {
+          "name": "base-bigarray",
+          "version": "base",
+          "path": "esy.lock/opam/base-bigarray.base"
+        }
+      },
+      "overrides": [],
+      "dependencies": [ "@esy-ocaml/substs@0.0.1@d41d8cd9" ],
+      "devDependencies": []
     },
     "@opam/base@opam:v0.14.1@9b424fee": {
       "id": "@opam/base@opam:v0.14.1@9b424fee",

--- a/esy.lock/opam/base-bigarray.base/opam
+++ b/esy.lock/opam/base-bigarray.base/opam
@@ -1,0 +1,6 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+description: """
+Bigarray library distributed with the OCaml compiler
+"""
+

--- a/esy.lock/opam/bigstring.0.3/opam
+++ b/esy.lock/opam/bigstring.0.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "A set of utils for dealing with `bigarrays` of `char`"
+authors: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+maintainer: "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+tags: [ "bigstring" "bigarray" ]
+homepage: "https://github.com/c-cube/ocaml-bigstring/"
+bug-reports: "https://github.com/c-cube/ocaml-bigstring/issues"
+dev-repo: "git://github.com/c-cube/ocaml-bigstring.git"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+depends: [
+  "dune" {>= "1.2"}
+  "base-bigarray"
+  "base-bytes"
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {with-test & < "1.2"}
+  "bigstring-unix" {with-test}
+]
+url {
+  src: "https://github.com/c-cube/ocaml-bigstring/archive/0.3.tar.gz"
+  checksum: [
+    "md5=dff09605881c7f6efd4a8a1a71790889"
+    "sha512=d0c530603e9bb37a704d736137953e4f2a1b1e16517587010f2fb323a5c3e4d887f558775349231ea15a98d3c085ed9daaf0a7603f165cdd0097ff2548ce790a"
+  ]
+}

--- a/esy.lock/opam/secp256k1-internal.0.2.0/opam
+++ b/esy.lock/opam/secp256k1-internal.0.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+homepage: "https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal"
+synopsis: "Bindings to secp256k1 internal functions (generic operations on the curve)"
+
+license: "MIT"
+bug-reports: "https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name "@install"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "conf-gmp" {build}
+  "dune" {>= "2"}
+  "dune-configurator"
+  "cstruct" {>= "3.2.1"}
+  "bigstring" {>= "0.1.1"}
+  "hex" {with-test & >= "1.4.0"}
+  "alcotest" {with-test}
+]
+
+url {
+  src: "https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal/-/archive/v0.2/ocaml-secp256k1-internal-v0.2.tar.bz2"
+  checksum: [
+    "sha256=56a12978d13058761ae495068ad683f1da837b2e280c70b2042c4325926a12f1"
+    "sha512=607b8c9d6514421f9fd042a883531d613eb2cb2c2c5bb38d038d930454081dbd707f5b318de6b0c981675ecf6ca56d1eec06b8afbabc293c7600e86b1578cf2d"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "@taquito/rpc": "^9.0.1",
     "webpack": "^5.47.1",
     "webpack-cli": "^4.7.1",
-    "@opam/ppx_blob": "*"
+    "@opam/ppx_blob": "*",
+    "@opam/secp256k1-internal": "0.2.0"
   },
   "devDependencies": {
     "@opam/ocaml-lsp-server": "*",


### PR DESCRIPTION
## Problem

We need to add a support for interop with tz2, but our current library mirage-crypto doesn't support it.

## Solution

Add a library for secp256k1 by nomadic labs as a dependency for our project

## Related
- #199
 