### PR TITLE
fix sandbox and start script

### DIFF
--- a/sandbox.sh
+++ b/sandbox.sh
@@ -154,7 +154,7 @@ EOF
 tear-down() {
   if [[ $(docker ps | grep my-sandbox) ]]; then
     docker kill my-sandbox
-    rm -rf "$DATA_DIRECTORY/**"
+    rm -r "$DATA_DIRECTORY"
     echo "Stopped the sandbox and wiped all state."
   fi
 }

--- a/start.sh
+++ b/start.sh
@@ -21,7 +21,7 @@ for i in ${VALIDATORS[@]}; do
   SERVERS+=($!)
 done
 
-sleep 0.1
+sleep 1
 
 echo "Producing a block"
 HASH=$(sidecli produce-block "$data_directory/0" | awk '{ print $2 }')


### PR DESCRIPTION
## Problem

The `./sandbox.sh tear-down` is not removing old data and the `./start.sh` is currently starting too fast.

## Solution

Fix the tear-down flow of `sandbox.sh`. Also increase the start script delay to one second, this is required due to the fact that starting the node is now slower as it needs to talk to a Tezos node.