### PR TITLE
dune: make dtop.exe private

### DIFF
--- a/tools/dune
+++ b/tools/dune
@@ -1,6 +1,5 @@
 (executable
  (name dtop)
- (public_name dtop)
  (modes byte)
  (link_flags (-linkall))
  (libraries compiler-libs.toplevel utop reason rtop))


### PR DESCRIPTION
## Problem

Installing Deku need not install the custom repl meant for development. `esy release` is broken because it tries to build the REPL which contains only development dependencies

## Solution

This PR makes `dtop` private and local to project

## Related

#315 
 