### PR TITLE
Add if/else to the zinc interpreter

### DIFF
--- a/ligolang/.ocamlformat-enable
+++ b/ligolang/.ocamlformat-enable
@@ -1,2 +1,2 @@
 src/test/zinc_tests.ml
-
+src/passes/13deku-zincing/compiler.ml

--- a/ligolang/src/test/contracts/if_then_else.religo
+++ b/ligolang/src/test/contracts/if_then_else.religo
@@ -1,0 +1,3 @@
+let a : int = 2
+let b : int = 3
+let lf = if (true) {a + 2;} else {b;}

--- a/ligolang/src/test/contracts/if_then_else_op.ligo
+++ b/ligolang/src/test/contracts/if_then_else_op.ligo
@@ -1,3 +1,3 @@
 const a : int = 2
 const b : int = 3
-function lf (const d: bool; const c: bool) : int is if d or c then a else a
+const lf : int = if (False or True) then a else b

--- a/ligolang/src/test/contracts/if_then_else_op_function.ligo
+++ b/ligolang/src/test/contracts/if_then_else_op_function.ligo
@@ -1,0 +1,3 @@
+const a : int = 2
+const b : int = 3
+function lf (const d: bool; const c: bool) : int is if d or c then a else b


### PR DESCRIPTION
## Depends

#356

## Problem

#330 added booleans and if/else to zinc and to the compiler, but not to the interpreter. The tests also did not catch this because none of them were testing the interpreter due to confusing defaults in the test function

## Solution

Add support for if/else to the interpreter. A good test to add would be to ensure that it's lazy - it is lazy, but there's no test for it yet. 

Also, change the `expect_simple_compile_to` function to default to executing the *last* binding, rather than the first one.
