### PR TITLE
Optimistic async state hashing

### DIFF
--- a/bin/deku_node.re
+++ b/bin/deku_node.re
@@ -272,18 +272,25 @@ let node = folder => {
   };
   let state_bin = folder ++ "/state.bin";
   let.await state_bin_exists = Lwt_unix.file_exists(state_bin);
-  let.await protocol =
+  let.await (protocol, next_state_root_hash) =
     if (state_bin_exists) {
-      Files.State_bin.read(~file=state_bin);
+      let.await protocol = Files.State_bin.read(~file=state_bin);
+      let prev_epoch_state_bin = folder ++ "/prev_epoch_state.bin";
+      let.await prev_protocol =
+        Files.State_bin.read(~file=prev_epoch_state_bin);
+      let (next_state_root_hash, _) = Protocol.hash(prev_protocol);
+      await((protocol, next_state_root_hash));
     } else {
       let.await () = Files.State_bin.write(node.protocol, ~file=state_bin);
-      await(node.protocol);
+      // TODO: should we write prev_epoch_state.bin here? Otherwise there's
+      // a possibility of the one existing without the other
+      await((node.protocol, node.next_state_root_hash));
     };
   Tezos_interop.Consensus.listen_operations(
     ~context=interop_context, ~on_operation=operation =>
     Flows.received_main_operation(Server.get_state(), update_state, operation)
   );
-  await({...node, protocol});
+  await({...node, next_state_root_hash, protocol});
 };
 
 let node = folder => {

--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -500,6 +500,7 @@ let produce_block = node_folder => {
   let block =
     Block.produce(
       ~state,
+      ~next_state_root_hash=None,
       ~author=address,
       ~main_chain_ops=[],
       ~side_chain_ops=[],

--- a/crypto/incremental_patricia.re
+++ b/crypto/incremental_patricia.re
@@ -33,6 +33,7 @@ module Make =
 
   let is_set = (bit, number) => 1 lsl bit land number != 0;
 
+  // Hash: 0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8
   let empty_hash = BLAKE2B.hash("");
   let hash_of_t =
     fun

--- a/node/flows.re
+++ b/node/flows.re
@@ -190,8 +190,11 @@ let rec try_to_apply_block = (state, update_state, block) => {
   );
   let.assert () = (
     `Invalid_state_root_hash,
-    state.protocol.state_root_hash == block.state_root_hash
-    || state.next_state_root_hash == block.state_root_hash,
+    BLAKE2B.equal(state.protocol.state_root_hash, block.state_root_hash)
+    || State.get_next_hash(state)
+    |> Option.map(fst)
+    |> Option.map(BLAKE2B.equal(block.state_root_hash))
+    |> Option.value(~default=false),
   );
 
   let.ok state = apply_block(state, update_state, block);

--- a/node/flows.re
+++ b/node/flows.re
@@ -188,6 +188,12 @@ let rec try_to_apply_block = (state, update_state, block) => {
     `Block_not_signed_enough_to_apply,
     Block_pool.is_signed(~hash=block.Block.hash, state.Node.block_pool),
   );
+  let.assert () = (
+    `Invalid_state_root_hash,
+    state.protocol.state_root_hash == block.state_root_hash
+    || state.next_state_root_hash == block.state_root_hash,
+  );
+
   let.ok state = apply_block(state, update_state, block);
   reset_timeout^();
   let state = clean(state, update_state, block);

--- a/node/flows.re
+++ b/node/flows.re
@@ -183,6 +183,37 @@ let try_to_sign_block = (state, update_state, block) =>
     state;
   };
 
+/** Starts asynchronously hashing a new state. Side-effectfully updates
+    the map of epoches to hashes when done.
+
+    Each block is associated with a particular state root hash.
+    The state root starts with genesis, and then updates periodically.
+    This means you don't have to download the entire history of the chain
+    to derive the state corresponding to a given block - only the state
+    corresponding to its state root hash is required.
+    Because hashing a state is an expensive operation, we do it in parallel
+    on a separate thread. This allows the block producer to continue
+    producing blocks even while the state root is being updated.
+ */
+let hash_new_state_root = (state, update_state) => {
+  Lwt.async(() => {
+    // Lwt_domain.detach causes the function to run in a separate thread.
+    // When the promise resolves, the rest of the function is run in main thread.
+    let.await next_state_root =
+      Lwt_domain.detach((s: Node.t) => Protocol.hash(s.protocol), state);
+    let _ =
+      update_state(
+        // The state may be stale so we must retrieve the current state again.
+        State.add_finished_hash(
+          state.protocol.block_height,
+          next_state_root,
+          get_state^(),
+        ),
+      );
+    Lwt.return();
+  });
+};
+
 let rec try_to_apply_block = (state, update_state, block) => {
   let.assert () = (
     `Block_not_signed_enough_to_apply,
@@ -200,6 +231,11 @@ let rec try_to_apply_block = (state, update_state, block) => {
   let.ok state = apply_block(state, update_state, block);
   reset_timeout^();
   let state = clean(state, update_state, block);
+
+  if (!BLAKE2B.equal(state.protocol.state_root_hash, block.state_root_hash)) {
+    hash_new_state_root(state, update_state);
+  };
+
   switch (
     Block_pool.find_next_block_to_apply(
       ~hash=block.Block.hash,

--- a/node/state.re
+++ b/node/state.re
@@ -111,6 +111,26 @@ let try_to_commit_state_hash = (~old_state, state, block, signatures) => {
            Address_map.find_opt(wallet, signatures_map),
          )
        );
+  let signatures_of_block =
+    Block_pool.find_signatures(~hash=block.Block.hash, state.block_pool)
+    |> Option.map(Signatures.to_list);
+
+  let current_validator_keys =
+    List.map(
+      ((signer_key, _signature_opt)) => {
+        let.some signatures_of_block = signatures_of_block;
+        let.some validator_signature =
+          List.find_opt(
+            s => {
+              let key_hash = Signature.address(s) |> Address.to_key_hash;
+              Key_hash.equal(signer_key, key_hash);
+            },
+            signatures_of_block,
+          );
+        some(Signature.public_key(validator_signature));
+      },
+      signatures,
+    );
 
   Lwt.async(() => {
     /* TODO: solve this magic number
@@ -128,6 +148,7 @@ let try_to_commit_state_hash = (~old_state, state, block, signatures) => {
       ~state_hash=block.state_root_hash,
       ~validators,
       ~signatures,
+      ~current_validator_keys,
     );
   });
 };

--- a/node/state.re
+++ b/node/state.re
@@ -141,7 +141,6 @@ let try_to_commit_state_hash = (~old_state, state, block, signatures) => {
         ? Lwt.return_unit : Lwt_unix.sleep(120.0);
     commit_state_hash(
       state,
-      ~block_hash=block.hash,
       ~block_height=block.block_height,
       ~block_payload_hash=block.payload_hash,
       ~handles_hash=block.handles_hash,

--- a/node/state.re
+++ b/node/state.re
@@ -199,7 +199,16 @@ let apply_block = (state, block) => {
   let state =
     if (new_epoch) {
       let state = start_new_epoch(state);
-      let new_snapshot = Protocol.hash(state.protocol);
+      let (new_snapshot, state) =
+        switch (get_next_hash(state)) {
+        | Some(snapshot) => (snapshot, state)
+        | None =>
+          let new_snapshot = Protocol.hash(old_state.protocol);
+          (
+            new_snapshot,
+            add_finished_hash(block.block_height, new_snapshot, state),
+          );
+        };
       let state = add_finished_hash(block.block_height, new_snapshot, state);
       let snapshots =
         Snapshots.update(

--- a/node/state.rei
+++ b/node/state.rei
@@ -12,6 +12,7 @@ type identity = {
 
 module Address_map: Map.S with type key = Address.t;
 module Uri_map: Map.S with type key = Uri.t;
+module Int64_map: Map.S with type key = int64;
 
 type t = {
   identity,
@@ -23,7 +24,8 @@ type t = {
   block_pool: Block_pool.t,
   protocol: Protocol.t,
   snapshots: Snapshots.t,
-  next_state_root_hash: BLAKE2B.t,
+  next_state_root_hash_block_height: int64,
+  finished_hashes: Int64_map.t((BLAKE2B.t, string)),
   // networking
   uri_state: Uri_map.t(string),
   validators_uri: Address_map.t(Uri.t),
@@ -39,6 +41,14 @@ type t = {
   persist_trusted_membership_change:
     list(Trusted_validators_membership_change.t) => Lwt.t(unit),
 };
+
+/** Adds a (hash, data) pair to the map of finished hashes,
+    indexed by the block height it was generated on. */
+let add_finished_hash: (int64, (BLAKE2B.t, string), t) => t;
+
+/** Gets the next state root hash.
+    Returns [None] if it is not known. */
+let get_next_hash: t => option((BLAKE2B.t, string));
 
 let make:
   (

--- a/node/state.rei
+++ b/node/state.rei
@@ -23,6 +23,7 @@ type t = {
   block_pool: Block_pool.t,
   protocol: Protocol.t,
   snapshots: Snapshots.t,
+  next_state_root_hash: BLAKE2B.t,
   // networking
   uri_state: Uri_map.t(string),
   validators_uri: Address_map.t(Uri.t),

--- a/protocol/block.re
+++ b/protocol/block.re
@@ -166,26 +166,12 @@ let genesis =
     ~author=Address.of_key(Wallet.genesis_wallet),
   );
 
-// TODO: move this to a global module
-let state_root_hash_epoch = 60.0;
-/** to prevent changing the validator just because of network jittering
-    this introduce a delay between can receive a block with new state
-    root hash and can produce that block
-
-    1s choosen here but any reasonable time will make it */
-let avoid_jitter = 1.0;
-let _can_update_state_root_hash = state =>
-  Unix.time() -. state.State.last_state_root_update >= state_root_hash_epoch;
-let can_produce_with_new_state_root_hash = state =>
-  Unix.time()
-  -. state.State.last_state_root_update
-  -. avoid_jitter >= state_root_hash_epoch;
-let produce = (~state) => {
-  let update_state_hashes = can_produce_with_new_state_root_hash(state);
+let produce = (~state, ~next_state_root_hash) => {
+  let next_state_root_hash =
+    Option.value(~default=state.State.state_root_hash, next_state_root_hash);
   make(
     ~previous_hash=state.State.last_block_hash,
-    ~state_root_hash=
-      update_state_hashes ? fst(State.hash(state)) : state.state_root_hash,
+    ~state_root_hash=next_state_root_hash,
     ~handles_hash=Ledger.handles_root_hash(state.ledger),
     ~validators_hash=Validators.hash(state.validators),
     ~block_height=Int64.add(state.block_height, 1L),

--- a/protocol/block.re
+++ b/protocol/block.re
@@ -153,8 +153,11 @@ let compare = (a, b) => BLAKE2B.compare(a.hash, b.hash);
 
 let genesis =
   make(
+    // Hash: b55ce6d1804e12b112c9795f18b81d2ec7ff33047e67a05e0c8603c5e49c3203
     ~previous_hash=BLAKE2B.hash("tuturu"),
+    // Hash: 5eda8fbfa16cbef410d16ab2ee1d29613b6ecb02e1cb919d7c3e42c830c40b28
     ~state_root_hash=BLAKE2B.hash("mayuushi"),
+    // Hash: 841dac8bea2a4a8501aceb9228837d900eedd8f489ef73958f56a6ef9c7e7e49
     ~handles_hash=BLAKE2B.hash("desu"),
     ~validators_hash=Validators.hash(Validators.empty),
     ~block_height=0L,

--- a/protocol/block.re
+++ b/protocol/block.re
@@ -151,6 +151,7 @@ let of_yojson = json => {
 
 let compare = (a, b) => BLAKE2B.compare(a.hash, b.hash);
 
+// Genesis Block Hash: bb796b51b2bcf4c2e799a6ff009b4e37f8dff1c60a9e77fb18aa48fc07c5ef61
 let genesis =
   make(
     // Hash: b55ce6d1804e12b112c9795f18b81d2ec7ff33047e67a05e0c8603c5e49c3203

--- a/protocol/block.rei
+++ b/protocol/block.rei
@@ -23,6 +23,7 @@ let genesis: t;
 let produce:
   (
     ~state: State.t,
+    ~next_state_root_hash: option(BLAKE2B.t),
     ~author: Address.t,
     ~main_chain_ops: list(Main_chain.t),
     ~side_chain_ops: list(Side_chain.t)

--- a/protocol/protocol.re
+++ b/protocol/protocol.re
@@ -180,15 +180,8 @@ let make = (~initial_block) => {
 };
 let apply_block = (state, block) => {
   let.assert () = (`Invalid_block_when_applying, is_next(state, block));
-  let hash =
-    if (Crypto.BLAKE2B.equal(block.state_root_hash, state.state_root_hash)) {
-      None;
-    } else {
-      let (next_state_root_hash, next_state_root_data) = State.hash(state);
-      Some((next_state_root_hash, next_state_root_data));
-    };
   let (state, result) = apply_block(state, block);
-  Ok(({...state, state_root_hash: block.state_root_hash}, hash, result));
+  Ok(({...state, state_root_hash: block.state_root_hash}, result));
 };
 
 let get_current_block_producer = state =>

--- a/tests/test_protocol.re
+++ b/tests/test_protocol.re
@@ -45,6 +45,7 @@ describe("protocol state", ({test, _}) => {
     let block =
       Block.produce(
         ~state,
+        ~next_state_root_hash=None,
         ~author,
         ~main_chain_ops=main,
         ~side_chain_ops=side,

--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -246,7 +246,6 @@ module Consensus = {
   let commit_state_hash =
       (
         ~context,
-        ~block_hash,
         ~block_height,
         ~block_payload_hash,
         ~state_hash,
@@ -258,7 +257,6 @@ module Consensus = {
     module Payload = {
       [@deriving to_yojson]
       type t = {
-        block_hash: BLAKE2B.t,
         block_height: int64,
         block_payload_hash: BLAKE2B.t,
         signatures: list(option(string)),
@@ -282,7 +280,6 @@ module Consensus = {
       List.map(Option.map(Key.to_string), current_validator_keys);
 
     let payload = {
-      block_hash,
       block_height,
       block_payload_hash,
       signatures,

--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -253,6 +253,7 @@ module Consensus = {
         ~handles_hash,
         ~validators,
         ~signatures,
+        ~current_validator_keys,
       ) => {
     module Payload = {
       [@deriving to_yojson]
@@ -264,6 +265,7 @@ module Consensus = {
         handles_hash: BLAKE2B.t,
         state_hash: BLAKE2B.t,
         validators: list(string),
+        current_validator_keys: list(option(string)),
       };
     };
     open Payload;
@@ -275,6 +277,10 @@ module Consensus = {
         signatures,
       );
     let validators = List.map(Key_hash.to_string, validators);
+
+    let current_validator_keys =
+      List.map(Option.map(Key.to_string), current_validator_keys);
+
     let payload = {
       block_hash,
       block_height,
@@ -283,6 +289,7 @@ module Consensus = {
       handles_hash,
       state_hash,
       validators,
+      current_validator_keys,
     };
     // TODO: what should this code do with the output? Retry?
     //      return back that it was a failure?

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -22,7 +22,8 @@ module Consensus: {
       ~state_hash: BLAKE2B.t,
       ~handles_hash: BLAKE2B.t,
       ~validators: list(Key_hash.t),
-      ~signatures: list((Key_hash.t, option(Signature.t)))
+      ~signatures: list((Key_hash.t, option(Signature.t))),
+      ~current_validator_keys: list(option(Key.t))
     ) =>
     Lwt.t(unit);
 

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -16,7 +16,6 @@ module Consensus: {
   let commit_state_hash:
     (
       ~context: Context.t,
-      ~block_hash: BLAKE2B.t,
       ~block_height: int64,
       ~block_payload_hash: BLAKE2B.t,
       ~state_hash: BLAKE2B.t,


### PR DESCRIPTION

## Depends

- [ ] #232

## Problem

We want async state hashing per #147. 

This review is highly contingent on #232 - please review that one first. 

## Solution

#232 lifts state hashing from inside `Protocol` to inside the node. 

This PR is an incremental step towards full async hashing. In the best case, hashing is done fully asynchronously; however, if the hash is not finished, the node hashes the state synchronously on demand. 

To achieve this, the PR builds on #232 in two steps (1 commit per step):

1. First, it drops the notion of `next_state_root_hash`. Instead, we extend the node state with two fields:
  - `current_epoch` - an integer identifier for the current state root hash epoch.
   - `finished_hashes` - a map from epochs to the corresponding hash.
   - In the "setter" function, we build in a filter that drops any hashes older than the current epoch. This prevents the map from growing forever and also prevents the epoch from moving backwards.
  - This commit should not change the behavior in any way from #232 - reviewers, please help me check this!
2.  Next, we add an additional way to add hashes to the map, namely via async state hashing. We also slightly modify the `apply_block` function to be optimistic: if the map already contains the hash (because of async state hashing), then we use that value - otherwise,  we generate the hash synchronously. This allows us to have aysnc state hashing while never getting out of sync because of slow hashing. The cost of course is that some hashes may be done twice. 

In the next PR, we'll add more sophistication on the case where the hash is not already finished, adding a notion of in-sync and out-of-sync. 

## Related

<!--- add here all the related issues to your PR --->
- #147
 