### PR TITLE
esy: export gmp and openssl for npm release

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "esy": {
     "build": "dune build -p #{self.name}",
     "release": {
+      "rewritePrefix": true,
+      "includePackages": [
+        "root",
+        "esy-gmp",
+        "esy-openssl"
+      ],
       "bin": [
         "sidecli",
         "deku-node"


### PR DESCRIPTION
## Problem

`esy release` doesn't work on macos without including the dylibs in the bin wrapper.

```
dyld: Library not loaded: _____________________________________________________________________________________/i/esy_openssl-93ba2454/lib/libssl.1.1.dylib
  Referenced from: /opt/homebrew/lib/node_modules/sidechain/3/i/sidechain-22dd4d5f/bin/sidecli
  Reason: image not found
```

## Solution

This PR includes packages necessary for exported NPM package.