### PR TITLE
Delayed State Hashing

### DIFF
--- a/bin/deku_node.re
+++ b/bin/deku_node.re
@@ -5,9 +5,8 @@
 open Cmdliner;
 open Opium;
 open Helpers;
-open Protocol;
-open Core;
 open Node;
+open Bin_common;
 
 let ignore_some_errors =
   fun
@@ -209,91 +208,16 @@ let handle_ticket_balance =
   );
 
 let node = folder => {
-  let.await identity = Files.Identity.read(~file=folder ++ "/identity.json");
-
-  let trusted_validator_membership_change_file =
-    folder ++ "/trusted-validator-membership-change.json";
-
-  let.await trusted_validator_membership_change_list =
-    Files.Trusted_validators_membership_change.read(
-      ~file=trusted_validator_membership_change_file,
-    );
-  let trusted_validator_membership_change =
-    Trusted_validators_membership_change.Set.of_list(
-      trusted_validator_membership_change_list,
-    );
-  let.await interop_context =
-    Files.Interop_context.read(~file=folder ++ "/tezos.json");
-  let.await validator_res =
-    Tezos_interop.Consensus.fetch_validators(~context=interop_context);
-  let validators =
-    switch (validator_res) {
-    | Ok(current_validators) =>
-      current_validators
-      |> List.mapi((i, validator) => {
-           (
-             Address.of_key_hash(validator),
-             Printf.sprintf("http://localhost:444%d", i) |> Uri.of_string,
-           )
-         })
-    | Error(err) => failwith(err)
-    };
-
-  let initial_validators_uri =
-    List.fold_left(
-      (validators_uri, (address, uri)) =>
-        State.Address_map.add(address, uri, validators_uri),
-      State.Address_map.empty,
-      validators,
-    );
-  let persist_trusted_membership_change =
-    Files.Trusted_validators_membership_change.write(
-      ~file=trusted_validator_membership_change_file,
-    );
-  let node =
-    State.make(
-      ~identity,
-      ~trusted_validator_membership_change,
-      ~interop_context,
-      ~data_folder=folder,
-      ~initial_validators_uri,
-      ~persist_trusted_membership_change,
-    );
-  let node = {
-    ...node,
-    protocol: {
-      ...node.protocol,
-      validators:
-        List.fold_left(
-          (validators, (address, _)) =>
-            Validators.add({address: address}, validators),
-          Validators.empty,
-          validators,
-        ),
-    },
-  };
-  let state_bin = folder ++ "/state.bin";
-  let.await state_bin_exists = Lwt_unix.file_exists(state_bin);
-  let.await protocol =
-    if (state_bin_exists) {
-      Files.State_bin.read(~file=state_bin);
-    } else {
-      let.await () = Files.State_bin.write(node.protocol, ~file=state_bin);
-      await(node.protocol);
-    };
+  let node = Node_state.get_initial_state(~folder) |> Lwt_main.run;
   Tezos_interop.Consensus.listen_operations(
-    ~context=interop_context, ~on_operation=operation =>
+    ~context=node.Node.State.interop_context, ~on_operation=operation =>
     Flows.received_tezos_operation(
       Server.get_state(),
       update_state,
       operation,
     )
   );
-  await({...node, protocol});
-};
-
-let node = folder => {
-  let () = Node.Server.start(~initial=node(folder) |> Lwt_main.run);
+  let () = Node.Server.start(~initial=node);
 
   let _server =
     App.empty

--- a/bin/dune
+++ b/bin/dune
@@ -1,23 +1,23 @@
 (executable
  (name deku_node)
  (public_name deku-node)
- (libraries opium files node helpers cmdliner)
+ (libraries opium bin_common node helpers cmdliner)
  (modules Deku_node)
  (preprocess
   (pps ppx_deriving.show ppx_deriving_yojson)))
 
 (executable
  (name sidecli)
- (libraries node files helpers cmdliner)
+ (libraries node bin_common helpers cmdliner)
  (modules Sidecli)
  (public_name sidecli)
  (preprocess
   (pps ppx_deriving_yojson)))
 
 (library
- (name files)
- (modules Files)
- (libraries lwt lwt.unix node)
+ (name bin_common)
+ (modules Files Node_state)
+ (libraries lwt lwt.unix node helpers)
  (preprocess
   (pps ppx_deriving_yojson)))
 

--- a/bin/files.re
+++ b/bin/files.re
@@ -78,6 +78,7 @@ module Interop_context = {
 module State_bin = {
   let read = (~file) =>
     Lwt_io.with_file(~mode=Input, file, Lwt_io.read_value);
+
   let write = (protocol, ~file) =>
     Lwt_io.with_file(~mode=Output, file, Lwt_io.write_value(_, protocol));
 };

--- a/bin/node_state.re
+++ b/bin/node_state.re
@@ -69,14 +69,18 @@ let get_initial_state = (~folder) => {
   };
   let state_bin = folder ++ "/state.bin";
   let.await state_bin_exists = Lwt_unix.file_exists(state_bin);
-  let.await protocol =
+  let.await (protocol, next_state_root) =
     if (state_bin_exists) {
       let.await protocol = Files.State_bin.read(~file=state_bin);
-      await(protocol);
+      let prev_epoch_state_bin = folder ++ "/prev_epoch_state.bin";
+      let.await prev_protocol =
+        Files.State_bin.read(~file=prev_epoch_state_bin);
+      let next_state_root = Protocol.hash(prev_protocol);
+      await((protocol, next_state_root));
     } else {
-      await(node.protocol);
+      await((node.protocol, node.next_state_root));
     };
-  let node = {...node, protocol};
+  let node = {...node, next_state_root, protocol};
 
   await(node);
 };

--- a/bin/node_state.re
+++ b/bin/node_state.re
@@ -1,0 +1,82 @@
+open Helpers;
+open Core;
+open Protocol;
+open Node;
+
+let get_initial_state = (~folder) => {
+  let.await identity = Files.Identity.read(~file=folder ++ "/identity.json");
+
+  let trusted_validator_membership_change_file =
+    folder ++ "/trusted-validator-membership-change.json";
+
+  let.await trusted_validator_membership_change_list =
+    Files.Trusted_validators_membership_change.read(
+      ~file=trusted_validator_membership_change_file,
+    );
+  let trusted_validator_membership_change =
+    Trusted_validators_membership_change.Set.of_list(
+      trusted_validator_membership_change_list,
+    );
+  let.await interop_context =
+    Files.Interop_context.read(~file=folder ++ "/tezos.json");
+  let.await validator_res =
+    Tezos_interop.Consensus.fetch_validators(~context=interop_context);
+  let validators =
+    switch (validator_res) {
+    | Ok(current_validators) =>
+      current_validators
+      |> List.mapi((i, validator) => {
+           (
+             Address.of_key_hash(validator),
+             Printf.sprintf("http://localhost:444%d", i) |> Uri.of_string,
+           )
+         })
+    | Error(err) => failwith(err)
+    };
+
+  let initial_validators_uri =
+    List.fold_left(
+      (validators_uri, (address, uri)) =>
+        State.Address_map.add(address, uri, validators_uri),
+      State.Address_map.empty,
+      validators,
+    );
+  let persist_trusted_membership_change =
+    Files.Trusted_validators_membership_change.write(
+      ~file=trusted_validator_membership_change_file,
+    );
+  let node =
+    State.make(
+      ~identity,
+      ~trusted_validator_membership_change,
+      ~interop_context,
+      ~data_folder=folder,
+      ~initial_validators_uri,
+      ~persist_trusted_membership_change,
+    );
+  let node = {
+    ...node,
+    protocol: {
+      ...node.protocol,
+      validators:
+        List.fold_left(
+          (validators, (address, _)) =>
+            Validators.add({address: address}, validators),
+          Validators.empty,
+          validators,
+        ),
+    },
+  };
+  let state_bin = folder ++ "/state.bin";
+  let.await state_bin_exists = Lwt_unix.file_exists(state_bin);
+  let.await protocol =
+    if (state_bin_exists) {
+      let.await protocol = Files.State_bin.read(~file=state_bin);
+      await(protocol);
+    } else {
+      await(node.protocol);
+    };
+  let node = {...node, protocol};
+
+  await(node);
+};

--- a/bin/node_state.rei
+++ b/bin/node_state.rei
@@ -1,0 +1,1 @@
+let get_initial_state: (~folder: string) => Lwt.t(Node.State.t);

--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -499,7 +499,12 @@ let produce_block = node_folder => {
   let.await state = Node_state.get_initial_state(~folder=node_folder);
   let address = identity.t;
   let block =
-    Block.produce(~state=state.protocol, ~author=address, ~operations=[]);
+    Block.produce(
+      ~state=state.protocol,
+      ~next_state_root_hash=None,
+      ~author=address,
+      ~operations=[],
+    );
   let signature = Block.sign(~key=identity.secret, block);
   let.await validators_uris = validators_uris(node_folder);
   let.await () =

--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -5,6 +5,7 @@ open State;
 open Protocol;
 open Cmdliner;
 open Core;
+open Bin_common;
 
 Printexc.record_backtrace(true);
 
@@ -18,12 +19,6 @@ let write_identity = (~node_folder) =>
   Files.Identity.write(~file=node_folder ++ "/identity.json");
 let write_interop_context = (~node_folder) =>
   Files.Interop_context.write(~file=node_folder ++ "/tezos.json");
-let read_state = (~node_folder): Lwt.t(Protocol.t) =>
-  Lwt_io.with_file(
-    ~mode=Input,
-    node_folder ++ "/state.bin",
-    Lwt_io.read_value,
-  );
 
 let man = [
   `S(Manpage.s_bugs),
@@ -501,9 +496,10 @@ let info_produce_block = {
 
 let produce_block = node_folder => {
   let.await identity = read_identity(~node_folder);
-  let.await state = read_state(~node_folder);
+  let.await state = Node_state.get_initial_state(~folder=node_folder);
   let address = identity.t;
-  let block = Block.produce(~state, ~author=address, ~operations=[]);
+  let block =
+    Block.produce(~state=state.protocol, ~author=address, ~operations=[]);
   let signature = Block.sign(~key=identity.secret, block);
   let.await validators_uris = validators_uris(node_folder);
   let.await () =

--- a/crypto/incremental_patricia.re
+++ b/crypto/incremental_patricia.re
@@ -33,6 +33,7 @@ module Make =
 
   let is_set = (bit, number) => 1 lsl bit land number != 0;
 
+  // Hash: 0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8
   let empty_hash = BLAKE2B.hash("");
   let hash_of_t =
     fun

--- a/node/building_blocks.re
+++ b/node/building_blocks.re
@@ -56,6 +56,29 @@ let is_current_producer = (state, ~key_hash) => {
   Some(current_producer.address == key_hash);
 };
 
+// TODO: verify reasonable times for this with benchmarking.
+// currently set to [state_root_min_timeout] as a reasonable
+// default.
+let minimum_signable_time_between_epochs = 10.0;
+
+// TODO: verify reasonable times for this with benchmarking.
+// Currently set to [minimum_signable_time_between_epochs] + 10
+// as a reasonable default.
+let maximum_signable_time_between_epochs = 20.0;
+
+let block_has_signable_state_root_hash = (~current_time, state, block) => {
+  let protocol = state.Node.protocol;
+  let time_since_last_epoch = current_time -. protocol.last_state_root_update;
+  Crypto.(
+    if (BLAKE2B.equal(block.Block.state_root_hash, protocol.state_root_hash)) {
+      time_since_last_epoch <= maximum_signable_time_between_epochs;
+    } else {
+      BLAKE2B.equal(block.state_root_hash, state.next_state_root |> fst)
+      && time_since_last_epoch >= minimum_signable_time_between_epochs;
+    }
+  );
+};
+
 // TODO: bad naming
 // TODO: check if block must have published a new snapshot
 let is_signable = (state, block) => {
@@ -103,17 +126,50 @@ let is_signable = (state, block) => {
   && !is_signed_by_self(state, ~hash=block.hash)
   && is_current_producer(state, ~key_hash=block.author)
   && !has_next_block_to_apply(state, ~hash=block.hash)
-  && all_operations_are_trusted;
+  && all_operations_are_trusted
+  && block_has_signable_state_root_hash(~current_time, state, block);
 };
 
 let sign = (~key, block) => Block.sign(~key, block);
 
-let produce_block = state =>
+/** Calculates whether to start sending a new state root hash.
+
+    The state root epoch is the interval (in blocks) between state root
+    hash updates. Thus, a new epoch is triggered by applying a block with
+    a new state root hash. The block producer decides when to send
+    blocks with new state root hashes. To enforce that he does so on time,
+    validators reject blocks with updates that occur to soon or too late
+    (see [Protocol.apply]).
+
+    The block producer uses this function to determine when to send a
+    block with an updated state root hash.
+*/
+let should_start_new_epoch = (last_state_root_update, current_time) => {
+  let avoid_jitter = 1.0;
+  current_time
+  -. last_state_root_update
+  -. avoid_jitter >= minimum_signable_time_between_epochs;
+};
+
+let produce_block = state => {
+  let start_new_epoch =
+    should_start_new_epoch(
+      state.Node.protocol.last_state_root_update,
+      Unix.time(),
+    );
+  let next_state_root_hash =
+    if (start_new_epoch) {
+      Some(state.Node.next_state_root |> fst);
+    } else {
+      None;
+    };
   Block.produce(
     ~state=state.Node.protocol,
     ~author=state.identity.t,
+    ~next_state_root_hash,
     ~operations=state.pending_operations,
   );
+};
 
 let is_valid_block_height = (state, block_height) =>
   block_height >= 1L && block_height <= state.Node.protocol.block_height;

--- a/node/flows.re
+++ b/node/flows.re
@@ -187,6 +187,15 @@ let rec try_to_apply_block = (state, update_state, block) => {
     `Block_not_signed_enough_to_apply,
     Block_pool.is_signed(~hash=block.Block.hash, state.Node.block_pool),
   );
+
+  let (next_state_root_hash, _) = state.next_state_root;
+  // TODO: in the future, we should stop the chain if this assert fails
+  let.assert () = (
+    `Invalid_state_root_hash,
+    BLAKE2B.equal(state.protocol.state_root_hash, block.state_root_hash)
+    || BLAKE2B.equal(next_state_root_hash, block.state_root_hash),
+  );
+
   let.ok state = apply_block(state, update_state, block);
   reset_timeout^();
   let state = clean(state, update_state, block);

--- a/node/snapshots.rei
+++ b/node/snapshots.rei
@@ -4,6 +4,7 @@ open Protocol;
 type t =
   pri {
     last_snapshot: (BLAKE2B.t, string),
+    last_snapshot_height: int64,
     last_block: Block.t,
     last_block_signatures: Signatures.t,
     additional_blocks: list(Block.t),

--- a/node/state.re
+++ b/node/state.re
@@ -23,6 +23,7 @@ type t = {
   block_pool: Block_pool.t,
   protocol: Protocol.t,
   snapshots: Snapshots.t,
+  next_state_root: (BLAKE2B.t, string),
   // networking
   // TODO: move this to somewhere else but the string means the nonce needed
   // TODO: someone right now can spam the network to prevent uri changes
@@ -54,10 +55,10 @@ let make =
   let initial_block_pool =
     Block_pool.make(~self_key=identity.key)
     |> Block_pool.append_block(initial_block);
-  let initial_snapshots = {
-    let initial_snapshot = Protocol.hash(initial_protocol);
+  let initial_snapshot = Protocol.hash(initial_protocol);
+  let initial_snapshots =
     Snapshots.make(~initial_snapshot, ~initial_block, ~initial_signatures);
-  };
+
   {
     identity,
     trusted_validator_membership_change,
@@ -67,6 +68,7 @@ let make =
     block_pool: initial_block_pool,
     protocol: initial_protocol,
     snapshots: initial_snapshots,
+    next_state_root: initial_snapshot,
     // networking
     uri_state: Uri_map.empty,
     validators_uri: initial_validators_uri,
@@ -120,6 +122,26 @@ let try_to_commit_state_hash = (~old_state, state, block, signatures) => {
     );
   });
 };
+
+let write_data_to_file = (path, protocol) => {
+  let protocol_bin = Marshal.to_string(protocol, []);
+  Lwt.async(() =>
+    Lwt_io.with_file(
+      ~mode=Output,
+      path,
+      oc => {
+        let.await () = Lwt_io.write(oc, protocol_bin);
+        Lwt_io.flush(oc);
+      },
+    )
+  );
+};
+
+let write_state_to_file = (~data_folder, protocol) =>
+  write_data_to_file(data_folder ++ "/state.bin", protocol);
+let write_prev_epoch_state_to_file = (~data_folder, protocol) =>
+  write_data_to_file(data_folder ++ "/prev_epoch_state.bin", protocol);
+
 let apply_block = (state, block) => {
   let old_state = state;
   let.ok (protocol, new_snapshot, receipts) =
@@ -130,28 +152,29 @@ let apply_block = (state, block) => {
       state.recent_operation_receipts,
       receipts,
     );
-  let state = {...state, protocol, recent_operation_receipts};
-  Lwt.async(() =>
-    Lwt_io.with_file(
-      ~mode=Output,
-      state.data_folder ++ "/state.bin",
-      oc => {
-        let protocol_bin = Marshal.to_string(state.protocol, []);
-        let.await () = Lwt_io.write(oc, protocol_bin);
-        Lwt_io.flush(oc);
-      },
-    )
-  );
+  let next_state_root =
+    new_snapshot |> Option.value(~default=state.next_state_root);
+  let state = {
+    ...state,
+    protocol,
+    next_state_root,
+    recent_operation_receipts,
+  };
+  write_state_to_file(~data_folder=state.data_folder, state.protocol);
   switch (new_snapshot) {
-  | Some(new_snapshot) =>
+  | Some(_) =>
     switch (Block_pool.find_signatures(~hash=block.hash, state.block_pool)) {
     | Some(signatures) when Signatures.is_self_signed(signatures) =>
       try_to_commit_state_hash(~old_state, state, block, signatures)
     | _ => ()
     };
+    write_prev_epoch_state_to_file(
+      ~data_folder=state.data_folder,
+      old_state.protocol,
+    );
     let snapshots =
       Snapshots.update(
-        ~new_snapshot,
+        ~new_snapshot=old_state.next_state_root,
         ~applied_block_height=state.protocol.block_height,
         state.snapshots,
       );
@@ -210,14 +233,18 @@ let load_snapshot =
   );
   let.assert () = (
     `State_root_not_the_expected,
-    // TODO: this List.hd will not fail, but it makes me anxious
-    state_root_hash == List.hd(all_blocks).state_root_hash,
+    // TODO: It may not hold in the future that the last block's
+    // state root hash is equal to this state root's hash. E.g.,
+    // we may send blocks from the requested epoch and future ones.
+    // In the future, the equivalent check should be something like this:
+    // let hd_srh == List.hd(all_blocks).state_root_hash;
+    // state_root_hash == List.find(b => b.srh != hd_srh)
+    state_root_hash == last_block.state_root_hash,
   );
   let.assert () = (
     `Snapshots_with_invalid_hash,
     BLAKE2B.verify(~hash=state_root_hash, state_root),
   );
-
   let of_yojson = [%of_yojson:
     (
       Core.State.t,
@@ -259,18 +286,32 @@ let load_snapshot =
       last_applied_block_timestamp: 0.0,
       last_seen_membership_change_timestamp: 0.0,
     };
-  let.ok protocol =
+  let next_state_root = (state_root_hash, state_root);
+
+  let.ok (protocol, next_state_root) =
     List.fold_left_ok(
-      (protocol, block) => {
+      ((protocol, prev_state_root), block) => {
+        // TODO: we're leaking information about when the protocol
+        // hashes a new state here; however, this will get much cleaner
+        // in the next PR.
+        if (block.Block.state_root_hash != protocol.state_root_hash) {
+          write_prev_epoch_state_to_file(
+            ~data_folder=t.data_folder,
+            protocol,
+          );
+        };
         // TODO: ignore this may be really bad for snapshots
         // TODO: ignore the result is also really bad
-        let.ok (protocol, _new_hash, _result) =
+        let.ok (protocol, next_state_root, _result) =
           Protocol.apply_block(protocol, block);
-        Ok(protocol);
+        Ok((
+          protocol,
+          Option.value(~default=prev_state_root, next_state_root),
+        ));
       },
-      protocol,
+      (protocol, next_state_root),
       all_blocks,
     );
   //TODO: snapshots?
-  Ok({...t, block_pool, protocol});
+  Ok({...t, next_state_root, block_pool, protocol});
 };

--- a/node/state.re
+++ b/node/state.re
@@ -122,7 +122,7 @@ let try_to_commit_state_hash = (~old_state, state, block, signatures) => {
     );
   });
 };
-
+// TODO: this function should be moved anywhere else, it doesn't make sense in the protocol
 let write_data_to_file = (path, protocol) => {
   let protocol_bin = Marshal.to_string(protocol, []);
   Lwt.async(() =>

--- a/node/state.rei
+++ b/node/state.rei
@@ -22,6 +22,7 @@ type t = {
   block_pool: Block_pool.t,
   protocol: Protocol.t,
   snapshots: Snapshots.t,
+  next_state_root: (BLAKE2B.t, string),
   // networking
   uri_state: Uri_map.t(string),
   validators_uri: Address_map.t(Uri.t),

--- a/protocol/block.re
+++ b/protocol/block.re
@@ -156,28 +156,15 @@ let genesis =
     ~author=Address.of_key(Wallet.genesis_wallet),
   );
 
-// TODO: move this to a global module
-let state_root_hash_epoch = 60.0;
-/** to prevent changing the validator just because of network jittering
-    this introduce a delay between can receive a block with new state
-    root hash and can produce that block
-
-    1s choosen here but any reasonable time will make it */
-let avoid_jitter = 1.0;
-let _can_update_state_root_hash = state =>
-  Unix.time()
-  -. state.Protocol_state.last_state_root_update >= state_root_hash_epoch;
-let can_produce_with_new_state_root_hash = state =>
-  Unix.time()
-  -. state.Protocol_state.last_state_root_update
-  -. avoid_jitter >= state_root_hash_epoch;
-let produce = (~state) => {
-  let update_state_hashes = can_produce_with_new_state_root_hash(state);
+let produce = (~state, ~next_state_root_hash) => {
+  let next_state_root_hash =
+    Option.value(
+      ~default=state.Protocol_state.state_root_hash,
+      next_state_root_hash,
+    );
   make(
     ~previous_hash=state.Protocol_state.last_block_hash,
-    ~state_root_hash=
-      update_state_hashes
-        ? fst(Protocol_state.hash(state)) : state.state_root_hash,
+    ~state_root_hash=next_state_root_hash,
     ~handles_hash=
       Core.State.ledger(state.core_state) |> Ledger.handles_root_hash,
     ~validators_hash=Validators.hash(state.validators),

--- a/protocol/block.re
+++ b/protocol/block.re
@@ -144,8 +144,11 @@ let compare = (a, b) => BLAKE2B.compare(a.hash, b.hash);
 
 let genesis =
   make(
+    // Hash: b55ce6d1804e12b112c9795f18b81d2ec7ff33047e67a05e0c8603c5e49c3203
     ~previous_hash=BLAKE2B.hash("tuturu"),
+    // Hash: 5eda8fbfa16cbef410d16ab2ee1d29613b6ecb02e1cb919d7c3e42c830c40b28
     ~state_root_hash=BLAKE2B.hash("mayuushi"),
+    // Hash: 841dac8bea2a4a8501aceb9228837d900eedd8f489ef73958f56a6ef9c7e7e49
     ~handles_hash=BLAKE2B.hash("desu"),
     ~validators_hash=Validators.hash(Validators.empty),
     ~block_height=0L,

--- a/protocol/block.rei
+++ b/protocol/block.rei
@@ -21,6 +21,7 @@ let genesis: t;
 let produce:
   (
     ~state: Protocol_state.t,
+    ~next_state_root_hash: option(BLAKE2B.t),
     ~author: Address.t,
     ~operations: list(Protocol_operation.t)
   ) =>

--- a/protocol/protocol.re
+++ b/protocol/protocol.re
@@ -156,15 +156,18 @@ let make = (~initial_block) => {
 };
 let apply_block = (state, block) => {
   let.assert () = (`Invalid_block_when_applying, is_next(state, block));
-  let (valid_hash, hash) =
-    if (block.state_root_hash == state.state_root_hash) {
-      (true, None);
+  let hash =
+    if (Crypto.BLAKE2B.equal(block.state_root_hash, state.state_root_hash)) {
+      None;
     } else {
-      // TODO: pipeline this
-      let (hash, data) = hash(state);
-      (block.state_root_hash == hash, Some((hash, data)));
+      let (next_state_root_hash, next_state_root_data) =
+        Protocol_state.hash(state);
+      Format.printf(
+        "\x1b[36m New protocol hash: %s\x1b[m\n%!",
+        next_state_root_hash |> Crypto.BLAKE2B.to_string,
+      );
+      Some((next_state_root_hash, next_state_root_data));
     };
-  let.assert () = (`Invalid_state_root_hash, valid_hash);
   let (state, result) = apply_block(state, block);
   Ok((state, hash, result));
 };


### PR DESCRIPTION
## Depends

- [x] #308
- [x] #309
- [x] #398 

## Problem

Per #147, we want async state hashing. We have a design in #218; however, the problem remains a complex one, and we need to break apart the design in to incremental steps. This PR avoids asynchronicity, and instead introduces the smallest step possible in the right direction: the delayed state hashing.

## Solution

Recall that #218 introduces the new terminology of "state root epoch" to refer to the interval (in blocks) between state root hash updates. This PR delays the state root hash sent by one epoch, such that the next state root hash N is calculated during epoch N - 1 (refer to #218 for diagrams illustrating this).

To achieve this, we extend the protocol state with a fields `current_epoch` and `next_epoch`. `current_epoch` is merely an integer identifier for the epoch (that will be used in subsequent PR's). `next_epoch` is record defined to be the state root hash of the next epoch along with the data that produced that hash. The field acts like an expectation: when applying a block with a different state root hash than the current one (i.e, when the epoch changes), it _must_ match `next_epoch.state_root_hash`, else the block will be rejected. 

Updating this field is simple (at least when done synchronously): when applying a block with a new state root hash, update `next_epoc` to be the hash the current state (along with its data as a JSON string). This achieves our inductive definition: at epoch N - 1, we generate the hash of epoch N, and so on. Additionally, increment `current_epoch`. 

Of course, we need a base case. Let epoch of the empty chain (i.e, before appyling the genesis block) be `-1`. Let the state root hash associated with epoch -1 be the hash of some arbitrary data (not reachable as a protocol state). At epoch -1, we know that the next block will be the genesis block, and so we can predetermine the hash of epoch 0. Thus, at the initial state, we can set `next_epoch.state_root_hash` to the state root hash of the genesis block.


**Note to reviewers** - please make sure I didn't break snapshots etc. by adding the two fields `current_epoch` and `next_epoch`.

## Related

- #147
- #218
- #195 (this PR is a better first PR than #195 - I'll change 195 to depend on this one).
 