### PR TITLE
Ligo: Fix top level let dependency order

### DIFF
--- a/ligolang/src/passes/13deku-zincing/compiler.ml
+++ b/ligolang/src/passes/13deku-zincing/compiler.ml
@@ -392,8 +392,8 @@ let compile_module :
             tail_compile ~raise empty_environment (let_wrapper expression)
           in
           ( (fun a ->
-              make_expression_with_dependencies [ (expr_var, expression) ]
-                (let_wrapper a)),
+              let_wrapper (make_expression_with_dependencies [ (expr_var, expression) ]
+                a)),
             compiled )
         in
         (let_wrapper, (name, declaration) :: declarations))

--- a/ligolang/src/test/contracts/top_level_let_dependencies.religo
+++ b/ligolang/src/test/contracts/top_level_let_dependencies.religo
@@ -1,0 +1,3 @@
+let a = 1;
+let b = a;
+let c = 1

--- a/ligolang/src/test/zinc_tests.ml
+++ b/ligolang/src/test/zinc_tests.ml
@@ -416,6 +416,14 @@ let make_a_custom_option =
         ] );
     ]
 
+let top_level_let_dependencies =
+  expect_simple_compile_to ~dialect:ReasonLIGO "top_level_let_dependencies"
+    [
+      ("a", [ Plain_old_data (Num Z.one); Core Return ]);
+      ("b", [ Plain_old_data (Num Z.one); Core Grab; Core (Access 0); Core Return ]);
+      ("c", [ Plain_old_data (Num Z.one); Core Grab; Core (Access 0); Core Grab; Plain_old_data (Num Z.one); Core Return ]);
+    ]
+
 let main =
   let open Test_helpers in
   test_suite "Zinc tests"
@@ -440,4 +448,5 @@ let main =
       test_w "list_construction" list_construction;
       test_w "make_an_option" make_an_option;
       test_w "make_a_custom_option" make_a_custom_option;
+      test_w "top_level_let_dependencies" top_level_let_dependencies;
     ]


### PR DESCRIPTION
## Problem

Pointed out to me by @Zett98 - there was a bug in how we convert top-level-lets into single expressions. The idea is to convert this:

```reason
let a = 1;
let b = a;
let c = 1;
```

to this:

```reason
let a = 1;
let b = let a = 1 in a;
let c = let a = 1 in let b = a in 1;
```

That way each top-level let is self-contained. But the logic was wrong, and the conversion was actually doing this:

```reason
let a = 1;
let b = let a = 1 in a;
let c = let b = a in let a = 1 in 1; // Order got flipped
```

Which doesn't compile haha.

## Solution

Correct the order
