### PR TITLE
Lift state hashing to the node

### DIFF
--- a/node/state.re
+++ b/node/state.re
@@ -78,7 +78,7 @@ let make =
 };
 
 // TODO: this function should be moved anywhere else, it doesn't make sense in the protocol
-let write_data_to_file = (path, protocol) => {
+let write_state_to_file = (path, protocol) => {
   let protocol_bin = Marshal.to_string(protocol, []);
   Lwt.async(() =>
     Lwt_io.with_file(
@@ -92,45 +92,52 @@ let write_data_to_file = (path, protocol) => {
   );
 };
 
-let write_state_to_file = (~data_folder, protocol) =>
-  write_data_to_file(data_folder ++ "/state.bin", protocol);
-let write_prev_epoch_state_to_file = (~data_folder, protocol) =>
-  write_data_to_file(data_folder ++ "/prev_epoch_state.bin", protocol);
-
 let apply_block = (state, block) => {
-  let old_state = state;
-  let.ok (protocol, new_snapshot, receipts) =
-    apply_block(state.protocol, block);
+  let prev_protocol = state.protocol;
+  let.ok (protocol, receipts) = Protocol.apply_block(state.protocol, block);
+
+  write_state_to_file(state.data_folder ++ "/state.bin", protocol);
+  let (next_state_root, snapshots) =
+    if (Crypto.BLAKE2B.equal(
+          block.state_root_hash,
+          prev_protocol.state_root_hash,
+        )) {
+      (state.next_state_root, state.snapshots);
+    } else {
+      // Save the hash that will become the next state root
+      // to disk so if the node goes offline before finishing
+      // hashing it, it can pick up where it left off.
+      write_state_to_file(
+        state.data_folder ++ "/prev_epoch_state.bin",
+        prev_protocol,
+      );
+      let (next_state_root_hash, next_state_root_data) =
+        Protocol.hash(prev_protocol);
+      Format.printf(
+        "\x1b[36m New protocol hash: %s\x1b[m\n%!",
+        next_state_root_hash |> Crypto.BLAKE2B.to_string,
+      );
+      let snapshots =
+        Snapshots.update(
+          ~new_snapshot=state.next_state_root,
+          ~applied_block_height=block.block_height,
+          state.snapshots,
+        );
+      ((next_state_root_hash, next_state_root_data), snapshots);
+    };
   let recent_operation_receipts =
     List.fold_left(
       (results, (hash, receipt)) => BLAKE2B.Map.add(hash, receipt, results),
       state.recent_operation_receipts,
       receipts,
     );
-  let next_state_root =
-    new_snapshot |> Option.value(~default=state.next_state_root);
-  let state = {
+  Ok({
     ...state,
     protocol,
     next_state_root,
     recent_operation_receipts,
-  };
-  write_state_to_file(~data_folder=state.data_folder, state.protocol);
-  switch (new_snapshot) {
-  | Some(_) =>
-    write_prev_epoch_state_to_file(
-      ~data_folder=state.data_folder,
-      old_state.protocol,
-    );
-    let snapshots =
-      Snapshots.update(
-        ~new_snapshot=old_state.next_state_root,
-        ~applied_block_height=state.protocol.block_height,
-        state.snapshots,
-      );
-    Ok({...state, snapshots});
-  | None => Ok(state)
-  };
+    snapshots,
+  });
 };
 
 // TODO: duplicated code
@@ -237,31 +244,6 @@ let load_snapshot =
       last_seen_membership_change_timestamp: 0.0,
     };
   let next_state_root = (state_root_hash, state_root);
-
-  let.ok (protocol, next_state_root) =
-    List.fold_left_ok(
-      ((protocol, prev_state_root), block) => {
-        // TODO: we're leaking information about when the protocol
-        // hashes a new state here; however, this will get much cleaner
-        // in the next PR.
-        if (block.Block.state_root_hash != protocol.state_root_hash) {
-          write_prev_epoch_state_to_file(
-            ~data_folder=t.data_folder,
-            protocol,
-          );
-        };
-        // TODO: ignore this may be really bad for snapshots
-        // TODO: ignore the result is also really bad
-        let.ok (protocol, next_state_root, _result) =
-          Protocol.apply_block(protocol, block);
-        Ok((
-          protocol,
-          Option.value(~default=prev_state_root, next_state_root),
-        ));
-      },
-      (protocol, next_state_root),
-      all_blocks,
-    );
-  //TODO: snapshots?
-  Ok({...t, next_state_root, block_pool, protocol});
+  let t = {...t, next_state_root, protocol, block_pool};
+  List.fold_left_ok(apply_block, t, all_blocks);
 };

--- a/protocol/protocol.re
+++ b/protocol/protocol.re
@@ -156,20 +156,8 @@ let make = (~initial_block) => {
 };
 let apply_block = (state, block) => {
   let.assert () = (`Invalid_block_when_applying, is_next(state, block));
-  let hash =
-    if (Crypto.BLAKE2B.equal(block.state_root_hash, state.state_root_hash)) {
-      None;
-    } else {
-      let (next_state_root_hash, next_state_root_data) =
-        Protocol_state.hash(state);
-      Format.printf(
-        "\x1b[36m New protocol hash: %s\x1b[m\n%!",
-        next_state_root_hash |> Crypto.BLAKE2B.to_string,
-      );
-      Some((next_state_root_hash, next_state_root_data));
-    };
   let (state, result) = apply_block(state, block);
-  Ok((state, hash, result));
+  Ok((state, result));
 };
 
 let get_current_block_producer = state =>


### PR DESCRIPTION

## Depends

- [x] #227

## Problem

Per #147, we're trying to achieve async state hashing. But this is a complex problem (see #218). 

Before we make hashing async, we first need to lift the process of hashing out of the protocol and into the node. 

Remember, `./protocol` does not actually do consensus - rather, the `Protocol` library contains just the core state information  that is guaranteed to be agreed upon by every honest in-sync node. Therefore, any consensus checking should be done in `./node` - any checking done in `./protocol` is only as a redundancy/failsafe.



## Solution

This change should not modify the behavior in any way from #227 (reviewers, help me check this!). All it does is move the hashing process to `Node.State.apply_block`. In the next  PR, we'll introduce (partial) asynchronicity. 

## Related

- #147
 