### PR TITLE
add deku-node to package.json's esy.release.bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "build": "dune build -p #{self.name}",
     "release": {
       "bin": [
-        "sidecli"
+        "sidecli",
+        "deku-node"
       ]
     },
     "buildEnv": {


### PR DESCRIPTION
## Problem

Esy's package.json esy.release.bin field "helps esy figure which binaries have to be made binary relocatable and ready for publishing to NPM" (thanks @callistonianembrace for explaining that). But it doesn't currently contain `deku-node`.

## Solution

Add `deku-node`
