### PR TITLE
tezos: move Operation_hash from Tezos_interop

### DIFF
--- a/protocol/operation.re
+++ b/protocol/operation.re
@@ -14,7 +14,7 @@ module Main_chain = {
   [@deriving yojson]
   type t = {
     hash: BLAKE2B.t,
-    tezos_hash: BLAKE2B.t,
+    tezos_hash: Tezos.Operation_hash.t,
     tezos_index: int,
     kind,
   };
@@ -24,7 +24,7 @@ module Main_chain = {
     /* TODO: this is bad name, it exists like this to prevent
        duplicating all this name parameters */
     let apply = (f, ~tezos_hash, ~tezos_index, ~kind) => {
-      let to_yojson = [%to_yojson: (BLAKE2B.t, int, kind)];
+      let to_yojson = [%to_yojson: (Tezos.Operation_hash.t, int, kind)];
       let json = to_yojson((tezos_hash, tezos_index, kind));
       let payload = Yojson.Safe.to_string(json);
       f(payload);

--- a/protocol/operation.rei
+++ b/protocol/operation.rei
@@ -14,22 +14,17 @@ module Main_chain: {
   type t =
     pri {
       hash: BLAKE2B.t,
-      tezos_hash: Tezos_interop.Operation_hash.t,
+      tezos_hash: Tezos.Operation_hash.t,
       tezos_index: int,
       kind,
     };
 
   let make:
-    (
-      ~tezos_hash: Tezos_interop.Operation_hash.t,
-      ~tezos_index: int,
-      ~kind: kind
-    ) =>
-    t;
+    (~tezos_hash: Tezos.Operation_hash.t, ~tezos_index: int, ~kind: kind) => t;
   let verify:
     (
       ~hash: BLAKE2B.t,
-      ~tezos_hash: Tezos_interop.Operation_hash.t,
+      ~tezos_hash: Tezos.Operation_hash.t,
       ~tezos_index: int,
       ~kind: kind
     ) =>

--- a/tezos/operation_hash.re
+++ b/tezos/operation_hash.re
@@ -1,0 +1,19 @@
+open Helpers;
+open Crypto;
+
+[@deriving (eq, ord)]
+type t = BLAKE2B.t;
+
+include Encoding_helpers.Make_b58({
+  type nonrec t = t;
+  let name = "Operation_hash";
+  let title = "A Tezos operation ID";
+
+  let size = BLAKE2B.size;
+  let prefix = Base58.Prefix.operation_hash;
+
+  let to_raw = BLAKE2B.to_raw_string;
+  let of_raw = BLAKE2B.of_raw_string;
+});
+let (to_yojson, of_yojson) =
+  Yojson_ext.with_yojson_string("operation_hash", to_string, of_string);

--- a/tezos/operation_hash.rei
+++ b/tezos/operation_hash.rei
@@ -1,0 +1,7 @@
+open Crypto;
+
+[@deriving (eq, ord, yojson)]
+type t = BLAKE2B.t;
+let encoding: Data_encoding.t(t);
+let to_string: t => string;
+let of_string: string => option(t);

--- a/tezos/operation_hash.rei
+++ b/tezos/operation_hash.rei
@@ -1,7 +1,5 @@
-open Crypto;
-
 [@deriving (eq, ord, yojson)]
-type t = BLAKE2B.t;
+type t;
 let encoding: Data_encoding.t(t);
 let to_string: t => string;
 let of_string: string => option(t);

--- a/tezos/tezos.re
+++ b/tezos/tezos.re
@@ -2,3 +2,4 @@ module Contract_hash = Contract_hash;
 module Address = Address;
 module Ticket_id = Ticket_id;
 module Pack = Pack;
+module Operation_hash = Operation_hash;

--- a/tezos/tezos.rei
+++ b/tezos/tezos.rei
@@ -2,3 +2,4 @@ module Contract_hash = Contract_hash;
 module Address = Address;
 module Ticket_id = Ticket_id;
 module Pack = Pack;
+module Operation_hash = Operation_hash;

--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -332,7 +332,7 @@ module Consensus = {
       })
     | Update_root_hash(BLAKE2B.t);
   type operation = {
-    hash: BLAKE2B.t,
+    hash: Operation_hash.t,
     index: int,
     parameters,
   };

--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -2,17 +2,6 @@ open Helpers;
 open Crypto;
 open Tezos;
 
-module Operation_hash = {
-  [@deriving eq]
-  type t = BLAKE2B.t;
-
-  let prefix = Base58.Prefix.operation_hash;
-  let to_raw = BLAKE2B.to_raw_string;
-  let of_raw = BLAKE2B.of_raw_string;
-  let to_string = t => Base58.simple_encode(~prefix, ~to_raw, t);
-  let of_string = string => Base58.simple_decode(~prefix, ~of_raw, string);
-};
-
 module Context = {
   type t = {
     rpc_node: Uri.t,

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -2,13 +2,6 @@ open Helpers;
 open Crypto;
 open Tezos;
 
-module Operation_hash: {
-  type t = BLAKE2B.t;
-  let equal: (t, t) => bool;
-  let to_string: t => string;
-  let of_string: string => option(t);
-};
-
 module Context: {
   type t = {
     rpc_node: Uri.t,


### PR DESCRIPTION
## Depends

- [x] #306 

## Problem

Finishing what #303 started, an operation_hash is currently defined inside of Tezos_interop, but it should be conceptually inside of the Tezos library. It also lacks some basic utils like serialization and comparison.

## Solution

This refactors the Operation_hash module and moves it to the Tezos library.