### PR TITLE
refactor: Protocol_signatures should contain an address

### DIFF
--- a/node/flows.re
+++ b/node/flows.re
@@ -312,10 +312,9 @@ let received_operation =
             `Invalid_signature_author,
             Address.compare(
               state.Node.identity.t,
-              Signature.public_key(
+              Signature.address(
                 request.operation.Operation.Side_chain.signature,
-              )
-              |> Address.of_wallet,
+              ),
             )
             == 0,
           );
@@ -410,7 +409,7 @@ let register_uri = (state, update_state, ~uri, ~signature) => {
       ...state,
       validators_uri:
         Node.Address_map.add(
-          Signature.public_key(signature) |> Address.of_wallet,
+          Signature.address(signature),
           uri,
           state.validators_uri,
         ),
@@ -451,11 +450,7 @@ let trusted_validators_membership = (state, update_state, request) => {
     payload |> payload_to_yojson |> Yojson.Safe.to_string |> BLAKE2B.hash;
   let.assert () = (
     `Invalid_signature_author,
-    Address.compare(
-      state.Node.identity.t,
-      Address.of_wallet(Signature.public_key(signature)),
-    )
-    == 0,
+    Address.compare(state.Node.identity.t, Signature.address(signature)) == 0,
   );
   let.assert () = (
     `Failed_to_verify_payload,

--- a/node/state.re
+++ b/node/state.re
@@ -90,11 +90,7 @@ let try_to_commit_state_hash = (~old_state, state, block, signatures) => {
   let signatures_map =
     signatures
     |> Signatures.to_list
-    |> List.map(signature => {
-         let (wallet, signature) =
-           Signature.signature_to_signature_by_address(signature);
-         (Address.of_wallet(wallet), signature);
-       })
+    |> List.map(Signature.signature_to_signature_by_address)
     |> List.to_seq
     |> Address_map.of_seq;
 

--- a/protocol/protocol_signature.re
+++ b/protocol/protocol_signature.re
@@ -1,18 +1,45 @@
+open Helpers;
 open Crypto;
 
-[@deriving (ord, yojson)]
+[@deriving ord]
 type t = {
   // TODO: what is the name of a signature?
   signature: Signature.t,
   public_key: Wallet.t,
+  address: Address.t,
 };
 let public_key = t => t.public_key;
+let address = t => t.address;
+
+let (to_yojson, of_yojson) = {
+  module Serialized_data = {
+    [@deriving yojson]
+    type t = {
+      signature: Signature.t,
+      public_key: Wallet.t,
+    };
+  };
+
+  let to_yojson = t =>
+    Serialized_data.to_yojson({
+      signature: t.signature,
+      public_key: t.public_key,
+    });
+  let of_yojson = json => {
+    let.ok {signature, public_key} = Serialized_data.of_yojson(json);
+    let address = Address.of_wallet(public_key);
+    Ok({signature, public_key, address});
+  };
+  (to_yojson, of_yojson);
+};
+
 let sign = (~key as secret, hash) => {
   let signature = Signature.sign(secret, hash);
   let public_key = Key.of_secret(secret);
-  {signature, public_key};
+  let address = Address.of_wallet(public_key);
+  {signature, public_key, address};
 };
-let signature_to_signature_by_address = t => (t.public_key, t.signature);
+let signature_to_signature_by_address = t => (t.address, t.signature);
 let verify = (~signature, hash) =>
   Signature.verify(signature.public_key, signature.signature, hash);
 module type S = {

--- a/protocol/protocol_signature.re
+++ b/protocol/protocol_signature.re
@@ -12,10 +12,6 @@ let sign = (~key as secret, hash) => {
   let public_key = Key.of_secret(secret);
   {signature, public_key};
 };
-let signature_to_b58check = t => Signature.to_string(t.signature);
-let signature_to_b58check_by_address = t => {
-  (t.public_key, signature_to_b58check(t));
-};
 let signature_to_signature_by_address = t => (t.public_key, t.signature);
 let verify = (~signature, hash) =>
   Signature.verify(signature.public_key, signature.signature, hash);

--- a/protocol/protocol_signature.rei
+++ b/protocol/protocol_signature.rei
@@ -4,11 +4,12 @@ open Crypto;
 type t;
 let compare: (t, t) => int;
 let public_key: t => Wallet.t;
+let address: t => Address.t;
 
 let sign: (~key: Secret.t, BLAKE2B.t) => t;
 let verify: (~signature: t, BLAKE2B.t) => bool;
 
-let signature_to_signature_by_address: t => (Wallet.t, Signature.t);
+let signature_to_signature_by_address: t => (Address.t, Signature.t);
 
 module type S = {
   type value;

--- a/protocol/protocol_signature.rei
+++ b/protocol/protocol_signature.rei
@@ -8,8 +8,6 @@ let public_key: t => Wallet.t;
 let sign: (~key: Secret.t, BLAKE2B.t) => t;
 let verify: (~signature: t, BLAKE2B.t) => bool;
 
-let signature_to_b58check: t => string;
-let signature_to_b58check_by_address: t => (Wallet.t, string);
 let signature_to_signature_by_address: t => (Wallet.t, Signature.t);
 
 module type S = {


### PR DESCRIPTION
## Depends

- [x] #311 

## Problem

Right now we're hashing the public key quite often due to Protocol_signatures not containing an address.

## Solution

Just add an `address` to Protocol_signatures and separate the serialization from the internal representation. Also some dead functions were removed.