### PR TITLE
Use cmdliner for node

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,7 +1,7 @@
 (executable
  (name deku_node)
  (public_name deku-node)
- (libraries opium files node helpers)
+ (libraries opium files node helpers cmdliner)
  (modules Deku_node)
  (preprocess
   (pps ppx_deriving.show ppx_deriving_yojson)))


### PR DESCRIPTION
## Problem

The node does not use cmdliner. That means if you just run the node and pass no arguments you get a pretty unhelpful error message. 

```
$ esy x deku-node
Fatal error: exception (Invalid_argument "index out of bounds")
```

## Solution

Use cmdliner to process the command line arguments. Now the error is much more explanatory:

```
$ esy x deku-node
deku-node: required argument folder_node is missing
Usage: deku-node [OPTION]... folder_node
Try `deku-node --help' for more information.
```

I'm not sure that `folder_node` is the right name (I just copied it from sidecli), feel free to change it.

Also this helps with the logging PR. Cmdliner comes with built-in combinators for handling logging (e.g. changing the verbosity, enabling or disabling the colors, etc.) which we use in sidecli currently but can't use in deku-node without this PR or one like it. 

## Disclaimer

I feel like it probably works, but I don't know how to actually run the node so I'm not actually able to test it properly. I have a meeting tomorrow with daniel where I'll figure that and other things out.

## Related

Closes #2