### PR TITLE
use crypto library for everything

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,20 +1,14 @@
 (executable
  (name deku_node)
  (public_name deku-node)
- (libraries opium files node mirage-crypto-ec mirage-crypto-rng.unix helpers)
+ (libraries opium files node mirage-crypto-rng.unix helpers)
  (modules Deku_node)
  (preprocess
   (pps ppx_deriving.show ppx_deriving_yojson)))
 
 (executable
  (name sidecli)
- (libraries
-  node
-  files
-  mirage-crypto-ec
-  mirage-crypto-rng.unix
-  helpers
-  cmdliner)
+ (libraries node files mirage-crypto-rng.unix helpers cmdliner)
  (modules Sidecli)
  (public_name sidecli)
  (preprocess

--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -531,12 +531,10 @@ let ensure_folder = folder => {
   };
 };
 let setup_identity = (node_folder, uri) => {
-  open Mirage_crypto_ec;
-
   let.await () = ensure_folder(node_folder);
 
   let identity = {
-    let (key, t) = Ed25519.generate();
+    let (key, t) = Crypto.Ed25519.generate();
     {uri, t, key};
   };
   let.await () = write_identity(~node_folder, identity);

--- a/protocol/address.re
+++ b/protocol/address.re
@@ -1,7 +1,7 @@
 open Helpers;
-open Mirage_crypto_ec;
+open Crypto;
 
-type key = Ed25519.priv;
+type key = Ed25519.Secret.t;
 
 let key_to_yojson = key =>
   `String(Tezos_interop.Secret.to_string(Ed25519(key)));
@@ -13,15 +13,14 @@ let key_of_yojson = json => {
   ok(key);
 };
 
-type t = Ed25519.pub_; // TODO: is okay to have this public
+type t = Ed25519.Key.t; // TODO: is okay to have this public
 
 let make_pubkey = () => {
   let (_priv, pub_) = Ed25519.generate();
   pub_;
 };
 
-let compare = (a, b) =>
-  Cstruct.compare(Ed25519.pub_to_cstruct(a), Ed25519.pub_to_cstruct(b));
+let compare = Ed25519.Key.compare;
 let to_string = t => Tezos_interop.Key.to_string(Ed25519(t));
 let of_string = string => {
   let.some Ed25519(t) = Tezos_interop.Key.of_string(string);
@@ -34,7 +33,7 @@ let of_yojson = json => {
   of_string(string) |> Option.to_result(~none="failed to parse");
 };
 
-let of_key = Ed25519.pub_of_priv;
+let of_key = Ed25519.Key.of_secret;
 
 let genesis_key = {|edsk4bfbFdb4s2BdkW3ipfB23i9u82fgji6KT3oj2SCWTeHUthbSVd|};
 let genesis_key =
@@ -42,4 +41,4 @@ let genesis_key =
   | Ok(key) => key
   | Error(error) => failwith(error)
   };
-let genesis_address = Ed25519.pub_of_priv(genesis_key);
+let genesis_address = of_key(genesis_key);

--- a/protocol/address.rei
+++ b/protocol/address.rei
@@ -1,10 +1,10 @@
-open Mirage_crypto_ec;
+open Crypto;
 
 [@deriving yojson]
-type key = Ed25519.priv;
+type key = Ed25519.Secret.t;
 
 [@deriving (yojson, ord)]
-type t = Ed25519.pub_;
+type t = Ed25519.Key.t;
 
 let of_key: key => t;
 

--- a/protocol/signature.rei
+++ b/protocol/signature.rei
@@ -1,12 +1,12 @@
 open Helpers;
-open Mirage_crypto_ec;
+open Crypto;
 
 [@deriving yojson]
 type t;
 let compare: (t, t) => int;
 let public_key: t => Address.t;
 
-let sign: (~key: Ed25519.priv, BLAKE2B.t) => t;
+let sign: (~key: Ed25519.Secret.t, BLAKE2B.t) => t;
 let verify: (~signature: t, BLAKE2B.t) => bool;
 
 let signature_to_b58check: t => string;
@@ -22,7 +22,7 @@ module type S = {
       value,
       signature,
     };
-  let sign: (~key: Ed25519.priv, value) => t;
+  let sign: (~key: Ed25519.Secret.t, value) => t;
   // TODO: maybe it should be something else?
   let verify: (~signature: signature, value) => bool;
 };

--- a/protocol/wallet.re
+++ b/protocol/wallet.re
@@ -1,15 +1,14 @@
 open Helpers;
-open Mirage_crypto_ec;
+open Crypto;
 
 [@deriving ord]
 type t = BLAKE2B_20.t;
 
-let of_address = pubkey =>
-  Ed25519.pub_to_cstruct(pubkey) |> Cstruct.to_string |> BLAKE2B_20.hash;
+let of_address = pubkey => Ed25519.Key_hash.hash_key(pubkey);
 let pubkey_matches_wallet = (key, wallet) => {
   of_address(key) == wallet;
 };
-let get_pub_key = Ed25519.pub_of_priv;
+let get_pub_key = Ed25519.Key.of_secret;
 
 let make_address = () => {
   let (_key, pub_) = Ed25519.generate();

--- a/protocol/wallet.rei
+++ b/protocol/wallet.rei
@@ -1,4 +1,4 @@
-open Mirage_crypto_ec;
+open Crypto;
 open Helpers;
 
 [@deriving (ord, yojson)]
@@ -7,7 +7,7 @@ type t;
 let of_address: Address.t => t;
 let pubkey_matches_wallet: (Address.t, t) => bool;
 let get_pub_key: Address.key => Address.t;
-let make_wallet: unit => (Ed25519.priv, t);
+let make_wallet: unit => (Ed25519.Secret.t, t);
 let make_address: unit => t;
 let address_to_blake: t => BLAKE2B_20.t;
 let address_of_blake: BLAKE2B_20.t => t;

--- a/tests/test_ledger.re
+++ b/tests/test_ledger.re
@@ -27,16 +27,15 @@ describe("ledger", ({test, _}) => {
     Ticket.{ticketer, data};
   };
   let make_wallet = () => {
-    open Mirage_crypto_ec;
+    open Crypto;
     let (_key, address) = Ed25519.generate();
     Wallet.of_address(address);
   };
   let make_tezos_address = () => {
-    open Mirage_crypto_ec;
+    open Crypto;
     open Tezos_interop;
     let (_key, address) = Ed25519.generate();
-    let hash =
-      BLAKE2B_20.hash(Ed25519.pub_to_cstruct(address) |> Cstruct.to_string);
+    let hash = Ed25519.Key_hash.hash_key(address);
     Address.Implicit(Key_hash.Ed25519(hash));
   };
   let setup_two = () => {

--- a/tests/test_tezos_interop.re
+++ b/tests/test_tezos_interop.re
@@ -132,7 +132,7 @@ describe("signature", ({test, _}) => {
   });
   test("invalid key", ({expect, _}) => {
     let (secret, key) = {
-      let (secret, key) = Mirage_crypto_ec.Ed25519.generate();
+      let (secret, key) = Crypto.Ed25519.generate();
       (Secret.Ed25519(secret), Key.Ed25519(key));
     };
     let edsig_from_key = sign(secret, "tuturu");

--- a/tests/test_validators.re
+++ b/tests/test_validators.re
@@ -4,7 +4,7 @@ open Validators;
 
 describe("validators", ({test, _}) => {
   let make_validator = () => {
-    open Mirage_crypto_ec;
+    open Crypto;
     let (_key, address) = Ed25519.generate();
     Validators.{address: address};
   };

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -2,7 +2,7 @@ open Helpers;
 
 module Key: {
   type t =
-    | Ed25519(Mirage_crypto_ec.Ed25519.pub_);
+    | Ed25519(Crypto.Ed25519.Key.t);
   let equal: (t, t) => bool;
   let to_string: t => string;
   let of_string: string => option(t);
@@ -20,7 +20,7 @@ module Key_hash: {
 
 module Secret: {
   type t =
-    | Ed25519(Mirage_crypto_ec.Ed25519.priv);
+    | Ed25519(Crypto.Ed25519.Secret.t);
   let equal: (t, t) => bool;
   let to_string: t => string;
   let of_string: string => option(t);


### PR DESCRIPTION
## Depends

- [x] #236 
- [x] #237

## Problem

Deku has it's own crypto library abstraction now, but in most of the codebase it is still using mirage-crypto-ec directly, which is problematic especially if we plan to change the underlying crypto library, as discussed with @Zett98 

## Solution

Use the Crypto library for everything, the goal of this PR is that there is not a single mention of mirage-crypto-ec outside of the crypto library.