### PR TITLE
Abstract Ed25519.{Key,Secret,Signature}

### DIFF
--- a/crypto/crypto_intf.re
+++ b/crypto/crypto_intf.re
@@ -39,14 +39,7 @@ module type S = {
   let generate: unit => (Secret.t, Key.t);
 };
 module type Intf = {
-  open Helpers;
-  open Mirage_crypto_ec;
   module type S = S;
   module Base58 = Base58;
-  module Ed25519:
-    S with
-      type Key.t = Ed25519.pub_ and
-      type Key_hash.t = BLAKE2B_20.t and
-      type Secret.t = Ed25519.priv and
-      type Signature.t = string;
+  module Ed25519: S with type Key_hash.t = Helpers.BLAKE2B_20.t;
 };

--- a/protocol/signature.re
+++ b/protocol/signature.re
@@ -1,14 +1,23 @@
 open Helpers;
 open Crypto;
 
-[@deriving yojson]
+module Ed25519 = {
+  include Ed25519;
+  module Signature = {
+    include Signature;
+    let to_yojson = t => `String(to_string(t));
+    let of_yojson = string => {
+      let.ok string = [%of_yojson: string](string);
+      of_string(string) |> Option.to_result(~none="Invalid_signature");
+    };
+  };
+};
+[@deriving (ord, yojson)]
 type t = {
   // TODO: what is the name of a signature?
-  signature: string,
+  signature: Ed25519.Signature.t,
   public_key: Address.t,
 };
-// TODO: is it safe to compare only the signature?
-let compare = (a, b) => String.compare(a.signature, b.signature);
 let public_key = t => t.public_key;
 let sign = (~key, hash) => {
   // double hash because tezos always uses blake2b on CHECK_SIGNATURE
@@ -20,17 +29,13 @@ let sign = (~key, hash) => {
   let public_key = Ed25519.Key.of_secret(key);
   {signature, public_key};
 };
-let signature_to_b58check = t => {
-  let prefix = Crypto.Base58.Prefix.ed25519_signature;
-  let to_raw = t => t.signature;
-  Crypto.Base58.simple_encode(~prefix, ~to_raw, t);
-};
+let signature_to_b58check = t => Ed25519.Signature.to_string(t.signature);
 let signature_to_b58check_by_address = t => {
   (t.public_key, signature_to_b58check(t));
 };
 let signature_to_tezos_signature_by_address = t => (
   t.public_key,
-  Tezos_interop.Signature.of_raw_string(`Ed25519(t.signature)),
+  Tezos_interop.Signature.Ed25519(t.signature),
 );
 let verify = (~signature, hash) => {
   let hash = BLAKE2B.to_raw_string(hash) |> BLAKE2B.hash;

--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -244,10 +244,6 @@ module Signature = {
     };
     try_decode_list([ed25519]);
   };
-  // TODO: this is a leaky abstraction
-  let of_raw_string =
-    fun
-    | `Ed25519(data) => Ed25519(data);
 };
 
 module Ticket = {

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -27,7 +27,8 @@ module Secret: {
 };
 
 module Signature: {
-  type t = pri | Ed25519(string);
+  type t =
+    | Ed25519(Crypto.Ed25519.Signature.t);
 
   let equal: (t, t) => bool;
 
@@ -36,9 +37,6 @@ module Signature: {
 
   let to_string: t => string;
   let of_string: string => option(t);
-
-  // TODO: this is a leaky abstraction
-  let of_raw_string: [ | `Ed25519(string)] => t;
 };
 
 module Contract_hash: {


### PR DESCRIPTION
## Depends

- [x] #238

## Problem

Since #238 we're not using mirage-crypto-ec directly, but we're still exposing the types to the codebase and not using abstract types so mixing things like `signature` and `message` is possible.

## Solution

To avoid simple mistakes like using mirage-crypto-ec types outside of the crypto library, this PR makes `Ed25519.{Key,Secret,Signature}` abstracts, this also solves the problem of `Signature.t` being a string.
