### PR TITLE
esy: use coq overrides from esy-opam-overrides

### DIFF
--- a/ligolang/esy.lock/index.json
+++ b/ligolang/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "18b1de9b2251f9f3aa14bd2aa35cd125",
+  "checksum": "bc2e0e9d550babb112d764092b09ef6b",
   "root": "ligo@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -77,8 +77,8 @@
         "@opam/dune@opam:2.9.1@1e504822",
         "@opam/domain-name@opam:0.3.0@46ccc517",
         "@opam/data-encoding@opam:0.4@edfce09b",
-        "@opam/ctypes@github:ocamllabs/ocaml-ctypes:ctypes.opam#0cbd0378b494d6377fd40606433a846736109c22@d24c87ce",
-        "@opam/coq@archive:https://github.com/coq/coq/archive/V8.13.2.tar.gz#sha256:1e7793d8483f1e939f62df6749f843df967a15d843a4a5acb024904b76e25a14@bf80e8d3",
+        "@opam/ctypes@opam:0.18.0@1be5c5e5",
+        "@opam/coq@opam:8.13.1@88ed2461",
         "@opam/bls12-381-unix@archive:https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/1.0.1/ocaml-bls12-381-1.0.1.tar.bz2#sha512:f69d611deb6132d07f0a8ecde7bb118f733de802e241056c5e2b194579c5723a12d58e93410bd56f68a608568de035b61f018d1fea52388f54875d77b8f386c2@917bd8ad",
         "@opam/bls12-381-legacy@archive:https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/0.4.3-legacy/ocaml-bls12-381-0.4.3-legacy.tar.bz2#sha512:0102db9dcab07c788291e9f799a4cf7a480716f18da6833587381e88ecc699d6e6bb0f44afef0ec7cd14a742d8ec6efc7900b45b0bcdeba409a89420465c0a25@cb54e723",
         "@opam/bls12-381@opam:1.0.1@30956730",
@@ -4113,46 +4113,33 @@
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
-    "@opam/coq@archive:https://github.com/coq/coq/archive/V8.13.2.tar.gz#sha256:1e7793d8483f1e939f62df6749f843df967a15d843a4a5acb024904b76e25a14@bf80e8d3": {
-      "id":
-        "@opam/coq@archive:https://github.com/coq/coq/archive/V8.13.2.tar.gz#sha256:1e7793d8483f1e939f62df6749f843df967a15d843a4a5acb024904b76e25a14@bf80e8d3",
+    "@opam/coq@opam:8.13.1@88ed2461": {
+      "id": "@opam/coq@opam:8.13.1@88ed2461",
       "name": "@opam/coq",
-      "version":
-        "archive:https://github.com/coq/coq/archive/V8.13.2.tar.gz#sha256:1e7793d8483f1e939f62df6749f843df967a15d843a4a5acb024904b76e25a14",
+      "version": "opam:8.13.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://github.com/coq/coq/archive/V8.13.2.tar.gz#sha256:1e7793d8483f1e939f62df6749f843df967a15d843a4a5acb024904b76e25a14"
-        ]
-      },
-      "overrides": [
-        {
-          "build": [
-            [
-              "./configure", "-configdir", "#{self.lib}/coq/config",
-              "-prefix", "#{self.install}", "-mandir", "#{self.man}",
-              "-docdir", "#{self.doc}", "-libdir", "#{self.lib}/coq",
-              "-datadir", "#{self.share}/coq", "-coqide", "no", "-camldir",
-              "#{ ocaml.bin }"
-            ],
-            [ "make", "-j2" ],
-            [ "make", "-j2", "byte" ]
-          ],
-          "dependencies": {
-            "ocaml": "*",
-            "@opam/ocamlfind": "*",
-            "@opam/num": "*",
-            "@opam/conf-findutils": "*",
-            "@opam/zarith": "*"
-          }
+          "archive:https://opam.ocaml.org/cache/sha256/95/95e71b16e6f3592e53d8bb679f051b062afbd12069a4105ffc9ee50e421d4685#sha256:95e71b16e6f3592e53d8bb679f051b062afbd12069a4105ffc9ee50e421d4685",
+          "archive:https://github.com/coq/coq/archive/V8.13.1.tar.gz#sha256:95e71b16e6f3592e53d8bb679f051b062afbd12069a4105ffc9ee50e421d4685"
+        ],
+        "opam": {
+          "name": "coq",
+          "version": "8.13.1",
+          "path": "esy.lock/opam/coq.8.13.1"
         }
-      ],
+      },
+      "overrides": [],
       "dependencies": [
         "ocaml@4.12.0@d41d8cd9", "@opam/zarith@opam:1.11@6b66cdc1",
         "@opam/ocamlfind@opam:1.9.1@b748edf6", "@opam/num@opam:1.4@15ff926d",
-        "@opam/conf-findutils@opam:1@34f14152"
+        "@opam/conf-findutils@opam:1@34f14152",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
-      "devDependencies": []
+      "devDependencies": [
+        "ocaml@4.12.0@d41d8cd9", "@opam/zarith@opam:1.11@6b66cdc1",
+        "@opam/num@opam:1.4@15ff926d"
+      ]
     },
     "@opam/conf-rust@no-source:@3165ff25": {
       "id": "@opam/conf-rust@no-source:@3165ff25",

--- a/ligolang/esy.lock/opam/coq.8.13.1/files/coq.install
+++ b/ligolang/esy.lock/opam/coq.8.13.1/files/coq.install
@@ -1,0 +1,12 @@
+bin: [
+  "bin/coqwc"
+  "bin/coqtop"
+  "bin/coqtop.byte"
+  "bin/coqdoc"
+  "bin/coqdep"
+  "bin/coqchk"
+  "bin/coqc"
+  "bin/coq_makefile"
+  "bin/coq-tex"
+  "bin/coqworkmgr"
+]

--- a/ligolang/esy.lock/opam/coq.8.13.1/files/disable_warn_70.patch
+++ b/ligolang/esy.lock/opam/coq.8.13.1/files/disable_warn_70.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ml b/configure.ml
+index c14a069c49..40c75eb418 100644
+--- a/configure.ml
++++ b/configure.ml
+@@ -634,7 +634,7 @@ let camltag = match caml_version_list with
+     58: "no cmx file was found in path": See https://github.com/ocaml/num/issues/9
+     67: "unused functor parameter" seems totally bogus
+ *)
+-let coq_warnings = "-w +a-4-9-27-41-42-44-45-48-58-67"
++let coq_warnings = "-w +a-4-9-27-41-42-44-45-48-58-67-70"
+ let coq_warn_error =
+     if !prefs.warn_error
+     then "-warn-error +a"

--- a/ligolang/esy.lock/opam/coq.8.13.1/opam
+++ b/ligolang/esy.lock/opam/coq.8.13.1/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+maintainer: "coqdev@inria.fr"
+authors: "The Coq development team, INRIA, CNRS, and contributors."
+homepage: "https://coq.inria.fr/"
+bug-reports: "https://github.com/coq/coq/issues"
+dev-repo: "git+https://github.com/coq/coq.git"
+license: "LGPL-2.1-only"
+synopsis: "Formal proof management system"
+description: """
+The Coq proof assistant provides a formal language to write
+mathematical definitions, executable algorithms, and theorems, together
+with an environment for semi-interactive development of machine-checked
+proofs. Typical applications include the certification of properties of programming
+languages (e.g., the CompCert compiler certification project and the
+Bedrock verified low-level programming library), the formalization of
+mathematics (e.g., the full formalization of the Feit-Thompson theorem
+and homotopy type theory) and teaching.
+"""
+
+depopts: [
+  "coq-native"
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "num"
+  "conf-findutils" {build}
+  "zarith" {>= "1.10"}
+]
+conflicts: [
+  "ocaml-option-nnp"
+]
+build: [
+  [
+    "./configure"
+    "-configdir" "%{lib}%/coq/config"
+    "-prefix" prefix
+    "-mandir" man
+    "-docdir" doc
+    "-libdir" "%{lib}%/coq"
+    "-datadir" "%{share}%/coq"
+    "-coqide" "no"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
+  ]
+  [make "COQ_USE_DUNE=" "-j%{jobs}%"]
+  [make "COQ_USE_DUNE=" "-j%{jobs}%" "byte"]
+]
+install: [
+  [make "COQ_USE_DUNE=" "install"]
+  [make "COQ_USE_DUNE=" "install-byte"]
+]
+
+patches: [ "disable_warn_70.patch" ]
+extra-files: [
+   ["coq.install" "sha512=b501737b4dbd22adc1c0377d744448056fb1dc493caf72c05f57c8463cf23f758373605ab3a50b9f505e4c856c41039d0bd7f81f96ed62adc6a674179523e7d2"]
+   ["disable_warn_70.patch" "sha512=b60c151be108b86650417797e82db13460825909b637f56765164e88f20c538a711ca9439bc8c4d91d61aa06ad652f920d9be4a5c14faf52e359a91958d27904"]
+]
+
+url {
+  src: "https://github.com/coq/coq/archive/V8.13.1.tar.gz"
+  checksum: "sha256=95e71b16e6f3592e53d8bb679f051b062afbd12069a4105ffc9ee50e421d4685"
+}

--- a/ligolang/package.json
+++ b/ligolang/package.json
@@ -16,10 +16,6 @@
       ],
       "rewritePrefix": true
     },
-    "sandboxEnv": {
-      "DYLD_LIBRARY_PATH": "#{@esy-ocaml/libffi.lib : $DYLD_LIBRARY_PATH}",
-      "LD_LIBRARY_PATH": "#{@esy-ocaml/libffi.lib : $LD_LIBRARY_PATH}"
-    },
     "buildEnv": {
       "OPAM_SWITCH_PREFIX": "#{ @opam/tezos-rust-libs.install }"
     }
@@ -91,51 +87,6 @@
   "resolutions": {
     "@opam/zinc": "link:../zinc",
     "@opam/ocaml-recovery-parser": "serokell/ocaml-recovery-parser:ocaml-recovery-parser.opam#7a759aed307f986d43006c50b8ced677e18b5a6d",
-    "@opam/conf-libev": "esy-packages/libev:package.json#0817b2d",
-    "@opam/coq": {
-      "source": "https://github.com/coq/coq/archive/V8.13.2.tar.gz#sha256:1e7793d8483f1e939f62df6749f843df967a15d843a4a5acb024904b76e25a14",
-      "override": {
-        "build": [
-          [
-            "./configure",
-            "-configdir",
-            "#{self.lib}/coq/config",
-            "-prefix",
-            "#{self.install}",
-            "-mandir",
-            "#{self.man}",
-            "-docdir",
-            "#{self.doc}",
-            "-libdir",
-            "#{self.lib}/coq",
-            "-datadir",
-            "#{self.share}/coq",
-            "-coqide",
-            "no",
-            "-camldir",
-            "#{ ocaml.bin }"
-          ],
-          [
-            "make",
-            "-j2"
-          ],
-          [
-            "make",
-            "-j2",
-            "byte"
-          ]
-        ],
-        "dependencies": {
-          "ocaml": "*",
-          "@opam/ocamlfind": "*",
-          "@opam/num": "*",
-          "@opam/conf-findutils": "*",
-          "@opam/zarith": "*"
-        }
-      }
-    },
-    "@opam/nonstd": "git+https://bitbucket.org/smondet/nonstd.git:nonstd.opam#75e06d417730f64e74ec2060d1143e765c68ea1b",
-    "@opam/genspio": "hammerlab/genspio:genspio.opam#f270fb296cebcf25e2ea89a7929a274c03ae9e6e",
     "@esy-ocaml/libffi": "ManasJayanth/esy-libffi:esy.json#41698aeda66c004df26c0c1d80a191503bada03d",
     "@opam/conf-libffi": {
       "source": "no-source:",
@@ -145,18 +96,7 @@
         }
       }
     },
-    "@opam/conf-hidapi": {
-      "source": "no-source:",
-      "override": {
-        "dependencies": {
-          "yarn-pkg-config": "*",
-          "esy-hidapi": "*"
-        }
-      }
-    },
     "yarn-pkg-config": "esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79",
-    "esy-hidapi": "esy-packages/esy-hidapi:esy.json#e21f930d6474e460fa5bb955a26505f6c3500c7a",
-    "libtool": "ManasJayanth/esy-libtool:esy.json#d6725b52f8d021539e92d182d29979951e706836",
     "@opam/conduit-lwt-unix": "4.0.1",
     "@opam/hacl-star-raw": {
       "source": "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.3/hacl-star.0.4.3.tar.gz#sha512:bfb2ddf125a345deb361483aedf9d79837e9ee18b0bc31644588f8409a0fe0c50db2fc1e6b20a07e02fb9f393d2fc9968fd9d2aa9f506f4e23ca8b6ed4036870",
@@ -289,30 +229,6 @@
         }
       }
     },
-    "esy-rustup": "ManasJayanth/esy-rustup:esy.json#e07d864138ed41c5a151a4065063521d0588eb2a",
-    "@opam/tezos-client": {
-      "source": "./src/bin_client",
-      "override": {
-        "dependencies": {
-          "@opam/dune": "*",
-          "@opam/tezos-base": "*",
-          "@opam/tezos-client-base": "*",
-          "@opam/tezos-client-genesis": "*",
-          "@opam/tezos-client-genesis-carthagenet": "*",
-          "@opam/tezos-client-alpha": "*",
-          "@opam/tezos-client-demo-counter": "*",
-          "@opam/tezos-client-alpha-commands": "*",
-          "@opam/tezos-baking-alpha-commands": "*",
-          "@opam/tezos-client-base-unix": "*",
-          "@opam/tezos-mockup-commands": "*",
-          "@opam/tezos-signer-backends": "*"
-        },
-        "devDependencies": {
-          "tezos-node": "*",
-          "tezos-protocol-compiler": "*",
-          "tezos-protocol-alpha-parameters": "*"
-        }
-      }
-    }
+    "esy-rustup": "ManasJayanth/esy-rustup:esy.json#e07d864138ed41c5a151a4065063521d0588eb2a"
   }
 }


### PR DESCRIPTION
## Depends

- [x] #352 

## Problem

Older overrides wouldn't install coq artifacts correctly. 

## Solution

Fixed and upstreamed the overrides [here](https://github.com/esy-ocaml/esy-opam-override). This PR removes local overrides for coq so that the upstream repo is looked into for overrides.