### PR TITLE
refactor: move consensus hashing to Tezos.Deku

### DIFF
--- a/protocol/block.re
+++ b/protocol/block.re
@@ -71,7 +71,7 @@ let (hash, verify) = {
     // TODO: maybe should also be previous?
 
     let hash =
-      Tezos_interop.Consensus.hash_block(
+      Tezos.Deku.Consensus.hash_block(
         ~block_height,
         ~block_payload_hash,
         ~state_root_hash,

--- a/protocol/ledger.re
+++ b/protocol/ledger.re
@@ -29,7 +29,7 @@ module Handle = {
   };
   let hash = (~id, ~owner, ~amount, ~ticket) => {
     let Ticket.{ticketer, data} = ticket;
-    Tezos_interop.Consensus.hash_withdraw_handle(
+    Tezos.Deku.Consensus.hash_withdraw_handle(
       ~id=Z.of_int(id),
       ~owner,
       ~amount=Z.of_int(Amount.to_int(amount)),

--- a/protocol/validators.re
+++ b/protocol/validators.re
@@ -38,7 +38,7 @@ let update_current = (address, t) => {
 let hash_validators = validators => {
   validators
   |> List.map(validator => validator.address |> Address.to_key_hash)
-  |> Tezos_interop.Consensus.hash_validators;
+  |> Tezos.Deku.Consensus.hash_validators;
 };
 let empty = {
   current: None,

--- a/tests/test_tezos_interop.re
+++ b/tests/test_tezos_interop.re
@@ -663,7 +663,7 @@ describe("pack", ({test, _}) => {
 });
 describe("consensus", ({test, _}) => {
   open Helpers;
-  open Consensus;
+  open Deku.Consensus;
 
   let hash_exn = s => BLAKE2B.of_string(s) |> Option.get;
   let key_hash_exn = s => Key_hash.of_string(s) |> Option.get;

--- a/tezos/deku.re
+++ b/tezos/deku.re
@@ -1,0 +1,37 @@
+open Crypto;
+
+module Consensus = {
+  open Pack;
+
+  let hash_packed_data = data =>
+    data |> to_bytes |> Bytes.to_string |> BLAKE2B.hash;
+
+  let hash_validators = validators =>
+    list(List.map(key_hash, validators)) |> hash_packed_data;
+  let hash = hash => bytes(BLAKE2B.to_raw_string(hash) |> Bytes.of_string);
+  let hash_block =
+      (
+        ~block_height,
+        ~block_payload_hash,
+        ~state_root_hash,
+        ~handles_hash,
+        ~validators_hash,
+      ) =>
+    pair(
+      pair(
+        pair(int(Z.of_int64(block_height)), hash(block_payload_hash)),
+        pair(hash(handles_hash), hash(state_root_hash)),
+      ),
+      hash(validators_hash),
+    )
+    |> hash_packed_data;
+  let hash_withdraw_handle = (~id, ~owner, ~amount, ~ticketer, ~data) =>
+    pair(
+      pair(
+        pair(nat(amount), bytes(data)),
+        pair(nat(id), address(owner)),
+      ),
+      address(ticketer),
+    )
+    |> hash_packed_data;
+};

--- a/tezos/deku.rei
+++ b/tezos/deku.rei
@@ -1,0 +1,23 @@
+open Crypto;
+
+module Consensus: {
+  let hash_validators: list(Key_hash.t) => BLAKE2B.t;
+  let hash_block:
+    (
+      ~block_height: int64,
+      ~block_payload_hash: BLAKE2B.t,
+      ~state_root_hash: BLAKE2B.t,
+      ~handles_hash: BLAKE2B.t,
+      ~validators_hash: BLAKE2B.t
+    ) =>
+    BLAKE2B.t;
+  let hash_withdraw_handle:
+    (
+      ~id: Z.t,
+      ~owner: Address.t,
+      ~amount: Z.t,
+      ~ticketer: Address.t,
+      ~data: bytes
+    ) =>
+    BLAKE2B.t;
+};

--- a/tezos/tezos.re
+++ b/tezos/tezos.re
@@ -3,3 +3,4 @@ module Address = Address;
 module Ticket_id = Ticket_id;
 module Pack = Pack;
 module Operation_hash = Operation_hash;
+module Deku = Deku;

--- a/tezos/tezos.rei
+++ b/tezos/tezos.rei
@@ -3,3 +3,4 @@ module Address = Address;
 module Ticket_id = Ticket_id;
 module Pack = Pack;
 module Operation_hash = Operation_hash;
+module Deku = Deku;

--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -237,38 +237,6 @@ module Consensus = {
   open Pack;
   open Tezos_micheline;
 
-  let hash_packed_data = data =>
-    data |> to_bytes |> Bytes.to_string |> BLAKE2B.hash;
-
-  let hash_validators = validators =>
-    list(List.map(key_hash, validators)) |> hash_packed_data;
-  let hash = hash => bytes(BLAKE2B.to_raw_string(hash) |> Bytes.of_string);
-  let hash_block =
-      (
-        ~block_height,
-        ~block_payload_hash,
-        ~state_root_hash,
-        ~handles_hash,
-        ~validators_hash,
-      ) =>
-    pair(
-      pair(
-        pair(int(Z.of_int64(block_height)), hash(block_payload_hash)),
-        pair(hash(handles_hash), hash(state_root_hash)),
-      ),
-      hash(validators_hash),
-    )
-    |> hash_packed_data;
-  let hash_withdraw_handle = (~id, ~owner, ~amount, ~ticketer, ~data) =>
-    pair(
-      pair(
-        pair(nat(amount), bytes(data)),
-        pair(nat(id), address(owner)),
-      ),
-      address(ticketer),
-    )
-    |> hash_packed_data;
-
   // TODO: how to test this?
   let commit_state_hash =
       (

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -12,26 +12,6 @@ module Context: {
 };
 
 module Consensus: {
-  let hash_validators: list(Key_hash.t) => BLAKE2B.t;
-  let hash_block:
-    (
-      ~block_height: int64,
-      ~block_payload_hash: BLAKE2B.t,
-      ~state_root_hash: BLAKE2B.t,
-      ~handles_hash: BLAKE2B.t,
-      ~validators_hash: BLAKE2B.t
-    ) =>
-    BLAKE2B.t;
-  let hash_withdraw_handle:
-    (
-      ~id: Z.t,
-      ~owner: Address.t,
-      ~amount: Z.t,
-      ~ticketer: Address.t,
-      ~data: bytes
-    ) =>
-    BLAKE2B.t;
-
   /** ~signatures should be in the same order as the old validators */
   let commit_state_hash:
     (


### PR DESCRIPTION
## Problem

The hash functions described at `Tezos_interop.Consensus` are crucial for the core state machine of Deku but they currently live inside of `Tezos_interop` which is a library designed to describe IO communication with Tezos.

## Solution

Move the hashing functions to `Tezos.Deku.Consensus` so that it can safely be used inside of the core.