### PR TITLE
tezos: move Ticket_id from Tezos_interop

### DIFF
--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -140,10 +140,10 @@ let tezos_required_confirmations = {
 
 let ticket = {
   let parser = string =>
-    Tezos_interop.Ticket.of_string(string)
+    Tezos.Ticket_id.of_string(string)
     |> Option.to_result(~none=`Msg("Expected a ticket"));
   let printer = (fmt, ticket) =>
-    Format.fprintf(fmt, "%S", Tezos_interop.Ticket.to_string(ticket));
+    Format.fprintf(fmt, "%S", Tezos.Ticket_id.to_string(ticket));
   Arg.(conv(~docv="A ticket", (parser, printer)));
 };
 let hash = {

--- a/protocol/ticket.re
+++ b/protocol/ticket.re
@@ -1,8 +1,6 @@
-open Tezos_interop;
-
-[@deriving (ord, yojson)]
+include Tezos.Ticket_id;
 type t =
-  Ticket.t = {
+  Tezos.Ticket_id.t = {
     ticketer: Tezos.Address.t,
     data: bytes,
   };

--- a/protocol/ticket.rei
+++ b/protocol/ticket.rei
@@ -1,7 +1,7 @@
 // TODO: at least do a proper abstraction here
 [@deriving (ord, yojson)]
 type t =
-  Tezos_interop.Ticket.t = {
+  Tezos.Ticket_id.t = {
     ticketer: Tezos.Address.t,
     data: bytes,
   };

--- a/tests/test_tezos_interop.re
+++ b/tests/test_tezos_interop.re
@@ -384,7 +384,7 @@ describe("address", ({test, _}) => {
   });
 });
 describe("ticket", ({test, _}) => {
-  open Ticket;
+  open Ticket_id;
 
   let kt1 =
     Address.Originated({contract: some_contract_hash, entrypoint: None});
@@ -399,7 +399,7 @@ describe("ticket", ({test, _}) => {
       of_string({|(Pair "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc" 0x61)|}),
     ).
       toBe(
-      ~equals=Ticket.equal,
+      ~equals=equal,
       Some(ticket),
     )
   });

--- a/tezos/dune
+++ b/tezos/dune
@@ -1,5 +1,5 @@
 (library
  (name tezos)
- (libraries helpers crypto)
+ (libraries helpers crypto tezos-micheline)
  (preprocess
   (pps ppx_deriving.eq ppx_deriving.ord ppx_deriving_yojson)))

--- a/tezos/tezos.re
+++ b/tezos/tezos.re
@@ -1,2 +1,3 @@
 module Contract_hash = Contract_hash;
 module Address = Address;
+module Ticket_id = Ticket_id;

--- a/tezos/tezos.rei
+++ b/tezos/tezos.rei
@@ -1,2 +1,3 @@
 module Contract_hash = Contract_hash;
 module Address = Address;
+module Ticket_id = Ticket_id;

--- a/tezos/ticket_id.re
+++ b/tezos/ticket_id.re
@@ -1,0 +1,48 @@
+open Tezos_micheline;
+open Helpers;
+
+[@deriving (eq, ord)]
+type t = {
+  ticketer: Address.t,
+  data: bytes,
+};
+
+let parse_micheline = string => {
+  let (tokens, errors) = Micheline_parser.tokenize(string);
+  switch (errors) {
+  | [] =>
+    let (micheline, errors) = Micheline_parser.parse_expression(tokens);
+    switch (errors) {
+    | [] => Some(micheline)
+    | _ => None
+    };
+  | _ => None
+  };
+};
+
+let to_string = t => {
+  let loc = Micheline_printer.{comment: None};
+  let micheline =
+    Micheline.Prim(
+      loc,
+      "Pair",
+      [String(loc, Address.to_string(t.ticketer)), Bytes(loc, t.data)],
+      [],
+    );
+  Format.asprintf("%a", Micheline_printer.print_expr, micheline);
+};
+let of_string = string => {
+  let.some micheline = parse_micheline(string);
+  let.some (ticketer, data) =
+    switch (micheline) {
+    // TODO: maybe full Michelson_v1_parser
+    | Prim(_, "Pair", [String(_, ticketer), Bytes(_, data)], []) =>
+      Some((ticketer, data))
+    | _ => None
+    };
+  let.some ticketer = Address.of_string(ticketer);
+  Some({ticketer, data});
+};
+
+let (to_yojson, of_yojson) =
+  Yojson_ext.with_yojson_string("ticket_id", to_string, of_string);

--- a/tezos/ticket_id.rei
+++ b/tezos/ticket_id.rei
@@ -1,0 +1,7 @@
+[@deriving (eq, ord, yojson)]
+type t = {
+  ticketer: Address.t,
+  data: bytes,
+};
+let to_string: t => string;
+let of_string: string => option(t);

--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -2,54 +2,6 @@ open Helpers;
 open Crypto;
 open Tezos;
 
-module Ticket = {
-  open Tezos_micheline;
-
-  [@deriving eq]
-  type t = {
-    // TODO: should we allow implicit contracts here?
-    ticketer: Address.t,
-    data: bytes,
-  };
-
-  let parse_micheline = string => {
-    let (tokens, errors) = Micheline_parser.tokenize(string);
-    switch (errors) {
-    | [] =>
-      let (micheline, errors) = Micheline_parser.parse_expression(tokens);
-      switch (errors) {
-      | [] => Some(micheline)
-      | _ => None
-      };
-    | _ => None
-    };
-  };
-
-  let to_string = t => {
-    let loc = Micheline_printer.{comment: None};
-    let micheline =
-      Micheline.Prim(
-        loc,
-        "Pair",
-        [String(loc, Address.to_string(t.ticketer)), Bytes(loc, t.data)],
-        [],
-      );
-    Format.asprintf("%a", Micheline_printer.print_expr, micheline);
-  };
-  let of_string = string => {
-    let.some micheline = parse_micheline(string);
-    let.some (ticketer, data) =
-      switch (micheline) {
-      // TODO: maybe full Michelson_v1_parser
-      | Prim(_, "Pair", [String(_, ticketer), Bytes(_, data)], []) =>
-        Some((ticketer, data))
-      | _ => None
-      };
-    let.some ticketer = Address.of_string(ticketer);
-    Some({ticketer, data});
-  };
-};
-
 module Operation_hash = {
   [@deriving eq]
   type t = BLAKE2B.t;
@@ -413,7 +365,7 @@ module Consensus = {
 
   type parameters =
     | Deposit({
-        ticket: Ticket.t,
+        ticket: Ticket_id.t,
         // TODO: proper type for amounts
         amount: Z.t,
         destination: Address.t,
@@ -492,7 +444,7 @@ module Consensus = {
         Data_encoding.Binary.of_bytes_opt(Address.encoding, destination);
       let.some ticketer =
         Data_encoding.Binary.of_bytes_opt(Address.encoding, ticketer);
-      let ticket = Ticket.{ticketer, data};
+      let ticket = Ticket_id.{ticketer, data};
       Some(Deposit({ticket, destination, amount}));
     | _ => None
     };

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -2,16 +2,6 @@ open Helpers;
 open Crypto;
 open Tezos;
 
-module Ticket: {
-  type t = {
-    ticketer: Address.t,
-    data: bytes,
-  };
-  let equal: (t, t) => bool;
-  let to_string: t => string;
-  let of_string: string => option(t);
-};
-
 module Operation_hash: {
   type t = BLAKE2B.t;
   let equal: (t, t) => bool;
@@ -79,7 +69,7 @@ module Consensus: {
 
   type parameters =
     | Deposit({
-        ticket: Ticket.t,
+        ticket: Ticket_id.t,
         // TODO: proper type for amounts
         amount: Z.t,
         destination: Address.t,


### PR DESCRIPTION
## Depends

- [x] #304 

## Problem

Following #303, a tezos ticket is also currently defined inside of Tezos_interop, and should be at the Tezos library, there is also the fact that a `Ticket.t` is actually an `Ticket_id.t` as it only represents the identification part of a Ticket.

## Solution

This PR refactors the Ticket module a bit, renames it to `Ticket_Id` and move it to the Tezos library.