### PR TITLE
networking: {user,consensus}-operation-gossip endpoints

### DIFF
--- a/bin/deku_node.re
+++ b/bin/deku_node.re
@@ -40,6 +40,8 @@ let print_error = err => {
   | `Not_a_valid_request(err) => eprintf("Invalid request: %s", err)
   | `Pending_blocks => eprintf("Pending_blocks")
   | `Unknown_uri => eprintf("Unknown_uri")
+  | `Not_a_user_opertaion => eprintf("Not_a_user_opertaion")
+  | `Not_consensus_operation => eprintf("Not_consensus_operation")
   };
   eprintf("\n%!");
 };
@@ -157,10 +159,23 @@ let handle_register_uri =
     (module Networking.Register_uri), (update_state, {uri, signature}) =>
     Flows.register_uri(Server.get_state(), update_state, ~uri, ~signature)
   );
-let handle_receive_operation_gossip =
+let handle_receive_user_operation_gossip =
   handle_request(
-    (module Networking.Operation_gossip), (update_state, request) => {
-    Flows.received_operation(Server.get_state(), update_state, request)
+    (module Networking.User_operation_gossip), (update_state, request) => {
+    Flows.received_user_operation(
+      Server.get_state(),
+      update_state,
+      request.user_operation,
+    )
+  });
+let handle_receive_consensus_operation =
+  handle_request(
+    (module Networking.Consensus_operation_gossip), (update_state, request) => {
+    Flows.received_consensus_operation(
+      Server.get_state(),
+      update_state,
+      request.consensus_operation,
+    )
   });
 
 let handle_trusted_validators_membership =
@@ -292,7 +307,8 @@ let node = folder => {
     |> handle_protocol_snapshot
     |> handle_request_nonce
     |> handle_register_uri
-    |> handle_receive_operation_gossip
+    |> handle_receive_user_operation_gossip
+    |> handle_receive_consensus_operation
     |> handle_withdraw_proof
     |> handle_ticket_balance
     |> handle_trusted_validators_membership

--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -214,8 +214,8 @@ let create_transaction =
 
   // Broadcast transaction
   let.await () =
-    Networking.request_operation_gossip(
-      Networking.Operation_gossip.{operation: transaction},
+    Networking.request_user_operation_gossip(
+      {user_operation: transaction},
       identity.uri,
     );
   Format.printf(
@@ -307,8 +307,8 @@ let withdraw =
 
   // Broadcast transaction
   let.await () =
-    Networking.request_operation_gossip(
-      Networking.Operation_gossip.{operation: operation},
+    Networking.request_user_operation_gossip(
+      {user_operation: operation},
       identity.uri,
     );
 

--- a/node/flows.re
+++ b/node/flows.re
@@ -300,38 +300,55 @@ let received_signature = (state, update_state, ~hash, ~signature) => {
   };
 };
 
-let received_operation =
-    (state, update_state, request: Networking.Operation_gossip.request) =>
-  if (!List.mem(request.operation, state.Node.pending_side_ops)) {
-    let.ok () =
-      Operation.Side_chain.(
-        switch (request.operation.kind) {
-        | Add_validator(_)
-        | Remove_validator(_) =>
-          let.assert () = (
-            `Invalid_signature_author,
-            Address.compare(
-              state.Node.identity.t,
-              Signature.address(
-                request.operation.Operation.Side_chain.signature,
-              ),
-            )
-            == 0,
-          );
-          Ok();
-        | _ =>
-          Lwt.async(() => {
-            Networking.broadcast_operation_gossip(state, request)
-          });
-          Ok();
-        }
+let received_user_operation = (state, update_state, user_operation) => {
+  let.ok () =
+    switch (user_operation.Operation.Side_chain.kind) {
+    | Add_validator(_)
+    | Remove_validator(_) => Error(`Not_a_user_opertaion)
+    | _ => Ok()
+    };
+
+  if (!List.mem(user_operation, state.Node.pending_side_ops)) {
+    Lwt.async(() =>
+      Networking.broadcast_user_operation_gossip(
+        state,
+        {user_operation: user_operation},
+      )
+    );
+    let _: State.t =
+      update_state(
+        Node.{
+          ...state,
+          pending_side_ops: [user_operation, ...state.Node.pending_side_ops],
+        },
       );
+    Ok();
+  } else {
+    Ok();
+  };
+};
+let received_consensus_operation = (state, update_state, consensus_operation) => {
+  let.ok () =
+    switch (consensus_operation.Protocol.Operation.Side_chain.kind) {
+    | Add_validator(_)
+    | Remove_validator(_) => Ok()
+    | _ => Error(`Not_consensus_operation)
+    };
+  let.assert () = (
+    `Invalid_signature_author,
+    Address.compare(
+      state.Node.identity.t,
+      Signature.address(consensus_operation.signature),
+    )
+    == 0,
+  );
+  if (!List.mem(consensus_operation, state.Node.pending_side_ops)) {
     let _: State.t =
       update_state(
         Node.{
           ...state,
           pending_side_ops: [
-            request.operation,
+            consensus_operation,
             ...state.Node.pending_side_ops,
           ],
         },
@@ -340,6 +357,7 @@ let received_operation =
   } else {
     Ok();
   };
+};
 
 let received_main_operation = (state, update_state, operation) => {
   switch (operation.Tezos_interop.Consensus.parameters) {

--- a/node/networking.re
+++ b/node/networking.re
@@ -150,12 +150,19 @@ module Register_uri = {
   let path = "/register-uri";
 };
 
-module Operation_gossip = {
+module User_operation_gossip = {
   [@deriving yojson]
-  type request = {operation: Operation.Side_chain.t};
+  type request = {user_operation: Operation.Side_chain.t};
   [@deriving yojson]
   type response = unit;
-  let path = "/operation-gossip";
+  let path = "/user-operation-gossip";
+};
+module Consensus_operation_gossip = {
+  [@deriving yojson]
+  type request = {consensus_operation: Protocol.Operation.Side_chain.t};
+  [@deriving yojson]
+  type response = unit;
+  let path = "/consensus-operation-gossip";
 };
 
 module Withdraw_proof = {
@@ -215,10 +222,12 @@ let request_withdraw_proof = request((module Withdraw_proof));
 let broadcast_signature = broadcast_to_validators((module Signature_spec));
 let broadcast_block_and_signature =
   broadcast_to_validators((module Block_and_signature_spec));
-let broadcast_operation_gossip =
-  broadcast_to_validators((module Operation_gossip));
-let broadcast_operation_gossip_to_list =
-  broadcast_to_list((module Operation_gossip));
-let request_operation_gossip = request((module Operation_gossip));
+let broadcast_user_operation_gossip =
+  broadcast_to_validators((module User_operation_gossip));
+let broadcast_user_operation_gossip_to_list =
+  broadcast_to_list((module User_operation_gossip));
+let request_user_operation_gossip = request((module User_operation_gossip));
+let request_consensus_operation =
+  request((module Consensus_operation_gossip));
 let request_trusted_validator_membership =
   request((module Trusted_validators_membership_change));


### PR DESCRIPTION
## Problem

Currently the `/operation-gossip` endpoint is used for both `consensus` operations(adding and removing validators) and also for `user` operations, like transactions and withdraws. This will be problematic in the future when we proper split the operations per group.

## Solution

This PR makes two new endpoints `/user-operation-gossip` and `/consensus-operation-gossip`, each responsible for it's own kind of operations.