### PR TITLE
Precompute validators hash

### DIFF
--- a/protocol/block.re
+++ b/protocol/block.re
@@ -177,9 +177,7 @@ let produce = (~state) => {
     ~state_root_hash=
       update_state_hashes ? fst(State.hash(state)) : state.state_root_hash,
     ~handles_hash=Ledger.handles_root_hash(state.ledger),
-    ~validators_hash=
-      update_state_hashes
-        ? Validators.hash(state.validators) : state.validators_hash,
+    ~validators_hash=Validators.hash(state.validators),
     ~block_height=Int64.add(state.block_height, 1L),
   );
 };


### PR DESCRIPTION
## Problem

Currently we update the validators hash only when the state root hash updates, in the past I thought this was required but after rethinking, we can easily update the validators a lot more frequently than the state root hash as the proof of the consensus is actually the block hash.

## Solution

As validators rarely change, we can compute the hash when adding or removing a new validator and just use the same hash. This allows to update the validators hash on every block.

## Related

- #227 
 