### PR TITLE
Fix trusted-validator-membership-changes.json path

### DIFF
--- a/bin/deku_node.re
+++ b/bin/deku_node.re
@@ -188,11 +188,15 @@ let handle_ticket_balance =
     },
   );
 
-let node = (folder, trusted_validator_membership_change_file) => {
+let node = folder => {
   let.await identity = Files.Identity.read(~file=folder ++ "/identity.json");
+
+  let trusted_validator_membership_change_file =
+    folder ++ "/trusted-validator-membership-change.json";
+
   let.await trusted_validator_membership_change_list =
     Files.Trusted_validators_membership_change.read(
-      ~file=folder ++ trusted_validator_membership_change_file,
+      ~file=trusted_validator_membership_change_file,
     );
   let trusted_validator_membership_change =
     Trusted_validators_membership_change.Set.of_list(
@@ -273,14 +277,7 @@ let node = (folder, trusted_validator_membership_change_file) => {
 };
 
 let node = folder => {
-  let trusted_validator_membership_change =
-    folder ++ "/trusted-validator-membership-change.json";
-
-  let () =
-    Node.Server.start(
-      ~initial=
-        node(folder, trusted_validator_membership_change) |> Lwt_main.run,
-    );
+  let () = Node.Server.start(~initial=node(folder) |> Lwt_main.run);
 
   let _server =
     App.empty


### PR DESCRIPTION
## Problem

The `deku-node` binary is broken. It double-prepends the `--folder` path when looking for `trusted-validator-membership-changes.json` and then fails when it can't find it.

## Solution

Fix the path. I did this by moving the place where we specify the path next to all the other places so it's more obvious what the path should be, preventing this mistake from happening again in the future.

## Related
NA