### PR TITLE
Add persist_trusted_membership_change to Node state

### DIFF
--- a/bin/files.re
+++ b/bin/files.re
@@ -84,7 +84,7 @@ module State_bin = {
 
 module Trusted_validators_membership_change = {
   [@deriving yojson]
-  type t = Node.Trusted_validators_membership_change.t;
+  type t = Trusted_validators_membership_change.t;
 
   let read = read_json([%of_yojson: list(t)]);
   let write = write_json([%to_yojson: list(t)]);

--- a/bin/files.rei
+++ b/bin/files.rei
@@ -1,6 +1,6 @@
+open Protocol;
 open Node;
 open State;
-open Protocol;
 
 exception Invalid_json(string);
 
@@ -35,7 +35,7 @@ module State_bin: {
 
 module Trusted_validators_membership_change: {
   [@deriving yojson]
-  type t = Node.Trusted_validators_membership_change.t;
+  type t = Trusted_validators_membership_change.t;
 
   let read: (~file: string) => Lwt.t(list(t));
   let write: (list(t), ~file: string) => Lwt.t(unit);

--- a/node/flows.re
+++ b/node/flows.re
@@ -435,8 +435,7 @@ let request_withdraw_proof = (state, ~hash) =>
 let request_ticket_balance = (state, ~ticket, ~address) =>
   state.Node.protocol.ledger |> Ledger.balance(address, ticket);
 
-let trusted_validators_membership =
-    (~file, ~persist, state, update_state, request) => {
+let trusted_validators_membership = (state, update_state, request) => {
   open Networking.Trusted_validators_membership_change;
   let {signature, payload: {address, action} as payload} = request;
   let payload_hash =
@@ -469,9 +468,8 @@ let trusted_validators_membership =
       trusted_validator_membership_change: new_validators,
     });
   Lwt.async(() =>
-    persist(
+    state.persist_trusted_membership_change(
       new_validators |> Trusted_validators_membership_change.Set.elements,
-      ~file,
     )
   );
   Ok();

--- a/node/state.re
+++ b/node/state.re
@@ -40,12 +40,15 @@ type t = {
         | `Withdraw(Ledger.Handle.t)
       ],
     ),
+  persist_trusted_membership_change:
+    list(Trusted_validators_membership_change.t) => Lwt.t(unit),
 };
 
 let make =
     (
       ~identity,
       ~trusted_validator_membership_change,
+      ~persist_trusted_membership_change,
       ~interop_context,
       ~data_folder,
       ~initial_validators_uri,
@@ -76,6 +79,7 @@ let make =
     uri_state: Uri_map.empty,
     validators_uri: initial_validators_uri,
     recent_operation_results: BLAKE2B.Map.empty,
+    persist_trusted_membership_change,
   };
 };
 

--- a/node/state.rei
+++ b/node/state.rei
@@ -10,6 +10,7 @@ type identity = {
 
 module Address_map: Map.S with type key = Address.t;
 module Uri_map: Map.S with type key = Uri.t;
+
 type t = {
   identity,
   trusted_validator_membership_change: Trusted_validators_membership_change.Set.t,
@@ -32,12 +33,18 @@ type t = {
         | `Withdraw(Ledger.Handle.t)
       ],
     ),
+  persist_trusted_membership_change:
+    list(Trusted_validators_membership_change.t) => Lwt.t(unit),
 };
 
 let make:
   (
     ~identity: identity,
     ~trusted_validator_membership_change: Trusted_validators_membership_change.Set.t,
+    ~persist_trusted_membership_change: list(
+                                          Trusted_validators_membership_change.t,
+                                        ) =>
+                                        Lwt.t(unit),
     ~interop_context: Tezos_interop.Context.t,
     ~data_folder: string,
     ~initial_validators_uri: Address_map.t(Uri.t)


### PR DESCRIPTION
## Depends

## Problem

To persist values to files via `Files` module, we have to pass a persist function as args to functions in `Node`. This is undesirable as it leads to arguments drilling (ie having to passing extra arguments to all intermediate calling functions) throughout the source.

## Solution

To work around this, at the same time avoiding moving `Files` to `Node` (which could make Node hard to test), this PR adds `persist_trusted_membership_change` to the node state (as suggested by @EduardoRFS )

## Related

- #266 (originally where the problem of arguments drilling was noticed)
 