### PR TITLE
Fix setup script file creation

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -16,8 +16,9 @@ for i in ${VALIDATORS[@]}; do
 
   sidecli setup-identity $FOLDER --uri "http://localhost:444$i"
   KEY=$(sidecli self $FOLDER | grep "key:" | awk '{ print $2 }')
+  ADDRESS=$(sidecli self $FOLDER | grep "key:" | awk '{ print $2 }')
   URI=$(sidecli self $FOLDER | grep "uri:" | awk '{ print $2 }')
-  VALIDATORS[$i]="$i;$KEY;$URI"
+  VALIDATORS[$i]="$i;$KEY;$URI;$ADDRESS"
 done
 
 # To register the validators, run consensus.mligo with the list of
@@ -57,7 +58,7 @@ validators_json () {
   echo "["
 for VALIDATOR in "${VALIDATORS[@]}"; do 
   i=$(echo $VALIDATOR | awk -F';' '{ print $1 }')
-  KEY=$(echo $VALIDATOR | awk -F';' '{ print $2 }')
+  ADDRESS=$(echo $VALIDATOR | awk -F';' '{ print $4 }')
   URI=$(echo $VALIDATOR | awk -F';' '{ print $3 }')
   if [ $i != 0 ]; then
     printf ",
@@ -65,7 +66,7 @@ for VALIDATOR in "${VALIDATORS[@]}"; do
   fi
 cat <<EOF
   {
-    "address": "$KEY",
+    "address": "$ADDRESS",
     "uri": "$URI"
 EOF
   printf "  }"

--- a/setup.sh
+++ b/setup.sh
@@ -37,8 +37,8 @@ cat <<EOF
 EOF
 ## this iteration is done here just to ensure the indentation
 for VALIDATOR in ${VALIDATORS[@]}; do
-  KEY=$(echo $VALIDATOR | awk -F';' '{ print $2 }')
-  echo "      (\"$KEY\": key);"
+  ADDRESS=$(echo $VALIDATOR | awk -F';' '{ print $4 }')
+  echo "      (\"$ADDRESS\": key_hash);"
 done
 cat <<EOF
     ];
@@ -79,7 +79,7 @@ trusted_validator_membership_change_json() {
   echo "["
   for VALIDATOR in "${VALIDATORS[@]}"; do
     i=$(echo $VALIDATOR | awk -F';' '{ print $1 }')
-    KEY=$(echo $VALIDATOR | awk -F';' '{ print $2 }')
+    ADDRESS=$(echo $VALIDATOR | awk -F';' '{ print $4 }')
     if [ $i != 0 ]; then
       printf ",
 "
@@ -87,7 +87,7 @@ trusted_validator_membership_change_json() {
     cat <<EOF
   {
     "action": [ "Add" ],
-    "address": "$KEY"
+    "address": "$ADDRESS"
 EOF
     printf "  }"
   done

--- a/setup.sh
+++ b/setup.sh
@@ -75,11 +75,32 @@ done
   echo "]"
 }
 
+trusted_validator_membership_change_json() {
+  echo "["
+  for VALIDATOR in "${VALIDATORS[@]}"; do
+    i=$(echo $VALIDATOR | awk -F';' '{ print $1 }')
+    KEY=$(echo $VALIDATOR | awk -F';' '{ print $2 }')
+    if [ $i != 0 ]; then
+      printf ",
+"
+    fi
+    cat <<EOF
+  {
+    "action": [ "Add" ],
+    "address": "$KEY"
+EOF
+    printf "  }"
+  done
+  echo ""
+  echo "]"
+}
+
 for VALIDATOR in ${VALIDATORS[@]}; do
   i=$(echo $VALIDATOR | awk -F';' '{ print $1 }')
   FOLDER="$data_directory/$i"
 
   validators_json > "$FOLDER/validators.json"
+  trusted_validator_membership_change_json >"$FOLDER/trusted-validator-membership-change.json"
 done
 
 # With the validators registered, use the address of the originated


### PR DESCRIPTION
## Problem
The setup script is currently incomplete/broken.

First, per #213, it does not generate the tursted-membership-validator-membership-change.json, without which the chain will not start.

Second, when we merged #283, we changed the type of an address from a public key to a public key hash (see [this line in the diff](https://github.com/marigold-dev/deku/commit/83abc7b1a1f4d6bad8d3ccd6cc4819682a0be553#diff-7c1b39fcf3624f72144844bfa6111a41df1b4c94844ad0e70456e0bf36f39ca9R5)). However, we did not change the setup script accordingly, and it still generates a public key in validators.json.

## Solution

Generating the trusted-membership-validator-change.json is very simple - I just copied the code for validators.json and made a slight modification.

Since `sidecli self` returns both the public key and the key hash, we can simply modify the setup script to use the key hash in the right place.

## Related
- #213
- #283