### PR TITLE
Don't search for blocks with lower block height

### DIFF
--- a/bin/deku_node.re
+++ b/bin/deku_node.re
@@ -15,29 +15,29 @@ let ignore_some_errors =
 let print_error = err => {
   open Format;
   switch (err) {
-  | `Not_a_json => eprintf("Invalid json")
-  | `Not_a_valid_request(err) => eprintf("Invalid request: %s", err)
+  | `Added_block_not_signed_enough_to_desync =>
+    eprintf("Added_block_not_signed_enough_to_desync")
   | `Added_signature_not_signed_enough_to_request =>
     eprintf("Added_signature_not_signed_enough_to_request")
   | `Already_known_block => eprintf("Already_known_block")
   | `Already_known_signature => eprintf("Already_known_signature")
   | `Block_not_signed_enough_to_apply =>
     eprintf("Block_not_signed_enough_to_apply")
+  | `Failed_to_verify_payload => eprintf("Failed to verify payload signature")
+  | `Invalid_address_on_main_operation =>
+    eprintf("Invalid_address_on_main_operation")
   | `Invalid_block(string) => eprintf("Invalid_block(%s)", string)
   | `Invalid_block_when_applying => eprintf("Invalid_block_when_applying")
+  | `Invalid_nonce_signature => eprintf("Invalid_nonce_signature")
+  | `Invalid_signature_author => eprintf("Invalid_signature_author")
   | `Invalid_signature_for_this_hash =>
     eprintf("Invalid_signature_for_this_hash")
   | `Invalid_state_root_hash => eprintf("Invalid_state_root_hash")
   | `Not_current_block_producer => eprintf("Not_current_block_producer")
+  | `Not_a_json => eprintf("Invalid json")
+  | `Not_a_valid_request(err) => eprintf("Invalid request: %s", err)
   | `Pending_blocks => eprintf("Pending_blocks")
-  | `Added_block_not_signed_enough_to_desync =>
-    eprintf("Added_block_not_signed_enough_to_desync")
-  | `Invalid_nonce_signature => eprintf("Invalid_nonce_signature")
   | `Unknown_uri => eprintf("Unknown_uri")
-  | `Invalid_address_on_main_operation =>
-    eprintf("Invalid_address_on_main_operation")
-  | `Invalid_signature_author => eprintf("Invalid_signature_author")
-  | `Failed_to_verify_payload => eprintf("Failed to verify payload signature")
   };
   eprintf("\n%!");
 };

--- a/bin/deku_node.re
+++ b/bin/deku_node.re
@@ -15,6 +15,8 @@ let ignore_some_errors =
 let print_error = err => {
   open Format;
   switch (err) {
+  | `Added_block_has_lower_block_height =>
+    eprintf("Added block has lower block height")
   | `Added_block_not_signed_enough_to_desync =>
     eprintf("Added_block_not_signed_enough_to_desync")
   | `Added_signature_not_signed_enough_to_request =>

--- a/node/flows.re
+++ b/node/flows.re
@@ -14,6 +14,7 @@ type ignore = [
   | `Block_not_signed_enough_to_apply
   | `Not_current_block_producer
   | `Pending_blocks
+  | `Added_block_has_lower_block_height
 ];
 
 // TODO: set this by server
@@ -37,6 +38,7 @@ let received_block':
         | `Invalid_state_root_hash
         | `Not_current_block_producer
         | `Pending_blocks
+        | `Added_block_has_lower_block_height
       ],
     ),
   ) =
@@ -52,6 +54,7 @@ let block_added_to_the_pool':
         | `Invalid_block_when_applying
         | `Invalid_state_root_hash
         | `Not_current_block_producer
+        | `Added_block_has_lower_block_height
       ],
     ),
   ) =
@@ -232,6 +235,11 @@ and block_added_to_the_pool = (state, update_state, block) => {
     let.assert () = (
       `Added_block_not_signed_enough_to_desync,
       Block_pool.is_signed(~hash=block.hash, state.block_pool),
+    );
+    // TODO: block.hash == state.protocol.last_block_hash should be Ok()
+    let.assert () = (
+      `Added_block_has_lower_block_height,
+      block.block_height > state.protocol.block_height,
     );
     switch (
       // TODO: this breaks request recursion

--- a/node/flows.re
+++ b/node/flows.re
@@ -7,11 +7,11 @@ module Node = State;
 
 type flag_node = [ | `Invalid_block | `Invalid_signature];
 type ignore = [
-  | `Already_known_block
   | `Added_block_not_signed_enough_to_desync
-  | `Block_not_signed_enough_to_apply
-  | `Already_known_signature
   | `Added_signature_not_signed_enough_to_request
+  | `Already_known_block
+  | `Already_known_signature
+  | `Block_not_signed_enough_to_apply
   | `Not_current_block_producer
   | `Pending_blocks
 ];


### PR DESCRIPTION
## Problem

There is a problem with the current block-fetching algorithm that causes the node to search for blocks it has already applied.

## Solution

Add a check to prevent this.

Additionally, to make it easier to interpret the error messages, I alphabetized the error variants.