### PR TITLE
Reorganize zinc primitives 

### DIFF
--- a/ligolang/src/test/zinc_test.ml
+++ b/ligolang/src/test/zinc_test.ml
@@ -27,29 +27,29 @@ let expect_program =
   Alcotest.(
     check
       (Alcotest.testable
-         (fun ppf program -> Fmt.pf ppf "%a" Zinc_types.pp_program program)
-         Zinc_types.equal_program))
+         (fun ppf program -> Fmt.pf ppf "%a" pp_program program)
+         equal_program))
 
 let expect_code =
   Alcotest.(
     check
       (Alcotest.testable
-         (fun ppf zinc -> Fmt.pf ppf "%a" Zinc_types.pp_zinc zinc)
-         Zinc_types.equal_zinc))
+         (fun ppf zinc -> Fmt.pf ppf "%a" Zinc.pp zinc)
+         Zinc.equal))
 
 let expect_env =
   Alcotest.(
     check
       (Alcotest.testable
-         (fun ppf env -> Fmt.pf ppf "%a" Zinc_types.pp_env env)
-         Zinc_types.equal_env))
+         (fun ppf env -> Fmt.pf ppf "%a" pp_env env)
+         equal_env))
 
 let expect_stack =
   Alcotest.(
     check
       (Alcotest.testable
-         (fun ppf stack -> Fmt.pf ppf "%a" Zinc_types.pp_stack stack)
-         Zinc_types.equal_stack))
+         (fun ppf stack -> Fmt.pf ppf "%a" pp_stack stack)
+         equal_stack))
 
 type test =
   raise:Main_errors.all Trace.raise ->
@@ -107,36 +107,36 @@ let expect_simple_compile_to ?reason:(enabled = false) ?(index = 0)
 
 let simple_1 =
   expect_simple_compile_to "simple1"
-    [ ("i", [ Num (Z.of_int 42); Return ]) ]
-    ~expected_output:[ Stack_item.Z (Num (Z.of_int 42)) ]
+    [ ("i", [  Plain_old_data (Num (Z.of_int 42)); Core Return ]) ]
+    ~expected_output:[ Stack_item.Z (Plain_old_data (Num (Z.of_int 42))) ]
 
 let simple_2 =
   expect_simple_compile_to "simple2"
-    [ ("i", [ Num (Z.of_int 42); Return ]) ]
-    ~expected_output:[ Stack_item.Z (Num (Z.of_int 42)) ]
+    [ ("i", [ Plain_old_data (Num (Z.of_int 42)); Core Return ]) ]
+    ~expected_output:[ Stack_item.Z (Plain_old_data (Num (Z.of_int 42))) ]
 
 let simple_3 =
   expect_simple_compile_to "simple3"
     [
-      ("my_address", [ Address "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx"; Return ]);
+      ("my_address", [ Plain_old_data (Address "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx"); Core Return ]);
     ]
     ~expected_output:
-      [ Stack_item.Z (Address "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx") ]
+      [ Stack_item.Z (Plain_old_data (Address "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx")) ]
 
 let id =
   expect_simple_compile_to "id_func"
-    [ ("id", [ Grab; Access 0; Return ]) ]
-    ~initial_stack:[ Stack_item.Z (Num (Z.of_int 42)) ]
-    ~expected_output:[ Stack_item.Z (Num (Z.of_int 42)) ]
+    [ ("id", [ Core Grab; Core (Access 0); Core Return ]) ]
+    ~initial_stack:[ Stack_item.Z (Plain_old_data (Num (Z.of_int 42))) ]
+    ~expected_output:[ Stack_item.Z (Plain_old_data (Num (Z.of_int 42))) ]
 
 let chain_id =
   expect_simple_compile_to "chain_id"
-    [ ("chain_id", [ ChainID; Return ]) ]
-    ~expected_output:[ Stack_item.Z (Zinc_types.Hash "not sure yet") ]
+    [ ("chain_id", [ Domain_specific_operation ChainID; Core Return ]) ]
+    ~expected_output:[ Stack_item.Z (Plain_old_data (Hash "not sure yet")) ]
 
 let chain_id_func =
   expect_simple_compile_to "chain_id_func"
-    [ ("chain_id", [ Grab; ChainID; Return ]) ]
+    [ ("chain_id", [ Core Grab; Domain_specific_operation ChainID; Core Return ]) ]
     ~initial_stack:[ Zinc_types.Utils.unit_record_stack ]
 
 let tuple_creation =
@@ -144,15 +144,15 @@ let tuple_creation =
     [
       ( "dup",
         [
-          Grab; Access 0; Access 0; MakeRecord 2; Return;
+          Core Grab; Core (Access 0); Core (Access 0); Adt (MakeRecord 2); Core Return;
         ] );
     ]
-    ~initial_stack:[ Stack_item.Z (Num Z.one) ]
+    ~initial_stack:[ Stack_item.Z (Plain_old_data (Num Z.one)) ]
     ~expected_output:
       [
         Stack_item.Record
           Zinc_utils.LMap.(
-            let one = Stack_item.Z (Num Z.one) in
+            let one = Stack_item.Z (Plain_old_data (Num Z.one)) in
             empty |> add (0) one |> add (1) one);
       ]
 
@@ -161,31 +161,31 @@ let check_record_destructure =
     [
       ( "check_record_destructure",
         [
-          Grab;
-          Access 0;
-          Grab;
-          Access 0;
-          Grab;
-          Access 0;
-          RecordAccess (1);
-          Grab;
-          Access 1;
-          RecordAccess (0);
-          Grab;
-          Access 1;
-          Access 0;
-          Add;
-          EndLet;
-          EndLet;
-          EndLet;
-          Return;
+          Core Grab;
+          Core (Access 0);
+          Core Grab;
+          Core (Access 0);
+          Core Grab;
+          Core (Access 0);
+          Adt (RecordAccess (1));
+          Core Grab;
+          Core (Access 1);
+          Adt (RecordAccess (0));
+          Core Grab;
+          Core (Access 1);
+          Core (Access 0);
+          Operation Add;
+          Core EndLet;
+          Core EndLet;
+          Core EndLet;
+          Core Return;
         ] );
     ]
     ~initial_stack:
       [
         Stack_item.Record
           Zinc_utils.LMap.(
-            let one = Stack_item.Z (Num Z.one) in
+            let one = Stack_item.Z (Plain_old_data (Num Z.one)) in
             empty |> add (0) one |> add (1) one);
       ]
 
@@ -195,30 +195,30 @@ let check_hash_key =
     [
       ( "check_hash_key",
         [
-          Grab;
-          Access 0;
-          Grab;
-          Access 0;
-          Grab;
-          Access 0;
-          RecordAccess (1);
-          Grab;
-          Access 1;
-          RecordAccess (0);
-          Grab;
-          Access 1;
-          HashKey;
-          Grab;
-          Access 0;
-          Access 0;
-          Access 1;
-          Eq;
-          MakeRecord 2;
-          EndLet;
-          EndLet;
-          EndLet;
-          EndLet;
-          Return;
+          Core Grab;
+          Core (Access 0);
+          Core Grab;
+          Core (Access 0);
+          Core Grab;
+          Core (Access 0);
+          Adt (RecordAccess (1));
+          Core Grab;
+          Core (Access 1);
+          Adt (RecordAccess (0));
+          Core Grab;
+          Core (Access 1);
+          Operation HashKey;
+          Core Grab;
+          Core (Access 0);
+          Core (Access 0);
+          Core (Access 1);
+          Operation Eq;
+          Adt (MakeRecord 2);
+          Core EndLet;
+          Core EndLet;
+          Core EndLet;
+          Core EndLet;
+          Core Return;
         ] );
     ]
     ~initial_stack:
@@ -226,32 +226,32 @@ let check_hash_key =
         Stack_item.Record
           (LMap.empty
           |> LMap.add (0)
-               (Stack_item.Z (Zinc_types.Hash "not sure yet"))
-          |> LMap.add (1) (Stack_item.Z (Key "Hashy hash!")));
+               (Stack_item.Z (Plain_old_data (Hash "not sure yet")))
+          |> LMap.add (1) (Stack_item.Z (Plain_old_data (Key "Hashy hash!"))));
       ]
 
 let basic_function_application =
   expect_simple_compile_to ~reason:true "basic_function_application"
-    [ ("a", [ Num (Z.of_int 3); Grab; Access 0; Return ]) ]
-    ~expected_output:[ Stack_item.Z (Num (Z.of_int 3)) ]
+    [ ("a", [ Plain_old_data (Num (Z.of_int 3)); Core Grab; Core (Access 0); Core Return ]) ]
+    ~expected_output:[ Stack_item.Z (Plain_old_data (Num (Z.of_int 3))) ]
 
 let basic_link =
   expect_simple_compile_to ~reason:true "basic_link"
     [
-      ("a", [ Num (Z.of_int 1); Return ]);
-      ("b", [ Num (Z.of_int 1); Grab; Access 0; Return ]);
+      ("a", [ Plain_old_data (Num (Z.of_int 1)); Core Return ]);
+      ("b", [ Plain_old_data (Num (Z.of_int 1)); Core Grab; Core (Access 0); Core Return ]);
     ]
     ~index:1
-    ~expected_output:[ Stack_item.Z (Num (Z.of_int 1)) ]
+    ~expected_output:[ Stack_item.Z (Plain_old_data (Num (Z.of_int 1))) ]
 
 let failwith_simple =
   expect_simple_compile_to ~reason:true "failwith_simple"
-    [ ("a", [ String "Not a contract"; Failwith; Return ]) ]
+    [ ("a", [ Plain_old_data (String "Not a contract"); Control_flow Failwith; Core Return ]) ]
     ~expect_failure:"Not a contract"
 
 let get_contract_opt =
   expect_simple_compile_to ~reason:true "get_contract_opt"
-    [ ("a", [ Address "whatever"; Contract_opt; Return ]) ]
+    [ ("a", [ Plain_old_data (Address "whatever"); Domain_specific_operation Contract_opt; Core Return ]) ]
     ~expected_output:
       [
         Stack_item.Variant
@@ -263,18 +263,18 @@ let match_on_sum =
     [
       ( "a",
         [
-          Address "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV";
-          Grab;
-          Access 0;
-          Contract_opt;
-          Grab;
-          Access 0;
-          MatchVariant
+          Plain_old_data (Address "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV");
+          Core Grab;
+          Core (Access 0);
+          Domain_specific_operation Contract_opt;
+          Core Grab;
+          Core (Access 0);
+          Adt (MatchVariant
             [
-              ( "Some", [ Grab; Access 0 ]);
-              ("None", [ Grab; String "Not a contract"; Failwith ]);
-            ];
-          Return;
+              ( "Some", [ Core Grab; Core (Access 0) ]);
+              ("None", [ Core Grab; Plain_old_data (String "Not a contract"); Control_flow Failwith ]);
+            ]);
+          Core Return;
         ] );
     ]
     ~expected_output:
@@ -287,37 +287,37 @@ let match_on_sum =
 
 let mutez_construction =
   expect_simple_compile_to ~reason:true "mutez_construction"
-    [ ("a", [ Mutez (Z.of_int 1); Return ]) ]
+    [ ("a", [ Plain_old_data (Mutez (Z.of_int 1)); Core Return ]) ]
 
 let create_transaction =
   expect_simple_compile_to ~reason:true "create_transaction"
     [
       ( "a",
         [
-          Address "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV";
-          Grab;
-          Access 0;
-          Contract_opt;
-          Grab;
-          Access 0;
-          MatchVariant
+          Plain_old_data (Address "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV");
+          Core Grab;
+          Core (Access 0);
+          Domain_specific_operation Contract_opt;
+          Core Grab;
+          Core (Access 0);
+          Adt (MatchVariant
             [
-              ("Some", [ Grab; Access 0 ]);
-              ("None", [ Grab; String "Not a contract"; Failwith ]);
-            ];
-          EndLet;
-          Grab;
-          Access 0;
-          Mutez (Z.of_int 10);
-          MakeRecord 0;
-          MakeTransaction;
-          Return;
+              ("Some", [ Core Grab; Core (Access 0) ]);
+              ("None", [ Core Grab; Plain_old_data (String "Not a contract"); Control_flow Failwith ]);
+            ]);
+          Core EndLet;
+          Core Grab;
+          Core (Access 0);
+          Plain_old_data (Mutez (Z.of_int 10));
+          Adt (MakeRecord 0);
+          Domain_specific_operation MakeTransaction;
+          Core Return;
         ] );
     ]
     ~expected_output:
       [
         Stack_item.NonliteralValue
-          (Operation
+          (Chain_operation
              (Transaction
                 (Z.of_int 10, ("tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV", None))));
       ]
@@ -328,27 +328,27 @@ let create_transaction_in_tuple =
     [
       ( "a",
         [
-          Address "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV";
-          Grab;
-          Access 0;
-          Contract_opt;
-          Grab;
-          Access 0;
-          MatchVariant
+          Plain_old_data (Address "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV");
+          Core Grab;
+          Core (Access 0);
+          Domain_specific_operation Contract_opt;
+          Core Grab;
+          Core (Access 0);
+          Adt (MatchVariant
             [
-              ("Some", [ Grab; Access 0 ]);
-              ("None", [ Grab; String "Not a contract"; Failwith ]);
-            ];
-          EndLet;
-          Grab;
-          String "my string";
-          Key "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav";
-          Access 0;
-          Mutez (Z.of_int 10);
-          MakeRecord 0;
-          MakeTransaction;
-          MakeRecord 3;
-          Return;
+              ("Some", [ Core Grab; Core (Access 0) ]);
+              ("None", [ Core Grab; Plain_old_data (String "Not a contract"); Control_flow Failwith ]);
+            ]);
+          Core EndLet;
+          Core Grab;
+          Plain_old_data (String "my string");
+          Plain_old_data (Key "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav");
+          Core (Access 0);
+          Plain_old_data (Mutez (Z.of_int 10));
+          Adt (MakeRecord 0);
+          Domain_specific_operation MakeTransaction;
+          Adt (MakeRecord 3);
+          Core Return;
         ] );
     ]
     ~expected_output:
@@ -357,25 +357,25 @@ let create_transaction_in_tuple =
           LMap.(
             empty
             |> add (0)
-                 (Stack_item.NonliteralValue (Operation
+                 (Stack_item.NonliteralValue (Chain_operation
                           (Transaction
                              ( Z.of_int 10,
                                ("tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV", None) ))))
             |> add (1)
                  (Stack_item.Z
-                    (Key
-                       "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav"))
-            |> add (2) (Stack_item.Z (String "my string")));
+                    (Plain_old_data (Key
+                       "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav")))
+            |> add (2) (Stack_item.Z (Plain_old_data (String "my string"))));
       ]
 
 let list_construction =
   expect_simple_compile_to ~reason:true "list_construction" 
-  [("a", [Nil; (Mutez (Z.of_int 2)); Cons; (Mutez (Z.of_int 1)); Cons; Return])]
+  [("a", [Plain_old_data Nil; Plain_old_data (Mutez (Z.of_int 2)); Operation Cons; Plain_old_data (Mutez (Z.of_int 1)); Operation Cons; Core Return])]
   ~expected_output:[
     (Zinc_types.Stack_item.List
       [ 
-        (Zinc_types.Stack_item.Z (Mutez (Z.of_int 1)));
-        (Zinc_types.Stack_item.Z (Mutez (Z.of_int 2)))
+        (Zinc_types.Stack_item.Z (Plain_old_data (Mutez (Z.of_int 1))));
+        (Zinc_types.Stack_item.Z (Plain_old_data (Mutez (Z.of_int 2))))
       ]
     )
   ]
@@ -383,34 +383,34 @@ let list_construction =
 let make_an_option =
   expect_simple_compile_to ~reason:true "make_an_option"
     [
-      ("a", [ MakeRecord 0; MakeVariant "None"; Return ]);
+      ("a", [ Adt (MakeRecord 0); Adt (MakeVariant "None"); Core Return ]);
       ( "b",
         [
-          MakeRecord 0;
+          Adt (MakeRecord 0);
           (* constructing None, from the definition of a *)
-          MakeVariant "None";
-          Grab;
-          MakeRecord 0;
+          Adt (MakeVariant "None");
+          Core Grab;
+          Adt (MakeRecord 0);
           (* constructing Some *)
-          MakeVariant "Some";
-          Return;
+          Adt (MakeVariant "Some");
+          Core Return;
         ] );
     ]
 
 let make_a_custom_option =
   expect_simple_compile_to ~reason:true "make_a_custom_option"
     [
-      ("a", [ MakeRecord 0; MakeVariant "My_none"; Return ]);
+      ("a", [ Adt (MakeRecord 0); Adt (MakeVariant "My_none"); Core Return ]);
       ( "b",
         [
-          MakeRecord 0;
+          Adt (MakeRecord 0);
           (* constructing My_none, from the definition of a *)
-          MakeVariant ("My_none");
-          Grab;
-          MakeRecord 0;
+          Adt (MakeVariant ("My_none"));
+          Core Grab;
+          Adt (MakeRecord 0);
           (* constructing Some *)
-          MakeVariant "My_some";
-          Return;
+          Adt (MakeVariant "My_some");
+          Core Return;
         ] );
     ]
 

--- a/zinc/lib/Zinc_interpreter.ml
+++ b/zinc/lib/Zinc_interpreter.ml
@@ -9,63 +9,69 @@ external stack_to_env_ext : Stack_item.t -> Env_item.t = "%identity"
 let stack_to_env = function
   | Stack_item.Marker _ ->
       failwith "type error, cant convert a stack_item into an env_item"
-  | Stack_item.(Clos _ | Record _ | Variant _ | List _ | Z _ | NonliteralValue _) as x -> stack_to_env_ext x
+  | Stack_item.(
+      Clos _ | Record _ | Variant _ | List _ | Z _ | NonliteralValue _) as x ->
+      stack_to_env_ext x
 
-type steps =
-  | Done
-  | Internal_error of string
-  | Failwith of string
-  | Continue of zinc * env * stack
+module Steps = struct
+  type t =
+    | Done
+    | Internal_error of string
+    | Failwith of string
+    | Continue of Zinc.t * env * stack
+end
 
 let initial_state ?initial_stack:(stack = []) a = (a, [], stack)
 
 let[@warning "-4"] interpret_zinc :
     interpreter_context -> interpreter_input -> Interpreter_output.t =
  fun interpreter_context (code, env, stack) ->
-  let apply_once (code : zinc) (env : env) (stack : stack) =
+  let apply_once (code : Zinc.t) (env : env) (stack : stack) =
     let () =
       print_endline
         (Format.asprintf
            "interpreting:\ncode:  %a\nenv:   %a\nstack: %a"
-           pp_zinc
+           Zinc.pp
            code
            pp_env
            env
            pp_stack
            stack)
     in
+    let open Zinc in
     match (code, env, stack) with
-    | (Nil :: c, env, s) -> Continue (c, env, Stack_item.List [] :: s)
+    | (Nil :: c, env, s) -> Steps.Continue (c, env, Stack_item.List [] :: s)
     | (Cons :: c, env, item :: Stack_item.List x :: s) ->
-        Continue (c, env, Stack_item.List (item :: x) :: s)
+        Steps.Continue (c, env, Stack_item.List (item :: x) :: s)
     | (Grab :: c, env, Stack_item.Marker (c', e') :: s) ->
-        Continue (c', e', Stack_item.Clos {Clos.code = Grab :: c; env} :: s)
-    | (Grab :: c, env, v :: s) -> Continue (c, stack_to_env v :: env, s)
+        Steps.Continue
+          (c', e', Stack_item.Clos {Clos.code = Grab :: c; env} :: s)
+    | (Grab :: c, env, v :: s) -> Steps.Continue (c, stack_to_env v :: env, s)
     | (Grab :: _, _, []) -> failwith "nothing to grab!"
     | (Return :: _, _, Stack_item.Z v :: Stack_item.Marker (c', e') :: s) ->
-        Continue (c', e', Stack_item.Z v :: s)
+        Steps.Continue (c', e', Stack_item.Z v :: s)
     | (Return :: _, _, Stack_item.Clos {Clos.code = c'; env = e'} :: s) ->
-        Continue (c', e', s)
+        Steps.Continue (c', e', s)
     | (PushRetAddr c' :: c, env, s) ->
-        Continue (c, env, Stack_item.Marker (c', env) :: s)
+        Steps.Continue (c, env, Stack_item.Marker (c', env) :: s)
     | (Apply :: _, _, Stack_item.Clos {Clos.code = c'; env = e'} :: s) ->
-        Continue (c', e', s)
+        Steps.Continue (c', e', s)
     (* Below here is just modern SECD *)
     | (Access n :: c, env, s) -> (
         let nth = Base.List.nth env n in
         match nth with
-        | Some nth -> Continue (c, env, (nth |> env_to_stack) :: s)
-        | None -> Internal_error "Tried to access env item out of bounds")
+        | Some nth -> Steps.Continue (c, env, (nth |> env_to_stack) :: s)
+        | None -> Steps.Internal_error "Tried to access env item out of bounds")
     | (Closure c' :: c, env, s) ->
-        Continue (c, env, Stack_item.Clos {Clos.code = c'; env} :: s)
-    | (EndLet :: c, _ :: env, s) -> Continue (c, env, s)
+        Steps.Continue (c, env, Stack_item.Clos {Clos.code = c'; env} :: s)
+    | (EndLet :: c, _ :: env, s) -> Steps.Continue (c, env, s)
     (* zinc extensions *)
     (* operations that jsut drop something on the stack haha *)
     | ( ((Num _ | Address _ | Key _ | Hash _ | Bool _ | String _ | Mutez _) as v)
         :: c,
         env,
         s ) ->
-        Continue (c, env, Stack_item.Z v :: s)
+        Steps.Continue (c, env, Stack_item.Z v :: s)
     (* ADTs *)
     | (MakeRecord r :: c, env, s) ->
         let list_split_at ~n lst =
@@ -80,12 +86,12 @@ let[@warning "-4"] interpret_zinc :
         in
         let (record, stack) = list_split_at ~n:r s in
         let record_contents = LMap.of_list (List.rev record) in
-        Continue (c, env, Stack_item.Record record_contents :: stack)
+        Steps.Continue (c, env, Stack_item.Record record_contents :: stack)
     | (RecordAccess accessor :: c, env, Stack_item.Record r :: s) ->
         let res =
           match LMap.find r accessor with
           | None -> failwith "field not found"
-          | Some x -> Continue (c, env, x :: s)
+          | Some x -> Steps.Continue (c, env, x :: s)
         in
         res
     | (MatchVariant vs :: c, env, Stack_item.Variant (label, item) :: s) -> (
@@ -93,26 +99,26 @@ let[@warning "-4"] interpret_zinc :
           Base.List.find_map vs ~f:(fun (match_arm, constructors) ->
               if String.equal match_arm label then Some constructors else None)
         with
-        | None -> Internal_error "inexhaustive match"
+        | None -> Steps.Internal_error "inexhaustive match"
         | Some match_code ->
-            Continue (List.concat [match_code; c], env, item :: s))
+            Steps.Continue (List.concat [match_code; c], env, item :: s))
     | (MakeVariant label :: c, env, value :: s) ->
-        Continue (c, env, Stack_item.Variant (label, value) :: s)
+        Steps.Continue (c, env, Stack_item.Variant (label, value) :: s)
     (* Math *)
     | (Add :: c, env, Stack_item.Z (Num a) :: Stack_item.Z (Num b) :: s) ->
-        Continue (c, env, Stack_item.Z (Num (Z.add a b)) :: s)
+        Steps.Continue (c, env, Stack_item.Z (Num (Z.add a b)) :: s)
     | (Add :: c, env, Stack_item.Z (Mutez a) :: Stack_item.Z (Mutez b) :: s) ->
-        Continue (c, env, Stack_item.Z (Mutez (Z.add a b)) :: s)
+        Steps.Continue (c, env, Stack_item.Z (Mutez (Z.add a b)) :: s)
     (* Booleans *)
     | (Eq :: c, env, a :: b :: s) ->
-        Continue (c, env, Stack_item.Z (Bool (Stack_item.equal a b)) :: s)
+        Steps.Continue (c, env, Stack_item.Z (Bool (Stack_item.equal a b)) :: s)
     (* Crypto *)
     | (HashKey :: c, env, Stack_item.Z (Key _key) :: s) ->
         let h = failwith "need to move this into interpreter_context" in
-        Continue (c, env, Stack_item.Z (Hash h) :: s)
+        Steps.Continue (c, env, Stack_item.Z (Hash h) :: s)
     (* Tezos specific *)
     | (ChainID :: c, env, s) ->
-        Continue
+        Steps.Continue
           ( c,
             env,
             Stack_item.Z
@@ -128,38 +134,38 @@ let[@warning "-4"] interpret_zinc :
           | Some (address, entrypoint) ->
               Stack_item.Variant
                 ( "Some",
-                  Stack_item.NonliteralValue (Contract (address, entrypoint))) 
+                  Stack_item.NonliteralValue (Contract (address, entrypoint)) )
           | None -> Stack_item.Variant ("None", Utils.unit_record_stack)
         in
-        Continue (c, env, contract :: s)
+        Steps.Continue (c, env, contract :: s)
     | ( MakeTransaction :: c,
         env,
         r
         :: Stack_item.Z (Mutez amount)
            :: Stack_item.NonliteralValue (Contract contract) :: s )
       when Stack_item.equal r Utils.unit_record_stack ->
-        Continue
+        Steps.Continue
           ( c,
             env,
             Stack_item.NonliteralValue
               (Operation (Transaction (amount, contract)))
             :: s )
     (* should be unreachable except when program is done *)
-    | ([Return], _, _) -> Done
-    | (Failwith :: _, _, Stack_item.Z (String s) :: _) -> Failwith s
+    | ([Return], _, _) -> Steps.Done
+    | (Failwith :: _, _, Stack_item.Z (String s) :: _) -> Steps.Failwith s
     (* should not be reachable *)
     | (x :: _, _, _) ->
-        Internal_error
-          (Format.asprintf "%a unimplemented!" pp_zinc_instruction x)
+        Steps.Internal_error
+          (Format.asprintf "%a unimplemented!" pp_instruction x)
     | _ ->
-        Internal_error
+        Steps.Internal_error
           (Format.asprintf "somehow ran out of code without hitting return!")
   in
   let rec loop code env stack =
     match apply_once code env stack with
-    | Done -> Interpreter_output.Success (env, stack)
-    | Failwith s -> Interpreter_output.Failure s
-    | Internal_error s -> failwith s
-    | Continue (code, env, stack) -> loop code env stack
+    | Steps.Done -> Interpreter_output.Success (env, stack)
+    | Steps.Failwith s -> Interpreter_output.Failure s
+    | Steps.Internal_error s -> failwith s
+    | Steps.Continue (code, env, stack) -> loop code env stack
   in
   loop code env stack

--- a/zinc/lib/Zinc_types.ml
+++ b/zinc/lib/Zinc_types.ml
@@ -5,84 +5,85 @@ type address = string [@@deriving show {with_path = false}, eq, yojson]
 type contract = string * address option
 [@@deriving show {with_path = false}, eq, yojson]
 
-type zinc_instruction =
-  (*
+module Zinc = struct
+  type t = instruction list [@@deriving show {with_path = false}, eq, yojson]
+
+  and instruction =
+    (*
       Everything in here should be safe and trustworthy. Our assumption is that an adversary
       can create whatever zinc they want and provide it as code to the interpreter.
       The code is guaranteed
   *)
-  (* ====================
-     zinc core operations
-     ====================
-  *)
-  | Grab
-  | Return
-  | PushRetAddr of zinc
-  | Apply
-  | Access of int
-  | Closure of zinc
-  | EndLet
-  (*
+    (* ====================
+       zinc core operations
+       ====================
+    *)
+    | Grab
+    | Return
+    | PushRetAddr of t
+    | Apply
+    | Access of int
+    | Closure of t
+    | EndLet
+    (*
      ================
      Extra operations
      ================
   *)
-  (* Core types *)
-  | Bool of bool
-  | Eq
-  | String of string
-  (* math *)
-  | Num of Z.t
-  | Add
-  (* ASTs *)
-  | MakeRecord of int
-  | RecordAccess of label
-  | MakeVariant of variant_label
-  | MatchVariant of (variant_label * zinc) list
-  (* Lists *)
-  | Nil
-  | Cons
-  (* Crypto *)
-  | Key of string
-  | HashKey
-  | Hash of string
-  (* serialization *)
-  | Bytes of bytes
-  (*
+    (* Core types *)
+    | Bool of bool
+    | Eq
+    | String of string
+    (* math *)
+    | Num of Z.t
+    | Add
+    (* ASTs *)
+    | MakeRecord of int
+    | RecordAccess of label
+    | MakeVariant of variant_label
+    | MatchVariant of (variant_label * t) list
+    (* Lists *)
+    | Nil
+    | Cons
+    (* Crypto *)
+    | Key of string
+    | HashKey
+    | Hash of string
+    (* serialization *)
+    | Bytes of bytes
+    (*
      ===========================
      tezos_specific instructions
      ===========================
   *)
-  | Address of address
-  | ChainID
-  | Contract_opt
-  | MakeTransaction
-  | Mutez of Z.t
-  (* Adding this to make contracts easier to interpret even though I think it's technically unecessary  *)
-  | Done
-  | Failwith
-[@@deriving show {with_path = false}, eq, yojson]
+    | Address of address
+    | ChainID
+    | Contract_opt
+    | MakeTransaction
+    | Mutez of Z.t
+    (* Adding this to make contracts easier to interpret even though I think it's technically unecessary  *)
+    | Done
+    | Failwith
+  [@@deriving show {with_path = false}, eq, yojson]
 
-and zinc = zinc_instruction list
-[@@deriving show {with_path = false}, eq, yojson]
+  (*
+    Not all zinc values can be expressed directly in code as literals.
+    So they're represented as a seperate type.
+  *)
+  type nonliteral_value = Contract of contract | Operation of operation
+  [@@deriving show {with_path = false}, eq, yojson]
 
-(*
-   Not all zinc values can be expressed directly in code as literals.
-   So they're represented as a seperate type.
-*)
-type zinc_nonliteral_value = Contract of contract | Operation of operation
-[@@deriving show {with_path = false}, eq, yojson]
+  and operation = Transaction of Z.t * contract (* todo: add parameter *)
+  [@@deriving show {with_path = false}, eq, yojson]
+end
 
-and operation = Transaction of Z.t * contract (* todo: add parameter *)
-[@@deriving show {with_path = false}, eq, yojson]
-
-type program = (string * zinc) list
+type program = (string * Zinc.t) list
 [@@deriving show {with_path = false}, eq, yojson]
 
 module rec Env_item : sig
   type t =
-    | Z of zinc_instruction
-    | NonliteralValue of zinc_nonliteral_value
+    | Z of Zinc.instruction
+    | NonliteralValue of Zinc.nonliteral_value
     | Clos of Clos.t
     | Record of Stack_item.t LMap.t
     | List of Stack_item.t list
@@ -90,8 +91,8 @@ module rec Env_item : sig
   [@@deriving show, eq, yojson]
 end = struct
   type t =
-    | Z of zinc_instruction
-    | NonliteralValue of zinc_nonliteral_value
+    | Z of Zinc.instruction
+    | NonliteralValue of Zinc.nonliteral_value
     | Clos of Clos.t
     | Record of Stack_item.t LMap.t
     | List of Stack_item.t list
@@ -101,37 +102,37 @@ end
 
 and Stack_item : sig
   type t =
-    | Z of zinc_instruction
-    | NonliteralValue of zinc_nonliteral_value
+    | Z of Zinc.instruction
+    | NonliteralValue of Zinc.nonliteral_value
     | Clos of Clos.t
     | Record of t LMap.t
     | List of t list
     | Variant of variant_label * t
-    | Marker of zinc * Env_item.t list
+    | Marker of Zinc.t * Env_item.t list
   [@@deriving show, eq, yojson]
 end = struct
   type t =
-    | Z of zinc_instruction
-    | NonliteralValue of zinc_nonliteral_value
+    | Z of Zinc.instruction
+    | NonliteralValue of Zinc.nonliteral_value
     | Clos of Clos.t
     | Record of t LMap.t
     | List of t list
     | Variant of variant_label * t
-    | Marker of zinc * Env_item.t list
+    | Marker of Zinc.t * Env_item.t list
   [@@deriving show, eq, yojson]
 end
 
 and Clos : sig
-  type t = {code : zinc; env : Env_item.t list} [@@deriving show, eq, yojson]
+  type t = {code : Zinc.t; env : Env_item.t list} [@@deriving show, eq, yojson]
 end = struct
-  type t = {code : zinc; env : Env_item.t list} [@@deriving show, eq, yojson]
+  type t = {code : Zinc.t; env : Env_item.t list} [@@deriving show, eq, yojson]
 end
 
 type env = Env_item.t list [@@deriving show, eq, yojson]
 
 type stack = Stack_item.t list [@@deriving show, eq, yojson]
 
-type interpreter_input = zinc * env * stack [@@deriving show, eq, yojson]
+type interpreter_input = Zinc.t * env * stack [@@deriving show, eq, yojson]
 
 module Interpreter_output = struct
   type t = Success of env * stack | Failure of string

--- a/zinc/lib/Zinc_types.ml
+++ b/zinc/lib/Zinc_types.ml
@@ -6,18 +6,7 @@ type contract = string * address option
 [@@deriving show {with_path = false}, eq, yojson]
 
 module Zinc = struct
-  type t = instruction list [@@deriving show {with_path = false}, eq, yojson]
-
-  and instruction =
-    (*
-      Everything in here should be safe and trustworthy. Our assumption is that an adversary
-      can create whatever zinc they want and provide it as code to the interpreter.
-      The code is guaranteed
-  *)
-    (* ====================
-       zinc core operations
-       ====================
-    *)
+  type core_instruction =
     | Grab
     | Return
     | PushRetAddr of t
@@ -25,55 +14,63 @@ module Zinc = struct
     | Access of int
     | Closure of t
     | EndLet
-    (*
-     ================
-     Extra operations
-     ================
-  *)
-    (* Core types *)
+  [@@deriving show {with_path = false}, eq, yojson]
+
+  and plain_old_data =
     | Bool of bool
-    | Eq
     | String of string
-    (* math *)
     | Num of Z.t
-    | Add
-    (* ASTs *)
+    | Mutez of Z.t
+    | Nil
+    | Bytes of bytes
+    | Address of address
+    | Key of string
+    | Hash of string
+  [@@deriving show {with_path = false}, eq, yojson]
+
+  and adt =
     | MakeRecord of int
     | RecordAccess of label
     | MakeVariant of variant_label
     | MatchVariant of (variant_label * t) list
-    (* Lists *)
-    | Nil
-    | Cons
-    (* Crypto *)
-    | Key of string
-    | HashKey
-    | Hash of string
-    (* serialization *)
-    | Bytes of bytes
-    (*
-     ===========================
-     tezos_specific instructions
-     ===========================
-  *)
-    | Address of address
-    | ChainID
-    | Contract_opt
-    | MakeTransaction
-    | Mutez of Z.t
-    (* Adding this to make contracts easier to interpret even though I think it's technically unecessary  *)
-    | Done
-    | Failwith
   [@@deriving show {with_path = false}, eq, yojson]
+
+  and operation = Eq | Add | Cons | HashKey
+  [@@deriving show {with_path = false}, eq, yojson]
+
+  and domain_specific_operation = ChainID | Contract_opt | MakeTransaction
+  [@@deriving show {with_path = false}, eq, yojson]
+
+  and control_flow = Failwith
+  [@@deriving show {with_path = false}, eq, yojson]
+
+  and instruction =
+    (*
+      Everything in here should be safe and trustworthy. Our assumption is that an adversary
+      can create whatever zinc they want and provide it as code to the interpreter.
+      The code is guaranteed
+  *)
+    | Core of core_instruction
+    | Plain_old_data of plain_old_data
+    | Adt of adt
+    | Operation of operation
+    | Domain_specific_operation of domain_specific_operation
+    | Control_flow of control_flow
+  [@@deriving show {with_path = false}, eq, yojson]
+
+  and t = instruction list [@@deriving show {with_path = false}, eq, yojson]
 
   (*
     Not all zinc values can be expressed directly in code as literals.
     So they're represented as a seperate type.
   *)
-  type nonliteral_value = Contract of contract | Operation of operation
+  type nonliteral_value =
+    | Contract of contract
+    | Chain_operation of chain_operation
   [@@deriving show {with_path = false}, eq, yojson]
 
-  and operation = Transaction of Z.t * contract (* todo: add parameter *)
+  and chain_operation =
+    | Transaction of Z.t * contract (* todo: add parameter *)
   [@@deriving show {with_path = false}, eq, yojson]
 end
 

--- a/zinc/tests/test_sample.ml
+++ b/zinc/tests/test_sample.ml
@@ -3,27 +3,29 @@
 let zinc =
   Zinc_types.Zinc.
     [
-      Address "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV";
-      Grab;
-      Access 0;
-      Contract_opt;
-      Grab;
-      Access 0;
-      MatchVariant
-        [
-          ("Some", [Grab; Access 0]);
-          ("None", [Grab; String "Not a contract"; Failwith]);
-        ];
-      EndLet;
-      Grab;
-      String "my string";
-      Key "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav";
-      Access 0;
-      Mutez (Z.of_int 10);
-      MakeRecord 0;
-      MakeTransaction;
-      MakeRecord 3;
-      Return;
+      Plain_old_data (Address "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV");
+      Core Grab;
+      Core (Access 0);
+      Domain_specific_operation Contract_opt;
+      Core Grab;
+      Core (Access 0);
+      Adt
+        (MatchVariant
+           [
+             ("Some", [Core Grab; Core (Access 0)]);
+             ("None", [Core Grab; Plain_old_data (String "Not a contract"); Control_flow Failwith]);
+           ]);
+      Core EndLet;
+      Core Grab;
+      Plain_old_data (String "my string");
+      Plain_old_data
+        (Key "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav");
+      Core (Access 0);
+      Plain_old_data (Mutez (Z.of_int 10));
+      Adt (MakeRecord 0);
+      Domain_specific_operation MakeTransaction;
+      Adt (MakeRecord 3);
+      Core Return;
     ]
 
 let%expect_test _ =
@@ -39,208 +41,271 @@ let%expect_test _ =
   [%expect
     {|
     interpreting:
-    code:  [(Address "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV"); Grab;
-                           (Access 0); Contract_opt; Grab; (Access 0);
-                           (MatchVariant
-                              [((Label "Some"), [Grab; (Access 0)]);
-                                ((Label "None"),
-                                 [Grab; (String "Not a contract"); Failwith])
-                                ]);
-                           EndLet; Grab; (String "my string");
-                           (Key
-                              "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav");
-                           (Access 0); (Mutez 10); (MakeRecord []);
-                           MakeTransaction;
-                           (MakeRecord [(Label "0"); (Label "1"); (Label "2")]);
-                           Return]
+    code:  [(Plain_old_data
+                             (Address "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV"));
+                           (Core Grab); (Core (Access 0));
+                           (Domain_specific_operation Contract_opt); (Core Grab);
+                           (Core (Access 0));
+                           (Adt
+                              (MatchVariant
+                                 [("Some", [(Core Grab); (Core (Access 0))]);
+                                   ("None",
+                                    [(Core Grab);
+                                      (Plain_old_data (String "Not a contract"));
+                                      (Control_flow Failwith)])
+                                   ]));
+                           (Core EndLet); (Core Grab);
+                           (Plain_old_data (String "my string"));
+                           (Plain_old_data
+                              (Key
+                                 "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav"));
+                           (Core (Access 0)); (Plain_old_data (Mutez 10));
+                           (Adt (MakeRecord 0));
+                           (Domain_specific_operation MakeTransaction);
+                           (Adt (MakeRecord 3)); (Core Return)]
     env:   []
-    stack: []
+    stack:
+    []
     interpreting:
-    code:  [Grab; (Access 0); Contract_opt; Grab; (Access 0);
-                           (MatchVariant
-                              [((Label "Some"), [Grab; (Access 0)]);
-                                ((Label "None"),
-                                 [Grab; (String "Not a contract"); Failwith])
-                                ]);
-                           EndLet; Grab; (String "my string");
-                           (Key
-                              "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav");
-                           (Access 0); (Mutez 10); (MakeRecord []);
-                           MakeTransaction;
-                           (MakeRecord [(Label "0"); (Label "1"); (Label "2")]);
-                           Return]
+    code:  [(Core Grab); (Core (Access 0));
+                           (Domain_specific_operation Contract_opt); (Core Grab);
+                           (Core (Access 0));
+                           (Adt
+                              (MatchVariant
+                                 [("Some", [(Core Grab); (Core (Access 0))]);
+                                   ("None",
+                                    [(Core Grab);
+                                      (Plain_old_data (String "Not a contract"));
+                                      (Control_flow Failwith)])
+                                   ]));
+                           (Core EndLet); (Core Grab);
+                           (Plain_old_data (String "my string"));
+                           (Plain_old_data
+                              (Key
+                                 "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav"));
+                           (Core (Access 0)); (Plain_old_data (Mutez 10));
+                           (Adt (MakeRecord 0));
+                           (Domain_specific_operation MakeTransaction);
+                           (Adt (MakeRecord 3)); (Core Return)]
     env:   []
-    stack: [(Zinc_types.Zinc.Stack_item.Z
-                                                        (Address
-                                                           "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV"))
-                                                      ]
+    stack:
+    [(Zinc_types.Stack_item.Z
+        (Plain_old_data (Address "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV")))
+      ]
     interpreting:
-    code:  [(Access 0); Contract_opt; Grab; (Access 0);
-                           (MatchVariant
-                              [((Label "Some"), [Grab; (Access 0)]);
-                                ((Label "None"),
-                                 [Grab; (String "Not a contract"); Failwith])
-                                ]);
-                           EndLet; Grab; (String "my string");
-                           (Key
-                              "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav");
-                           (Access 0); (Mutez 10); (MakeRecord []);
-                           MakeTransaction;
-                           (MakeRecord [(Label "0"); (Label "1"); (Label "2")]);
-                           Return]
-    env:   [(Zinc_types.Zinc.Env_item.Z
-                                              (Address
-                                                 "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV"))
-                                            ]
-    stack: []
+    code:  [(Core (Access 0));
+                           (Domain_specific_operation Contract_opt); (Core Grab);
+                           (Core (Access 0));
+                           (Adt
+                              (MatchVariant
+                                 [("Some", [(Core Grab); (Core (Access 0))]);
+                                   ("None",
+                                    [(Core Grab);
+                                      (Plain_old_data (String "Not a contract"));
+                                      (Control_flow Failwith)])
+                                   ]));
+                           (Core EndLet); (Core Grab);
+                           (Plain_old_data (String "my string"));
+                           (Plain_old_data
+                              (Key
+                                 "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav"));
+                           (Core (Access 0)); (Plain_old_data (Mutez 10));
+                           (Adt (MakeRecord 0));
+                           (Domain_specific_operation MakeTransaction);
+                           (Adt (MakeRecord 3)); (Core Return)]
+    env:   [(Zinc_types.Env_item.Z
+                                                                        (Plain_old_data
+                                                                        (Address
+                                                                        "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV")))
+                                                                        ]
+    stack:
+    []
     interpreting:
-    code:  [Contract_opt; Grab; (Access 0);
-                           (MatchVariant
-                              [((Label "Some"), [Grab; (Access 0)]);
-                                ((Label "None"),
-                                 [Grab; (String "Not a contract"); Failwith])
-                                ]);
-                           EndLet; Grab; (String "my string");
-                           (Key
-                              "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav");
-                           (Access 0); (Mutez 10); (MakeRecord []);
-                           MakeTransaction;
-                           (MakeRecord [(Label "0"); (Label "1"); (Label "2")]);
-                           Return]
-    env:   [(Zinc_types.Zinc.Env_item.Z
-                                              (Address
-                                                 "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV"))
-                                            ]
-    stack: [(Zinc_types.Zinc.Stack_item.Z
-                                                         (Address
-                                                            "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV"))
-                                                       ]
+    code:  [(Domain_specific_operation Contract_opt); (Core Grab);
+                           (Core (Access 0));
+                           (Adt
+                              (MatchVariant
+                                 [("Some", [(Core Grab); (Core (Access 0))]);
+                                   ("None",
+                                    [(Core Grab);
+                                      (Plain_old_data (String "Not a contract"));
+                                      (Control_flow Failwith)])
+                                   ]));
+                           (Core EndLet); (Core Grab);
+                           (Plain_old_data (String "my string"));
+                           (Plain_old_data
+                              (Key
+                                 "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav"));
+                           (Core (Access 0)); (Plain_old_data (Mutez 10));
+                           (Adt (MakeRecord 0));
+                           (Domain_specific_operation MakeTransaction);
+                           (Adt (MakeRecord 3)); (Core Return)]
+    env:   [(Zinc_types.Env_item.Z
+                                                                        (Plain_old_data
+                                                                        (Address
+                                                                        "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV")))
+                                                                        ]
+    stack:
+    [(Zinc_types.Stack_item.Z
+        (Plain_old_data (Address "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV")))
+      ]
     interpreting:
-    code:  [Grab; (Access 0);
-                           (MatchVariant
-                              [((Label "Some"), [Grab; (Access 0)]);
-                                ((Label "None"),
-                                 [Grab; (String "Not a contract"); Failwith])
-                                ]);
-                           EndLet; Grab; (String "my string");
-                           (Key
-                              "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav");
-                           (Access 0); (Mutez 10); (MakeRecord []);
-                           MakeTransaction;
-                           (MakeRecord [(Label "0"); (Label "1"); (Label "2")]);
-                           Return]
-    env:   [(Zinc_types.Zinc.Env_item.Z
-                                              (Address
-                                                 "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV"))
-                                            ]
-    stack: [(Zinc_types.Zinc.Stack_item.Variant (
-                                                         (Label "None"),
-                                                         (Zinc_types.Zinc.Stack_item.Record
-                                                            )
-                                                         ))
-                                                       ]
+    code:  [(Core Grab); (Core (Access 0));
+                           (Adt
+                              (MatchVariant
+                                 [("Some", [(Core Grab); (Core (Access 0))]);
+                                   ("None",
+                                    [(Core Grab);
+                                      (Plain_old_data (String "Not a contract"));
+                                      (Control_flow Failwith)])
+                                   ]));
+                           (Core EndLet); (Core Grab);
+                           (Plain_old_data (String "my string"));
+                           (Plain_old_data
+                              (Key
+                                 "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav"));
+                           (Core (Access 0)); (Plain_old_data (Mutez 10));
+                           (Adt (MakeRecord 0));
+                           (Domain_specific_operation MakeTransaction);
+                           (Adt (MakeRecord 3)); (Core Return)]
+    env:   [(Zinc_types.Env_item.Z
+                                                                        (Plain_old_data
+                                                                        (Address
+                                                                        "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV")))
+                                                                        ]
+    stack:
+    [(Zinc_types.Stack_item.Variant ("None", (Zinc_types.Stack_item.Record [||])
+        ))
+      ]
     interpreting:
-    code:  [(Access 0);
-                           (MatchVariant
-                              [((Label "Some"), [Grab; (Access 0)]);
-                                ((Label "None"),
-                                 [Grab; (String "Not a contract"); Failwith])
-                                ]);
-                           EndLet; Grab; (String "my string");
-                           (Key
-                              "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav");
-                           (Access 0); (Mutez 10); (MakeRecord []);
-                           MakeTransaction;
-                           (MakeRecord [(Label "0"); (Label "1"); (Label "2")]);
-                           Return]
-    env:   [(Zinc_types.Zinc.Env_item.Variant (
-                                              (Label "None"),
-                                              (Zinc_types.Zinc.Stack_item.Record )));
-                                            (Zinc_types.Zinc.Env_item.Z
-                                               (Address
-                                                  "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV"))
-                                            ]
-    stack: []
+    code:  [(Core (Access 0));
+                           (Adt
+                              (MatchVariant
+                                 [("Some", [(Core Grab); (Core (Access 0))]);
+                                   ("None",
+                                    [(Core Grab);
+                                      (Plain_old_data (String "Not a contract"));
+                                      (Control_flow Failwith)])
+                                   ]));
+                           (Core EndLet); (Core Grab);
+                           (Plain_old_data (String "my string"));
+                           (Plain_old_data
+                              (Key
+                                 "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav"));
+                           (Core (Access 0)); (Plain_old_data (Mutez 10));
+                           (Adt (MakeRecord 0));
+                           (Domain_specific_operation MakeTransaction);
+                           (Adt (MakeRecord 3)); (Core Return)]
+    env:   [(Zinc_types.Env_item.Variant (
+                                                                        "None",
+                                                                        (Zinc_types.Stack_item.Record
+                                                                        [||])));
+                                                                        (Zinc_types.Env_item.Z
+                                                                        (Plain_old_data
+                                                                        (Address
+                                                                        "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV")))
+                                                                        ]
+    stack:
+    []
     interpreting:
-    code:  [(MatchVariant
-                             [((Label "Some"), [Grab; (Access 0)]);
-                               ((Label "None"),
-                                [Grab; (String "Not a contract"); Failwith])
-                               ]);
-                           EndLet; Grab; (String "my string");
-                           (Key
-                              "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav");
-                           (Access 0); (Mutez 10); (MakeRecord []);
-                           MakeTransaction;
-                           (MakeRecord [(Label "0"); (Label "1"); (Label "2")]);
-                           Return]
-    env:   [(Zinc_types.Zinc.Env_item.Variant (
-                                              (Label "None"),
-                                              (Zinc_types.Zinc.Stack_item.Record )));
-                                            (Zinc_types.Zinc.Env_item.Z
-                                               (Address
-                                                  "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV"))
-                                            ]
-    stack: [(Zinc_types.Zinc.Stack_item.Variant (
-                                                         (Label "None"),
-                                                         (Zinc_types.Zinc.Stack_item.Record
-                                                            )
-                                                         ))
-                                                       ]
+    code:  [(Adt
+                             (MatchVariant
+                                [("Some", [(Core Grab); (Core (Access 0))]);
+                                  ("None",
+                                   [(Core Grab);
+                                     (Plain_old_data (String "Not a contract"));
+                                     (Control_flow Failwith)])
+                                  ]));
+                           (Core EndLet); (Core Grab);
+                           (Plain_old_data (String "my string"));
+                           (Plain_old_data
+                              (Key
+                                 "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav"));
+                           (Core (Access 0)); (Plain_old_data (Mutez 10));
+                           (Adt (MakeRecord 0));
+                           (Domain_specific_operation MakeTransaction);
+                           (Adt (MakeRecord 3)); (Core Return)]
+    env:   [(Zinc_types.Env_item.Variant (
+                                                                        "None",
+                                                                        (Zinc_types.Stack_item.Record
+                                                                        [||])));
+                                                                        (Zinc_types.Env_item.Z
+                                                                        (Plain_old_data
+                                                                        (Address
+                                                                        "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV")))
+                                                                        ]
+    stack:
+    [(Zinc_types.Stack_item.Variant ("None", (Zinc_types.Stack_item.Record [||])
+        ))
+      ]
     interpreting:
-    code:  [Grab; (String "Not a contract"); Failwith; EndLet;
-                           Grab; (String "my string");
-                           (Key
-                              "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav");
-                           (Access 0); (Mutez 10); (MakeRecord []);
-                           MakeTransaction;
-                           (MakeRecord [(Label "0"); (Label "1"); (Label "2")]);
-                           Return]
-    env:   [(Zinc_types.Zinc.Env_item.Variant (
-                                              (Label "None"),
-                                              (Zinc_types.Zinc.Stack_item.Record )));
-                                            (Zinc_types.Zinc.Env_item.Z
-                                               (Address
-                                                  "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV"))
-                                            ]
-    stack: [(Zinc_types.Zinc.Stack_item.Record
-                                                         )
-                                                       ]
+    code:  [(Core Grab);
+                           (Plain_old_data (String "Not a contract"));
+                           (Control_flow Failwith); (Core EndLet); (Core Grab);
+                           (Plain_old_data (String "my string"));
+                           (Plain_old_data
+                              (Key
+                                 "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav"));
+                           (Core (Access 0)); (Plain_old_data (Mutez 10));
+                           (Adt (MakeRecord 0));
+                           (Domain_specific_operation MakeTransaction);
+                           (Adt (MakeRecord 3)); (Core Return)]
+    env:   [(Zinc_types.Env_item.Variant (
+                                                                        "None",
+                                                                        (Zinc_types.Stack_item.Record
+                                                                        [||])));
+                                                                        (Zinc_types.Env_item.Z
+                                                                        (Plain_old_data
+                                                                        (Address
+                                                                        "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV")))
+                                                                        ]
+    stack:
+    [(Zinc_types.Stack_item.Record [||])]
     interpreting:
-    code:  [(String "Not a contract"); Failwith; EndLet; Grab;
-                           (String "my string");
-                           (Key
-                              "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav");
-                           (Access 0); (Mutez 10); (MakeRecord []);
-                           MakeTransaction;
-                           (MakeRecord [(Label "0"); (Label "1"); (Label "2")]);
-                           Return]
-    env:   [(Zinc_types.Zinc.Env_item.Record );
-                                            (Zinc_types.Zinc.Env_item.Variant (
-                                               (Label "None"),
-                                               (Zinc_types.Zinc.Stack_item.Record )));
-                                            (Zinc_types.Zinc.Env_item.Z
-                                               (Address
-                                                  "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV"))
-                                            ]
-    stack: []
+    code:  [(Plain_old_data (String "Not a contract"));
+                           (Control_flow Failwith); (Core EndLet); (Core Grab);
+                           (Plain_old_data (String "my string"));
+                           (Plain_old_data
+                              (Key
+                                 "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav"));
+                           (Core (Access 0)); (Plain_old_data (Mutez 10));
+                           (Adt (MakeRecord 0));
+                           (Domain_specific_operation MakeTransaction);
+                           (Adt (MakeRecord 3)); (Core Return)]
+    env:   [(Zinc_types.Env_item.Record
+                                                                        [||]);
+                                                                        (Zinc_types.Env_item.Variant (
+                                                                        "None",
+                                                                        (Zinc_types.Stack_item.Record
+                                                                        [||])));
+                                                                        (Zinc_types.Env_item.Z
+                                                                        (Plain_old_data
+                                                                        (Address
+                                                                        "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV")))
+                                                                        ]
+    stack:
+    []
     interpreting:
-    code:  [Failwith; EndLet; Grab; (String "my string");
-                           (Key
-                              "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav");
-                           (Access 0); (Mutez 10); (MakeRecord []);
-                           MakeTransaction;
-                           (MakeRecord [(Label "0"); (Label "1"); (Label "2")]);
-                           Return]
-    env:   [(Zinc_types.Zinc.Env_item.Record );
-                                            (Zinc_types.Zinc.Env_item.Variant (
-                                               (Label "None"),
-                                               (Zinc_types.Zinc.Stack_item.Record )));
-                                            (Zinc_types.Zinc.Env_item.Z
-                                               (Address
-                                                  "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV"))
-                                            ]
-    stack: [(Zinc_types.Zinc.Stack_item.Z
-                                                         (String "Not a contract"))
-                                                       ]
+    code:  [(Control_flow Failwith); (Core EndLet); (Core Grab);
+                           (Plain_old_data (String "my string"));
+                           (Plain_old_data
+                              (Key
+                                 "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav"));
+                           (Core (Access 0)); (Plain_old_data (Mutez 10));
+                           (Adt (MakeRecord 0));
+                           (Domain_specific_operation MakeTransaction);
+                           (Adt (MakeRecord 3)); (Core Return)]
+    env:   [(Zinc_types.Env_item.Record
+                                                                        [||]);
+                                                                        (Zinc_types.Env_item.Variant (
+                                                                        "None",
+                                                                        (Zinc_types.Stack_item.Record
+                                                                        [||])));
+                                                                        (Zinc_types.Env_item.Z
+                                                                        (Plain_old_data
+                                                                        (Address
+                                                                        "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV")))
+                                                                        ]
+    stack:
+    [(Zinc_types.Stack_item.Z (Plain_old_data (String "Not a contract")))]
     (Zinc_types.Interpreter_output.Failure "Not a contract") |}]

--- a/zinc/tests/test_sample.ml
+++ b/zinc/tests/test_sample.ml
@@ -1,7 +1,7 @@
 [@@@warning "-40"]
 
 let zinc =
-  Zinc_types.
+  Zinc_types.Zinc.
     [
       Address "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV";
       Grab;
@@ -70,7 +70,7 @@ let%expect_test _ =
                            (MakeRecord [(Label "0"); (Label "1"); (Label "2")]);
                            Return]
     env:   []
-    stack: [(Zinc_types.Stack_item.Z
+    stack: [(Zinc_types.Zinc.Stack_item.Z
                                                         (Address
                                                            "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV"))
                                                       ]
@@ -88,7 +88,7 @@ let%expect_test _ =
                            MakeTransaction;
                            (MakeRecord [(Label "0"); (Label "1"); (Label "2")]);
                            Return]
-    env:   [(Zinc_types.Env_item.Z
+    env:   [(Zinc_types.Zinc.Env_item.Z
                                               (Address
                                                  "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV"))
                                             ]
@@ -107,11 +107,11 @@ let%expect_test _ =
                            MakeTransaction;
                            (MakeRecord [(Label "0"); (Label "1"); (Label "2")]);
                            Return]
-    env:   [(Zinc_types.Env_item.Z
+    env:   [(Zinc_types.Zinc.Env_item.Z
                                               (Address
                                                  "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV"))
                                             ]
-    stack: [(Zinc_types.Stack_item.Z
+    stack: [(Zinc_types.Zinc.Stack_item.Z
                                                          (Address
                                                             "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV"))
                                                        ]
@@ -129,13 +129,13 @@ let%expect_test _ =
                            MakeTransaction;
                            (MakeRecord [(Label "0"); (Label "1"); (Label "2")]);
                            Return]
-    env:   [(Zinc_types.Env_item.Z
+    env:   [(Zinc_types.Zinc.Env_item.Z
                                               (Address
                                                  "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV"))
                                             ]
-    stack: [(Zinc_types.Stack_item.Variant (
+    stack: [(Zinc_types.Zinc.Stack_item.Variant (
                                                          (Label "None"),
-                                                         (Zinc_types.Stack_item.Record
+                                                         (Zinc_types.Zinc.Stack_item.Record
                                                             )
                                                          ))
                                                        ]
@@ -153,10 +153,10 @@ let%expect_test _ =
                            MakeTransaction;
                            (MakeRecord [(Label "0"); (Label "1"); (Label "2")]);
                            Return]
-    env:   [(Zinc_types.Env_item.Variant (
+    env:   [(Zinc_types.Zinc.Env_item.Variant (
                                               (Label "None"),
-                                              (Zinc_types.Stack_item.Record )));
-                                            (Zinc_types.Env_item.Z
+                                              (Zinc_types.Zinc.Stack_item.Record )));
+                                            (Zinc_types.Zinc.Env_item.Z
                                                (Address
                                                   "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV"))
                                             ]
@@ -174,16 +174,16 @@ let%expect_test _ =
                            MakeTransaction;
                            (MakeRecord [(Label "0"); (Label "1"); (Label "2")]);
                            Return]
-    env:   [(Zinc_types.Env_item.Variant (
+    env:   [(Zinc_types.Zinc.Env_item.Variant (
                                               (Label "None"),
-                                              (Zinc_types.Stack_item.Record )));
-                                            (Zinc_types.Env_item.Z
+                                              (Zinc_types.Zinc.Stack_item.Record )));
+                                            (Zinc_types.Zinc.Env_item.Z
                                                (Address
                                                   "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV"))
                                             ]
-    stack: [(Zinc_types.Stack_item.Variant (
+    stack: [(Zinc_types.Zinc.Stack_item.Variant (
                                                          (Label "None"),
-                                                         (Zinc_types.Stack_item.Record
+                                                         (Zinc_types.Zinc.Stack_item.Record
                                                             )
                                                          ))
                                                        ]
@@ -196,14 +196,14 @@ let%expect_test _ =
                            MakeTransaction;
                            (MakeRecord [(Label "0"); (Label "1"); (Label "2")]);
                            Return]
-    env:   [(Zinc_types.Env_item.Variant (
+    env:   [(Zinc_types.Zinc.Env_item.Variant (
                                               (Label "None"),
-                                              (Zinc_types.Stack_item.Record )));
-                                            (Zinc_types.Env_item.Z
+                                              (Zinc_types.Zinc.Stack_item.Record )));
+                                            (Zinc_types.Zinc.Env_item.Z
                                                (Address
                                                   "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV"))
                                             ]
-    stack: [(Zinc_types.Stack_item.Record
+    stack: [(Zinc_types.Zinc.Stack_item.Record
                                                          )
                                                        ]
     interpreting:
@@ -215,11 +215,11 @@ let%expect_test _ =
                            MakeTransaction;
                            (MakeRecord [(Label "0"); (Label "1"); (Label "2")]);
                            Return]
-    env:   [(Zinc_types.Env_item.Record );
-                                            (Zinc_types.Env_item.Variant (
+    env:   [(Zinc_types.Zinc.Env_item.Record );
+                                            (Zinc_types.Zinc.Env_item.Variant (
                                                (Label "None"),
-                                               (Zinc_types.Stack_item.Record )));
-                                            (Zinc_types.Env_item.Z
+                                               (Zinc_types.Zinc.Stack_item.Record )));
+                                            (Zinc_types.Zinc.Env_item.Z
                                                (Address
                                                   "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV"))
                                             ]
@@ -232,15 +232,15 @@ let%expect_test _ =
                            MakeTransaction;
                            (MakeRecord [(Label "0"); (Label "1"); (Label "2")]);
                            Return]
-    env:   [(Zinc_types.Env_item.Record );
-                                            (Zinc_types.Env_item.Variant (
+    env:   [(Zinc_types.Zinc.Env_item.Record );
+                                            (Zinc_types.Zinc.Env_item.Variant (
                                                (Label "None"),
-                                               (Zinc_types.Stack_item.Record )));
-                                            (Zinc_types.Env_item.Z
+                                               (Zinc_types.Zinc.Stack_item.Record )));
+                                            (Zinc_types.Zinc.Env_item.Z
                                                (Address
                                                   "tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV"))
                                             ]
-    stack: [(Zinc_types.Stack_item.Z
+    stack: [(Zinc_types.Zinc.Stack_item.Z
                                                          (String "Not a contract"))
                                                        ]
     (Zinc_types.Interpreter_output.Failure "Not a contract") |}]


### PR DESCRIPTION
## Problem

Every zinc instruction was just sitting in `Zinc_instruction`. 

## Solution

We can improve the organization by splitting it into multiple smaller types.

## Related
- closes #347 