### PR TITLE
fix random generator error

### DIFF
--- a/crypto/crypto.rei
+++ b/crypto/crypto.rei
@@ -1,11 +1,19 @@
-module Base58 = Base58;
-module Ed25519 = Ed25519;
-module Secp256k1 = Secp256k1;
-module Incremental_patricia = Incremental_patricia;
-module BLAKE2B = BLAKE2B;
-module BLAKE2B_20 = BLAKE2B_20;
-module Random = Random;
-module Secret = Secret;
-module Key = Key;
-module Key_hash = Key_hash;
-module Signature = Signature;
+/* WARNING: why the module type here?
+   OCaml module boot order doesn't necessarily follow the dep graph,
+   t doesn't load modules in sequence if it can skip them because
+   you're using module aliases(module X = Y), so this ensures that
+   the Random module is loaded before anything else
+
+   TODO: This is a workaround and we should discuss this in the future
+    */
+module Base58: (module type of Base58);
+module Random: (module type of Random);
+module Secp256k1: (module type of Secp256k1);
+module Ed25519: (module type of Ed25519);
+module Incremental_patricia: (module type of Incremental_patricia);
+module BLAKE2B: (module type of BLAKE2B);
+module BLAKE2B_20: (module type of BLAKE2B_20);
+module Secret: (module type of Secret);
+module Key: (module type of Key);
+module Key_hash: (module type of Key_hash);
+module Signature: (module type of Signature);


### PR DESCRIPTION
## Problem

Running Crypto.Ed25519.generate() fails due to uninitialized random generator
## Solution

pass the generator instance explicitly
 