### PR TITLE
tezos_interop: parse tezos operation as batch

### DIFF
--- a/bin/deku_node.re
+++ b/bin/deku_node.re
@@ -280,16 +280,7 @@ let node = folder => {
     };
   Tezos_interop.Consensus.listen_operations(
     ~context=interop_context, ~on_operation=operation =>
-    switch (
-      Flows.received_main_operation(
-        Server.get_state(),
-        update_state,
-        operation,
-      )
-    ) {
-    | Ok () => ()
-    | Error(err) => print_error(err)
-    }
+    Flows.received_main_operation(Server.get_state(), update_state, operation)
   );
   await({...node, protocol});
 };

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -26,7 +26,7 @@ module Consensus: {
     ) =>
     Lwt.t(unit);
 
-  type parameters =
+  type transaction =
     | Deposit({
         ticket: Ticket_id.t,
         // TODO: proper type for amounts
@@ -36,8 +36,7 @@ module Consensus: {
     | Update_root_hash(BLAKE2B.t);
   type operation = {
     hash: Operation_hash.t,
-    index: int,
-    parameters,
+    transactions: list(transaction),
   };
   let listen_operations:
     (~context: Context.t, ~on_operation: operation => unit) => unit;


### PR DESCRIPTION
## Problem

An operation on Tezos may actually trigger many Tezos internal operations, currently the script `listen_transactions.js` dispatch each one of those internal operations individually, which is problematic as it allows to apply only a portion of all Tezos internal operations in a single hash.

Also it doesn't model well how Tezos operations happens and the script is supposed to be a low level solution.

## Solution

Dispatch all Tezos operations in a single entry instead of multiple entries. Then internally this is dispatched to multiple protocol operations.