### PR TITLE
Ligo: Add support for compiling options to zinc

### DIFF
--- a/ligolang/src/passes/13deku-zincing/compiler.ml
+++ b/ligolang/src/passes/13deku-zincing/compiler.ml
@@ -124,14 +124,15 @@ and other_compile :
       | Literal_string (Verbatim b) -> String b :: k
       | Literal_mutez a -> Mutez a :: k
       | Literal_key a -> Key a :: k
+      | Literal_unit -> MakeRecord [] :: k
       | x ->
           failwith
-            (Format.asprintf "literal type %a not supported"
+            (Format.asprintf "literal type not supported: %a"
                Ast_typed.PP.literal x))
   | E_constant constant ->
       let compile_constant = compile_constant ~raise expr.type_expression in
       compile_known_function_application environment
-        (compile_constant constant :: k)
+        (compile_constant constant k)
         constant.arguments
   | E_variable ({ wrap_content = variable; location = _ } as binder) -> (
       let find_index x lst =
@@ -191,22 +192,25 @@ and compile_constant :
     raise:Errors.zincing_error raise ->
     AST.type_expression ->
     AST.constant ->
-    'a zinc_instruction =
- fun ~raise:_ _ constant ->
+    'a zinc ->
+    'a zinc =
+ fun ~raise:_ _ constant k ->
   match constant.cons_name with
-  | C_CHAIN_ID -> ChainID
-  | C_HASH_KEY -> HashKey
-  | C_EQ -> Eq
-  | C_ADD -> Add
-  | C_FAILWITH -> Failwith
-  | C_CONTRACT_OPT -> Contract_opt
-  | C_CALL -> MakeTransaction
-  | C_UNIT -> MakeRecord []
+  | C_CHAIN_ID -> ChainID :: k
+  | C_HASH_KEY -> HashKey :: k
+  | C_EQ -> Eq :: k
+  | C_ADD -> Add :: k
+  | C_FAILWITH -> Failwith :: k
+  | C_CONTRACT_OPT -> Contract_opt :: k
+  | C_CALL -> MakeTransaction :: k
+  | C_UNIT -> MakeRecord [] :: k
+  | C_NONE -> MakeRecord [] :: MakeVariant (Label "None") :: k
+  | C_SOME -> MakeVariant (Label "Some") :: k
   | name ->
       failwith
         (Format.asprintf "Unsupported constant: %a" AST.PP.constant' name)
 
-(*** This is for "known function"s, which is what we call functions whos definition is known at compile time. Compare to 
+(*** This is for "known function"s, which is what we call functions whose definition is known at compile time. Compare to 
      functions such as `f` in `List.map` - inside the function `List.map`, `f` could be anything. The important difference
      is that we know how many arguments known functions take before doing any actual work. This function assumes that you've 
      ensured that you've passed exactly that many arguments, and if you don't the generated code will be wrong. Since you can
@@ -241,8 +245,13 @@ and make_expression_with_dependencies :
                  let_binder = binder;
                  rhs = expression;
                  let_result = result;
-                 attr = { inline = false; no_mutation = false;   view =false;
-  public=false; };
+                 attr =
+                   {
+                     inline = false;
+                     no_mutation = false;
+                     view = false;
+                     public = false;
+                   };
                };
            location = loc;
            type_expression = expression.type_expression;
@@ -296,8 +305,13 @@ and compile_pattern_matching :
                 let_binder = { wrap_content = fresh; location = loc };
                 rhs = to_match.matchee;
                 let_result = lettified;
-                attr = { inline = false; no_mutation = false;   view =false;
-  public=false; };
+                attr =
+                  {
+                    inline = false;
+                    no_mutation = false;
+                    view = false;
+                    public = false;
+                  };
               };
           type_expression = to_match.matchee.type_expression;
           location = loc;

--- a/ligolang/src/test/contracts/make_an_option.religo
+++ b/ligolang/src/test/contracts/make_an_option.religo
@@ -1,0 +1,2 @@
+let a : option(unit) = None 
+let b = Some(())

--- a/ligolang/src/test/zinc_test.ml
+++ b/ligolang/src/test/zinc_test.ml
@@ -120,7 +120,8 @@ let simple_3 =
     [
       ("my_address", [ Address "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx"; Return ]);
     ]
-    ~expected_output:[ Stack_item.Z (Address "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx") ]
+    ~expected_output:
+      [ Stack_item.Z (Address "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx") ]
 
 let id =
   expect_simple_compile_to "id_func"
@@ -224,7 +225,8 @@ let check_hash_key =
       [
         Stack_item.Record
           (LMap.empty
-          |> LMap.add (Label "0") (Stack_item.Z (Zinc_types.Hash "not sure yet"))
+          |> LMap.add (Label "0")
+               (Stack_item.Z (Zinc_types.Hash "not sure yet"))
           |> LMap.add (Label "1") (Stack_item.Z (Key "Hashy hash!")));
       ]
 
@@ -251,7 +253,10 @@ let get_contract_opt =
   expect_simple_compile_to ~reason:true "get_contract_opt"
     [ ("a", [ Address "whatever"; Contract_opt; Return ]) ]
     ~expected_output:
-      [ Stack_item.Variant (Label "Some", Stack_item.Z (Extensions (Contract ("whatever", None)))) ]
+      [
+        Stack_item.Variant
+          (Label "Some", Stack_item.Z (Extensions (Contract ("whatever", None))));
+      ]
 
 let match_on_sum =
   expect_simple_compile_to ~reason:true "match_on_sum"
@@ -354,20 +359,37 @@ let create_transaction_in_tuple =
             empty
             |> add (Label "0")
                  (Stack_item.Z
-                   (Extensions
-                      (Operation
-                         (Transaction
-                            ( Z.of_int 10,
-                              ("tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV", None) )))))
+                    (Extensions
+                       (Operation
+                          (Transaction
+                             ( Z.of_int 10,
+                               ("tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV", None) )))))
             |> add (Label "1")
                  (Stack_item.Z
-                   (Key "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav"))
+                    (Key
+                       "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav"))
             |> add (Label "2") (Stack_item.Z (String "my string")));
       ]
 
 let list_construction =
   expect_simple_compile_to ~reason:true "list_construction" []
-(* necessary zinc_types primitives not yet implemented *)
+
+let make_an_option =
+  expect_simple_compile_to ~reason:true "make_an_option"
+    [
+      ("a", [ MakeRecord []; MakeVariant (Label "None"); Return ]);
+      ( "b",
+        [
+          MakeRecord [];
+          (* constructing None, from the definition of a *)
+          MakeVariant (Label "None");
+          Grab;
+          MakeRecord [];
+          (* constructing Some *)
+          MakeVariant (Label "Some");
+          Return;
+        ] );
+    ]
 
 let main =
   let open Test_helpers in
@@ -391,4 +413,5 @@ let main =
       test_w "create_transaction_in_tuple" create_transaction_in_tuple;
       test_w "mutez_construction" mutez_construction;
       test_w "list_construction" list_construction;
+      test_w "make_an_option" make_an_option;
     ]


### PR DESCRIPTION
## Depends

- [x] #313

## Problem

There was no way to construct the option variants `None` or `Some` in usercode

## Solution

Add implementations for the necessary constants  - also had to implement unit literals.

Work remains to be done to add support to the interpreter