### PR TITLE
adds a secure path for Add_remove/Remove_validators

### DIFF
--- a/bin/deku_node.re
+++ b/bin/deku_node.re
@@ -159,12 +159,9 @@ let handle_register_uri =
   );
 let handle_receive_operation_gossip =
   handle_request(
-    (module Networking.Operation_gossip),
-    (update_state, request) => {
-      Flows.received_operation(Server.get_state(), update_state, request);
-      Ok();
-    },
-  );
+    (module Networking.Operation_gossip), (update_state, request) => {
+    Flows.received_operation(Server.get_state(), update_state, request)
+  });
 
 let handle_trusted_validators_membership =
     (


### PR DESCRIPTION
## Problem

`received_operation` needs to check signature (and it author) to
ensure Add_validator and Remove_validator are only triggered by the
block producer. We currently dont have a way to do this.


## Solution

This PR adds a signature verification check for `Add_validator` and `Remove_validator` and making sure only the node operator initiated it. 

Note: these signature verified operations are not (and cannot be) broadcasted


## Related

- #206 
 