### PR TITLE
sidecli: Fix validator_address arg position

### DIFF
--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -732,7 +732,7 @@ let address_t = {
 let validator_address = {
   let docv = "validator_address";
   let doc = "The validator address to be added/removed as trusted";
-  Arg.(required & pos(2, some(address_t), None) & info([], ~docv, ~doc));
+  Arg.(required & pos(1, some(address_t), None) & info([], ~docv, ~doc));
 };
 
 let add_trusted_validator = {


### PR DESCRIPTION
## Problem

`add-trusted-validator` and `remove-trusted-validator` wrongly mention `validator_address` as 3rd positional argument

## Solution

This PR fixes the issue by making them 2nd positional argument

## Related

<!--- add here all the related issues to your PR --->
- #206 
 