### PR TITLE
initialize rng inside of crypto

### DIFF
--- a/bin/deku_node.re
+++ b/bin/deku_node.re
@@ -2,9 +2,6 @@
 // Can a core send a message and the other receive it in the past?
 // TODO: should start signing before being in sync?
 
-Random.self_init();
-Mirage_crypto_rng_unix.initialize();
-
 open Opium;
 open Helpers;
 open Protocol;

--- a/bin/dune
+++ b/bin/dune
@@ -1,14 +1,14 @@
 (executable
  (name deku_node)
  (public_name deku-node)
- (libraries opium files node mirage-crypto-rng.unix helpers)
+ (libraries opium files node helpers)
  (modules Deku_node)
  (preprocess
   (pps ppx_deriving.show ppx_deriving_yojson)))
 
 (executable
  (name sidecli)
- (libraries node files mirage-crypto-rng.unix helpers cmdliner)
+ (libraries node files helpers cmdliner)
  (modules Sidecli)
  (public_name sidecli)
  (preprocess

--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -754,7 +754,6 @@ let remove_trusted_validator = {
 // Run the CLI
 
 let () = {
-  Mirage_crypto_rng_unix.initialize();
   Term.exit @@
   Term.eval_choice(
     show_help,

--- a/crypto/crypto.re
+++ b/crypto/crypto.re
@@ -1,3 +1,6 @@
+Random.self_init();
+Mirage_crypto_rng_unix.initialize();
+
 include Crypto_intf;
 
 module Base58 = Base58;

--- a/crypto/dune
+++ b/crypto/dune
@@ -1,5 +1,5 @@
 (library
  (name crypto)
- (libraries data-encoding mirage-crypto-ec helpers)
+ (libraries data-encoding mirage-crypto-ec mirage-crypto-rng.unix helpers)
  (preprocess
   (pps ppx_deriving.ord ppx_deriving.eq)))

--- a/protocol/dune
+++ b/protocol/dune
@@ -1,5 +1,5 @@
 (library
  (name protocol)
- (libraries helpers tezos_interop mirage-crypto-rng.unix)
+ (libraries helpers tezos_interop)
  (preprocess
   (pps ppx_deriving_yojson ppx_deriving.ord)))

--- a/tests/dune
+++ b/tests/dune
@@ -4,14 +4,14 @@
   (:standard \ Test_runner))
  (library_flags
   (-linkall -g))
- (libraries rely.lib tezos_interop protocol node mirage-crypto-rng.unix)
+ (libraries rely.lib tezos_interop protocol node)
  (preprocess
   (pps ppx_deriving_yojson)))
 
 (executable
  (name Test_runner)
  (modules Test_runner)
- (libraries protocol_test_lib mirage-crypto-rng.unix))
+ (libraries protocol_test_lib))
 
 (rule
  (alias runtest)

--- a/tests/setup.re
+++ b/tests/setup.re
@@ -1,6 +1,5 @@
 Printexc.record_backtrace(true);
 
-Mirage_crypto_rng_unix.initialize();
 include Rely.Make({
   let config =
     Rely.TestFrameworkConfig.initialize({

--- a/tests/test_runner.re
+++ b/tests/test_runner.re
@@ -1,4 +1,3 @@
 Printexc.record_backtrace(true);
-Mirage_crypto_rng_unix.initialize();
 
 Protocol_test_lib.Setup.cli();

--- a/tezos_interop/dune
+++ b/tezos_interop/dune
@@ -1,6 +1,6 @@
 (library
  (name tezos_interop)
- (libraries helpers lwt.unix mirage-crypto-ec tezos-micheline crypto)
+ (libraries helpers lwt.unix tezos-micheline crypto)
  (preprocess
   (pps ppx_deriving_yojson ppx_deriving.eq ppx_blob))
  (preprocessor_deps


### PR DESCRIPTION
## Problem

mirage-crypto-rng which is used by mirage-crypto-ec needs to be initialized with a random generator before any other crypto call happens, this leads to a problem where we initialize the RNG in many places.

## Solution

Because the crypto module needs to be initialized before any crypto function can be used it creates a nice spot to do RNG initialization, and this is what I do on this PR.

As a bonus I remove all the external mentions to mirage-crypto.