### PR TITLE
crypto: Signature.{sign,verify} accepts a hash

### DIFF
--- a/crypto/crypto_intf.rei
+++ b/crypto/crypto_intf.rei
@@ -38,7 +38,7 @@ module type S = {
     let to_string: t => string;
     let of_string: string => option(t);
   };
-  let sign: (Secret.t, string) => Signature.t;
-  let verify: (Key.t, Signature.t, string) => bool;
+  let sign: (Secret.t, BLAKE2B.t) => Signature.t;
+  let verify: (Key.t, Signature.t, BLAKE2B.t) => bool;
   let generate: unit => (Secret.t, Key.t);
 };

--- a/crypto/ed25519.re
+++ b/crypto/ed25519.re
@@ -88,20 +88,14 @@ module Signature = {
   });
 };
 
-let sign = (secret, message) => {
-  // double hash because tezos always uses blake2b on CHECK_SIGNATURE
-  let hash = BLAKE2B.hash(message);
+let sign = (secret, hash) =>
   Cstruct.of_string(BLAKE2B.to_raw_string(hash))
-  // TODO: isn't this double hashing? Seems weird
   |> Ed25519.sign(~key=secret)
   |> Cstruct.to_string;
-};
-let verify = (public, signature, message) => {
-  let hash = BLAKE2B.hash(message);
+let verify = (public, signature, hash) =>
   verify(
     ~key=public,
     ~msg=Cstruct.of_string(BLAKE2B.to_raw_string(hash)),
     Cstruct.of_string(signature),
   );
-};
 let generate = () => Ed25519.generate();

--- a/crypto/secp256k1.re
+++ b/crypto/secp256k1.re
@@ -113,17 +113,15 @@ let generate = () => {
   let pk = Libsecp256k1.Key.neuterize_exn(context, sk);
   (sk, pk);
 };
-let sign = (secret, message) => {
-  let hash = BLAKE2B.hash(message);
-  Bigstring.of_string(BLAKE2B.to_raw_string(hash))
+let sign = (secret, hash) => {
+  BLAKE2B.to_raw_string(hash)
+  |> Bigstring.of_string
   |> Sign.sign_exn(context, ~sk=secret);
 };
-let verify = (public, signature, message) => {
-  let hash = BLAKE2B.hash(message);
+let verify = (public, signature, hash) =>
   Sign.verify_exn(
     context,
     ~pk=public,
     ~msg=Bigstring.of_string(BLAKE2B.to_raw_string(hash)),
     ~signature,
   );
-};

--- a/crypto/signature.re
+++ b/crypto/signature.re
@@ -4,17 +4,17 @@ type t =
   | Ed25519(Ed25519.Signature.t)
   | Secp256k1(Secp256k1.Signature.t);
 
-let sign = (secret, message) =>
+let sign = (secret, hash) =>
   switch (secret) {
-  | Secret.Ed25519(secret) => Ed25519(Ed25519.sign(secret, message))
-  | Secret.Secp256k1(secret) => Secp256k1(Secp256k1.sign(secret, message))
+  | Secret.Ed25519(secret) => Ed25519(Ed25519.sign(secret, hash))
+  | Secret.Secp256k1(secret) => Secp256k1(Secp256k1.sign(secret, hash))
   };
-let verify = (key, signature, message) =>
+let verify = (key, signature, hash) =>
   switch (key, signature) {
   | (Key.Ed25519(key), Ed25519(signature)) =>
-    Ed25519.verify(key, signature, message)
+    Ed25519.verify(key, signature, hash)
   | (Key.Secp256k1(key), Secp256k1(signature)) =>
-    Secp256k1.verify(key, signature, message)
+    Secp256k1.verify(key, signature, hash)
   | (Key.Ed25519(_) | Key.Secp256k1(_), Ed25519(_) | Secp256k1(_)) => false
   };
 

--- a/crypto/signature.rei
+++ b/crypto/signature.rei
@@ -3,8 +3,8 @@ type t =
   | Ed25519(Ed25519.Signature.t)
   | Secp256k1(Secp256k1.Signature.t);
 
-let sign: (Secret.t, string) => t;
-let verify: (Key.t, t, string) => bool;
+let sign: (Secret.t, BLAKE2B.t) => t;
+let verify: (Key.t, t, BLAKE2B.t) => bool;
 
 let to_string: t => string;
 let of_string: string => option(t);

--- a/protocol/block.re
+++ b/protocol/block.re
@@ -78,7 +78,10 @@ let (hash, verify) = {
         ~handles_hash,
         ~validators_hash,
       );
-    // double hash because tezos always uses blake2b on CHECK_SIGNATURE
+    /*
+       double hash because tezos always uses blake2b on CHECK_SIGNATURE
+       https://gitlab.com/tezos/tezos/-/blob/cf95d1507a13efb3ff4fb247aabb44efc0082fa7/src/lib_crypto/ed25519.ml#L338
+     */
     let hash = BLAKE2B.hash(BLAKE2B.to_raw_string(hash));
     f((hash, block_payload_hash));
   };

--- a/protocol/block.re
+++ b/protocol/block.re
@@ -78,6 +78,8 @@ let (hash, verify) = {
         ~handles_hash,
         ~validators_hash,
       );
+    // double hash because tezos always uses blake2b on CHECK_SIGNATURE
+    let hash = BLAKE2B.hash(BLAKE2B.to_raw_string(hash));
     f((hash, block_payload_hash));
   };
   let hash = apply(Fun.id);

--- a/protocol/protocol_signature.re
+++ b/protocol/protocol_signature.re
@@ -8,7 +8,7 @@ type t = {
 };
 let public_key = t => t.public_key;
 let sign = (~key as secret, hash) => {
-  let signature = Signature.sign(secret, BLAKE2B.to_raw_string(hash));
+  let signature = Signature.sign(secret, hash);
   let public_key = Key.of_secret(secret);
   {signature, public_key};
 };
@@ -18,11 +18,7 @@ let signature_to_b58check_by_address = t => {
 };
 let signature_to_signature_by_address = t => (t.public_key, t.signature);
 let verify = (~signature, hash) =>
-  Signature.verify(
-    signature.public_key,
-    signature.signature,
-    BLAKE2B.to_raw_string(hash),
-  );
+  Signature.verify(signature.public_key, signature.signature, hash);
 module type S = {
   type value;
   type signature = t;

--- a/tests/test_tezos_interop.re
+++ b/tests/test_tezos_interop.re
@@ -182,41 +182,45 @@ describe("secret", ({test, _}) => {
   });
 });
 describe("signature", ({test, _}) => {
+  open BLAKE2B;
   open Signature;
 
   let edpk = genesis_address;
   let edsk = genesis_key;
 
+  let tuturu = hash("tuturu");
+  let tuturu2 = hash("tuturu2");
+
   // TODO: proper test for sign
-  let edsig = sign(edsk, "tuturu");
+  let edsig = sign(edsk, tuturu);
 
   let sppk = TZ2_ex.pk;
   let spsk = TZ2_ex.sk;
-  let spsig = sign(spsk, "tuturu");
+  let spsig = sign(spsk, tuturu);
 
   test("check", ({expect, _}) => {
-    expect.bool(verify(edpk, edsig, "tuturu")).toBeTrue();
-    expect.bool(verify(sppk, spsig, "tuturu")).toBeTrue();
+    expect.bool(verify(edpk, edsig, tuturu)).toBeTrue();
+    expect.bool(verify(sppk, spsig, tuturu)).toBeTrue();
   });
   test("invalid message", ({expect, _}) => {
-    expect.bool(verify(edpk, edsig, "tuturu2")).toBeFalse();
-    expect.bool(verify(sppk, spsig, "tuturu2")).toBeFalse();
+    expect.bool(verify(edpk, edsig, tuturu2)).toBeFalse();
+    expect.bool(verify(sppk, spsig, tuturu2)).toBeFalse();
   });
   test("invalid key", ({expect, _}) => {
     let (secret, key) = {
       let (secret, key) = Ed25519.generate();
       (Secret.Ed25519(secret), Key.Ed25519(key));
     };
-    let edsig_from_key = sign(secret, "tuturu");
-    expect.bool(verify(key, edsig_from_key, "tuturu")).toBeTrue();
-    expect.bool(verify(edpk, edsig_from_key, "tuturu")).toBeFalse();
+    let edsig_from_key = sign(secret, tuturu);
+    expect.bool(verify(key, edsig_from_key, tuturu)).toBeTrue();
+    expect.bool(verify(edpk, edsig_from_key, tuturu)).toBeFalse();
     let (secret, key) = {
       let (secret, key) = Crypto.Secp256k1.generate();
       (Secret.Secp256k1(secret), Key.Secp256k1(key));
     };
-    let pksig_from_key = sign(secret, "tuturu");
-    expect.bool(verify(key, pksig_from_key, "tuturu")).toBeTrue();
-    expect.bool(verify(sppk, pksig_from_key, "tuturu")).toBeFalse();
+    let pksig_from_key = sign(secret, tuturu);
+    expect.bool(verify(key, pksig_from_key, tuturu)).toBeTrue();
+    expect.bool(verify(sppk, pksig_from_key, tuturu)).toBeFalse();
   });
 
   test("to_string", ({expect, _}) => {

--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -672,15 +672,13 @@ module Discovery = {
   open Pack;
 
   let sign = (secret, ~nonce, uri) =>
-    Signature.sign(
-      secret,
-      Bytes.to_string(
-        to_bytes(
-          pair(
-            int(Z.of_int64(nonce)),
-            bytes(Bytes.of_string(Uri.to_string(uri))),
-          ),
-        ),
+    to_bytes(
+      pair(
+        int(Z.of_int64(nonce)),
+        bytes(Bytes.of_string(Uri.to_string(uri))),
       ),
-    );
+    )
+    |> Bytes.to_string
+    |> BLAKE2B.hash
+    |> Signature.sign(secret);
 };


### PR DESCRIPTION
## Problem

Currently `Signature.{sign,verify}` accept any message, but this is not correct, a Deku node should always sign only a hash(BLAKE2B), this also reflects the behavior at Tezos where [CHECK_SIGNATURE](https://gitlab.com/tezos/tezos/-/blob/cf95d1507a13efb3ff4fb247aabb44efc0082fa7/src/lib_crypto/ed25519.ml#L338) always hashes the message before.

## Solution

This PR guarantees that on the type level by making so that the functions accept a hash directly. Because of that this removes the double hashing for a lot of operations, but for communication with Tezos it is still needed as seen at [consensus.mligo](https://github.com/marigold-dev/deku/blob/4798b2e221280036a389233000a1d600cd530317/tezos_interop/consensus.mligo#L64) where we first hash it, then pass to `Crypto.check` which will hash it again.

