### PR TITLE
move ed25519 to separate crypto module

### DIFF
--- a/tezos_interop/crypto.re
+++ b/tezos_interop/crypto.re
@@ -1,0 +1,102 @@
+open Helpers;
+open Mirage_crypto_ec;
+include Crypto_intf;
+let blake2b_20_encoding =
+  Data_encoding.(
+    conv(
+      hash => BLAKE2B_20.to_raw_string(hash) |> Bytes.of_string,
+      // TODO: I don't like this exception below
+      bytes =>
+        Bytes.to_string(bytes) |> BLAKE2B_20.of_raw_string |> Option.get,
+      Fixed.bytes(20),
+    )
+  );
+module Ed25519 = {
+  open Ed25519;
+  module Key = {
+    type t = pub_;
+
+    let size = 32;
+    let prefix = Base58.Prefix.ed25519_public_key;
+    let equal = (a, b) => {
+      let (a, b) = (pub_to_cstruct(a), pub_to_cstruct(b));
+      Cstruct.equal(a, b);
+    };
+    let encoding = {
+      // TODO: in tezos this is splitted json is not same as binary
+      let to_bytes = t => pub_to_cstruct(t) |> Cstruct.to_bytes;
+      let of_bytes_exn = b =>
+        Cstruct.of_bytes(b) |> pub_of_cstruct |> Result.get_ok;
+      Data_encoding.(conv(to_bytes, of_bytes_exn, Fixed.bytes(size)));
+    };
+    let to_raw = t => Cstruct.to_string(Ed25519.pub_to_cstruct(t));
+    let of_raw = string =>
+      Ed25519.pub_of_cstruct(Cstruct.of_string(string)) |> Result.to_option;
+    let to_string = t => Base58.simple_encode(~prefix, ~to_raw, t);
+    let of_string = string => Base58.simple_decode(~prefix, ~of_raw, string);
+  };
+
+  module Key_hash = {
+    [@deriving eq]
+    type t = BLAKE2B_20.t;
+
+    let hash_key = t =>
+      BLAKE2B_20.hash(Ed25519.pub_to_cstruct(t) |> Cstruct.to_string);
+
+    let encoding = {
+      let name = "Ed25519.Public_key_hash";
+      // TODO: in tezos this is splitted json is not same as bin
+      Data_encoding.(obj1(req(name, blake2b_20_encoding)));
+    };
+
+    let prefix = Base58.Prefix.ed25519_public_key_hash;
+    let to_raw = BLAKE2B_20.to_raw_string;
+    let of_raw = BLAKE2B_20.of_raw_string;
+    let to_string = t => Base58.simple_encode(~prefix, ~to_raw, t);
+    let of_string = string => Base58.simple_decode(~prefix, ~of_raw, string);
+  };
+
+  module Secret = {
+    type t = priv;
+    let equal = (a, b) => {
+      let (a, b) = (priv_to_cstruct(a), priv_to_cstruct(b));
+      Cstruct.equal(a, b);
+    };
+    let _size = 32;
+    let prefix = Base58.Prefix.ed25519_seed;
+    let to_raw = t => Cstruct.to_string(Ed25519.priv_to_cstruct(t));
+    let of_raw = string =>
+      Ed25519.priv_of_cstruct(Cstruct.of_string(string)) |> Result.to_option;
+
+    let to_string = t => Base58.simple_encode(~prefix, ~to_raw, t);
+    let of_string = string => Base58.simple_decode(~prefix, ~of_raw, string);
+  };
+  module Signature = {
+    [@deriving eq]
+    type t = string;
+    let sign = (secret, message) => {
+      // double hash because tezos always uses blake2b on CHECK_SIGNATURE
+      let hash = BLAKE2B.hash(message);
+      Cstruct.of_string(BLAKE2B.to_raw_string(hash))
+      // TODO: isn't this double hashing? Seems weird
+      |> Ed25519.sign(~key=secret)
+      |> Cstruct.to_string;
+    };
+    let check = (public, signature, message) => {
+      let hash = BLAKE2B.hash(message);
+      verify(
+        ~key=public,
+        ~msg=Cstruct.of_string(BLAKE2B.to_raw_string(hash)),
+        Cstruct.of_string(signature),
+      );
+    };
+
+    let size = 64;
+    let prefix = Base58.Prefix.ed25519_signature;
+    let to_raw = Fun.id;
+    let of_raw = string =>
+      String.length(string) == size ? Some(string) : None;
+    let to_string = t => Base58.simple_encode(~prefix, ~to_raw, t);
+    let of_string = string => Base58.simple_decode(~prefix, ~of_raw, string);
+  };
+};

--- a/tezos_interop/crypto.rei
+++ b/tezos_interop/crypto.rei
@@ -1,0 +1,4 @@
+open Helpers;
+let blake2b_20_encoding: Data_encoding.t(BLAKE2B_20.t);
+
+include Crypto_intf.Intf;

--- a/tezos_interop/crypto_intf.re
+++ b/tezos_interop/crypto_intf.re
@@ -1,0 +1,43 @@
+module type S = {
+  module Key: {
+    type t;
+    let encoding: Data_encoding.t(t);
+    let equal: (t, t) => bool;
+    let to_string: t => string;
+    let of_string: string => option(t);
+  };
+  module Key_hash: {
+    type t;
+    let hash_key: Key.t => t;
+    let encoding: Data_encoding.t(t);
+    let equal: (t, t) => bool;
+    let to_string: t => string;
+    let of_string: string => option(t);
+  };
+  module Secret: {
+    type t;
+    let equal: (t, t) => bool;
+
+    let to_string: t => string;
+    let of_string: string => option(t);
+  };
+  module Signature: {
+    type t;
+    let equal: (t, t) => bool;
+    let sign: (Secret.t, t) => t;
+    let check: (Key.t, t, t) => bool;
+    let to_string: t => t;
+    let of_string: t => option(t);
+  };
+};
+module type Intf = {
+  open Helpers;
+  open Mirage_crypto_ec;
+  module type S = S;
+  module Ed25519:
+    S with
+      type Key.t = Ed25519.pub_ and
+      type Key_hash.t = BLAKE2B_20.t and
+      type Secret.t = Ed25519.priv and
+      type Signature.t = string;
+};


### PR DESCRIPTION
## Problem

We will be adding more crypto modules to Tezos_interop, so keeping them in the same file as the interop file is bad
## Solution

Move ed25519 module to separate crypto module
## Related
 - #22 