### PR TITLE
Remove genesis_helper from package.jsons's esy.release.bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
     "build": "dune build -p #{self.name}",
     "release": {
       "bin": [
-        "genesis_helper",
         "sidecli"
       ]
     },


### PR DESCRIPTION
<!---
  if some of the following sections doesn't apply,
  delete the section.

  Also feel free to delete the comments.
--->

## Depends

None

## Problem

`genesis_helper` is listed in package.json's `esy.release.bin`, but `genesis_helper` is gone now so it serves no purpose.

## Solution

Remove it
 