### PR TITLE
fix: trusted membership flow must add not remove

### DIFF
--- a/node/flows.re
+++ b/node/flows.re
@@ -464,7 +464,7 @@ let trusted_validators_membership = (state, update_state, request) => {
         state.Node.trusted_validator_membership_change,
       )
     | Remove =>
-      Trusted_validators_membership_change.Set.remove(
+      Trusted_validators_membership_change.Set.add(
         {action: Remove, address},
         state.Node.trusted_validator_membership_change,
       )


### PR DESCRIPTION
## Problem

`remove-trusted-validator` is supposed to help us add a removal membership to the trusted list. (in retrospect, the command name is a misnomer too)

## Solution

This PR corrects adds the mechanism to add validator removals to the trusted list
 