### PR TITLE
use crypto directly inside deku

### DIFF
--- a/bin/deku_node.re
+++ b/bin/deku_node.re
@@ -223,7 +223,7 @@ let node = {
       |> List.mapi((i, validator) => {
            (
              switch (validator) {
-             | Tezos_interop.Key.Ed25519(k) => k
+             | k => k
              },
              Printf.sprintf("http://localhost:444%d", i) |> Uri.of_string,
            )

--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -88,10 +88,9 @@ let uri = {
 };
 
 let address = {
-  open Tezos_interop.Key_hash;
   let parser = string =>
-    Tezos_interop.Key_hash.of_string(string)
-    |> Option.map((Ed25519(hash)) => Wallet.address_of_blake(hash))
+    Crypto.Ed25519.Key_hash.of_string(string)
+    |> Option.map(hash => Wallet.address_of_blake(hash))
     |> Option.to_result(~none=`Msg("Expected a wallet address."));
   let printer = (fmt, wallet) =>
     Format.fprintf(
@@ -99,7 +98,7 @@ let address = {
       "%s",
       wallet
       |> Wallet.address_to_blake
-      |> (hash => Ed25519(hash) |> Tezos_interop.Key_hash.to_string),
+      |> (hash => hash |> Crypto.Ed25519.Key_hash.to_string),
     );
   Arg.(conv((parser, printer)));
 };

--- a/protocol/address.re
+++ b/protocol/address.re
@@ -7,8 +7,8 @@ let key_to_yojson = key =>
   `String(Tezos_interop.Secret.to_string(Ed25519(key)));
 let key_of_yojson = json => {
   let.ok string = [%of_yojson: string](json);
-  let.ok Ed25519(key) =
-    Tezos_interop.Secret.of_string(string)
+  let.ok key =
+    Ed25519.Secret.of_string(string)
     |> Option.to_result(~none="failed to parse");
   ok(key);
 };
@@ -23,8 +23,7 @@ let make_pubkey = () => {
 let compare = Ed25519.Key.compare;
 let to_string = t => Tezos_interop.Key.to_string(Ed25519(t));
 let of_string = string => {
-  let.some Ed25519(t) = Tezos_interop.Key.of_string(string);
-  Some(t);
+  Ed25519.Key.of_string(string);
 };
 
 let to_yojson = t => `String(to_string(t));

--- a/protocol/wallet.re
+++ b/protocol/wallet.re
@@ -25,8 +25,8 @@ let address_of_blake = t => t;
 let address_to_string = wallet =>
   Tezos_interop.Key_hash.(Ed25519(wallet |> address_to_blake) |> to_string);
 let address_of_string = string =>
-  switch (Tezos_interop.Key_hash.of_string(string)) {
-  | Some(Ed25519(key)) => Some(key)
+  switch (Ed25519.Key_hash.of_string(string)) {
+  | Some(key) => Some(key)
   | None => None
   };
 let to_yojson = t => `String(address_to_string(t));

--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -774,7 +774,7 @@ module Consensus = {
             (acc, k) =>
               switch (k) {
               | Micheline.String(_, k) =>
-                switch (Key.of_string(k)) {
+                switch (Ed25519.Key.of_string(k)) {
                 | Some(k) => Ok([k, ...acc])
                 | None => Error("Failed to parse " ++ k)
                 }

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -153,7 +153,8 @@ module Consensus: {
   let listen_operations:
     (~context: Context.t, ~on_operation: operation => unit) => unit;
   let fetch_validators:
-    (~context: Context.t) => Lwt.t(result(list(Key.t), string));
+    (~context: Context.t) =>
+    Lwt.t(result(list(Crypto.Ed25519.Key.t), string));
 };
 
 module Discovery: {let sign: (Secret.t, ~nonce: int64, Uri.t) => Signature.t;};


### PR DESCRIPTION
## Problem

we use Tezos_interop address types for plain ed25519 types.
Edit: 
Address.t and wallet.t are represented as ed25519 internally, but use tezos_interop module, which only had ed25519 previously, now that we will have support for tz2 and tz3 it will introduce redundant pattern matching into those modules and modules that call functions defined there.
## Solution

use ed25519 directly
## Related
- #22 
 