### PR TITLE
zinc: add custom variants to zinc interpreter

### DIFF
--- a/zinc/lib/Zinc_interpreter.ml
+++ b/zinc/lib/Zinc_interpreter.ml
@@ -97,6 +97,8 @@ let[@warning "-4"] interpret_zinc :
         | None -> Internal_error "inexhaustive match"
         | Some match_code ->
             Continue (List.concat [match_code; c], env, item :: s))
+    | (MakeVariant label :: c, env, value :: s) ->
+        Continue (c, env, Stack_item.Variant (label, value) :: s)
     (* Math *)
     | (Add :: c, env, Stack_item.Z (Num a) :: Stack_item.Z (Num b) :: s) ->
         Continue (c, env, Stack_item.Z (Num (Z.add a b)) :: s)


### PR DESCRIPTION
<!---
  if some of the following sections doesn't apply,
  delete the section.

  Also feel free to delete the comments.
--->

## Depends

- [x] #321 

## Problem

As of #321, custom variants are supported by the Zinc compiler, but not by the Zinc interpreter (and hence, their tests are currently failing).

## Solution

Add a match case to the interpreter that constructs a custom variant and pushes it to the stack
<!--- Restate the basic ideas behind your solution --->
<!--- Here it is also a good space to put details of your implementation --->

## Related

<!--- add here all the related issues to your PR --->
- #328 