### PR TITLE
Lower required confirmations for Tezos transactions

### DIFF
--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -570,7 +570,7 @@ let setup_tezos = (node_folder, rpc_node, secret, consensus_contract) => {
       rpc_node,
       secret,
       consensus_contract,
-      required_confirmations: 10,
+      required_confirmations: 1,
     };
   let.await () = write_interop_context(~node_folder, context);
 


### PR DESCRIPTION

## Depends

NA

## Problem

Currently the sidecli configures a Deku node to require 10 confirmations to every Tezos transaction it posts. This takes a very long time, especially on granadanet. The result is that the chain appears to just halt when running `./start.sh`.


## Solution


I propose lowering it to 1. Even at 2 the chain is very slow, appearing broken. In future PR's we  can accept a CLI option or environment variable during setup, but I believe in these early stages the default should lean towards the fastest possible setup for devs and early testers.

## Related

NA
 