### PR TITLE
Refactor identity state

### DIFF
--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -545,9 +545,9 @@ let setup_identity = (node_folder, uri) => {
   let.await () = ensure_folder(node_folder);
 
   let identity = {
-    let (key, t) = Crypto.Ed25519.generate();
-    let t = Address.of_wallet(Ed25519(t));
-    {uri, t, secret: Ed25519(key)};
+    let (secret, key) = Crypto.Ed25519.generate();
+    let t = Address.of_wallet(Ed25519(key));
+    {uri, t, key: Ed25519(key), secret: Ed25519(secret)};
   };
   let.await () = write_identity(~node_folder, identity);
   await(`Ok());
@@ -674,7 +674,7 @@ let info_self = {
 
 let self = node_folder => {
   let.await identity = read_identity(~node_folder);
-  Format.printf("key: %s\n", Wallet.(of_key(identity.secret) |> to_string));
+  Format.printf("key: %s\n", Wallet.to_string(identity.key));
   Format.printf("address: %s\n", Address.to_string(identity.t));
   Format.printf("uri: %s\n", Uri.to_string(identity.uri));
   await(`Ok());

--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -459,7 +459,7 @@ let info_sign_block = {
 };
 let sign_block = (node_folder, block_hash) => {
   let.await identity = read_identity(~node_folder);
-  let signature = Signature.sign(~key=identity.key, block_hash);
+  let signature = Signature.sign(~key=identity.secret, block_hash);
   let.await validators_uris = validators_uris(node_folder);
   let.await () =
     Networking.(
@@ -503,7 +503,7 @@ let produce_block = node_folder => {
       ~main_chain_ops=[],
       ~side_chain_ops=[],
     );
-  let signature = Block.sign(~key=identity.key, block);
+  let signature = Block.sign(~key=identity.secret, block);
   let.await validators_uris = validators_uris(node_folder);
   let.await () =
     Networking.(
@@ -547,7 +547,7 @@ let setup_identity = (node_folder, uri) => {
   let identity = {
     let (key, t) = Crypto.Ed25519.generate();
     let t = Address.of_wallet(Ed25519(t));
-    {uri, t, key: Ed25519(key)};
+    {uri, t, secret: Ed25519(key)};
   };
   let.await () = write_identity(~node_folder, identity);
   await(`Ok());
@@ -674,7 +674,7 @@ let info_self = {
 
 let self = node_folder => {
   let.await identity = read_identity(~node_folder);
-  Format.printf("key: %s\n", Wallet.(of_key(identity.key) |> to_string));
+  Format.printf("key: %s\n", Wallet.(of_key(identity.secret) |> to_string));
   Format.printf("address: %s\n", Address.to_string(identity.t));
   Format.printf("uri: %s\n", Uri.to_string(identity.uri));
   await(`Ok());
@@ -710,7 +710,7 @@ let add_trusted_validator = (node_folder, address) => {
     |> Trusted_validators_membership_change.payload_to_yojson
     |> Yojson.Safe.to_string;
   let payload_hash = BLAKE2B.hash(payload_json_str);
-  let signature = Signature.sign(~key=identity.key, payload_hash);
+  let signature = Signature.sign(~key=identity.secret, payload_hash);
   let.await () =
     Networking.request_trusted_validator_membership(
       {signature, payload},
@@ -762,7 +762,7 @@ let remove_trusted_validator = (node_folder, address) => {
     |> Trusted_validators_membership_change.payload_to_yojson
     |> Yojson.Safe.to_string;
   let payload_hash = BLAKE2B.hash(payload_json_str);
-  let signature = Signature.sign(~key=identity.key, payload_hash);
+  let signature = Signature.sign(~key=identity.secret, payload_hash);
   let.await () =
     Networking.request_trusted_validator_membership(
       {signature, payload},

--- a/node/flows.re
+++ b/node/flows.re
@@ -166,7 +166,7 @@ let try_to_produce_block = (state, update_state) => {
 
   // TODO: avoid spam? how?
   let block = produce_block(state);
-  let signature = sign(~key=state.identity.key, block);
+  let signature = sign(~key=state.identity.secret, block);
   let state =
     append_signature(state, update_state, ~signature, ~hash=block.hash);
   broadcast_block_and_signature(state, ~block, ~signature);
@@ -175,7 +175,7 @@ let try_to_produce_block = (state, update_state) => {
 
 let try_to_sign_block = (state, update_state, block) =>
   if (is_signable(state, block)) {
-    let signature = sign(~key=state.identity.key, block);
+    let signature = sign(~key=state.identity.secret, block);
     broadcast_signature(state, ~hash=block.hash, ~signature);
     append_signature(state, update_state, ~hash=block.hash, ~signature);
   } else {

--- a/node/state.re
+++ b/node/state.re
@@ -4,7 +4,7 @@ open Protocol;
 
 [@deriving yojson]
 type identity = {
-  key: Secret.t,
+  secret: Secret.t,
   t: Address.t,
   uri: Uri.t,
 };
@@ -56,11 +56,11 @@ let make =
   let initial_block = Block.genesis;
   let initial_protocol = Protocol.make(~initial_block);
   let initial_signatures =
-    Signatures.make(~self_key=Wallet.of_key(identity.key))
+    Signatures.make(~self_key=Wallet.of_key(identity.secret))
     |> Signatures.set_signed;
 
   let initial_block_pool =
-    Block_pool.make(~self_key=Wallet.of_key(identity.key))
+    Block_pool.make(~self_key=Wallet.of_key(identity.secret))
     |> Block_pool.append_block(initial_block);
   let initial_snapshots = {
     let initial_snapshot = Protocol.hash(initial_protocol);

--- a/node/state.re
+++ b/node/state.re
@@ -5,6 +5,7 @@ open Protocol;
 [@deriving yojson]
 type identity = {
   secret: Secret.t,
+  key: Key.t,
   t: Address.t,
   uri: Uri.t,
 };
@@ -56,11 +57,10 @@ let make =
   let initial_block = Block.genesis;
   let initial_protocol = Protocol.make(~initial_block);
   let initial_signatures =
-    Signatures.make(~self_key=Wallet.of_key(identity.secret))
-    |> Signatures.set_signed;
+    Signatures.make(~self_key=identity.key) |> Signatures.set_signed;
 
   let initial_block_pool =
-    Block_pool.make(~self_key=Wallet.of_key(identity.secret))
+    Block_pool.make(~self_key=identity.key)
     |> Block_pool.append_block(initial_block);
   let initial_snapshots = {
     let initial_snapshot = Protocol.hash(initial_protocol);

--- a/node/state.rei
+++ b/node/state.rei
@@ -4,6 +4,7 @@ open Protocol;
 [@deriving yojson]
 type identity = {
   secret: Secret.t,
+  key: Key.t,
   t: Address.t,
   uri: Uri.t,
 };

--- a/node/state.rei
+++ b/node/state.rei
@@ -3,7 +3,7 @@ open Protocol;
 
 [@deriving yojson]
 type identity = {
-  key: Secret.t,
+  secret: Secret.t,
   t: Address.t,
   uri: Uri.t,
 };


### PR DESCRIPTION
## Problem

`State.identity` currently refers to a secret as `key` which is wrong. Also `State.identity` doesn't have a key, which makes so that in some places we do `of_secret`, which is not a free operation.

## Solution

Rename `State.identity.key` to secret and add a `key` field on `State.identity` to replace the occurrences of `of_secret(identity.t)`.