### PR TITLE
Enable ocamlformat on the zinc compiler

### DIFF
--- a/ligolang/.ocamlformat-enable
+++ b/ligolang/.ocamlformat-enable
@@ -1,2 +1,2 @@
 src/test/zinc_tests.ml
-
+src/passes/13deku-zincing/compiler.ml


### PR DESCRIPTION
I've convinced the ligo team to enable ocamlformat on an opt-in, whitelist basis, so now we can whitelist our files to keep them formatted. I added zinc_tests already to the whitelist already, so this MR adds compiler.ml