### PR TITLE
Fix typo in docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          push: ${{ github.ref == 'refs/head/main' && github.event_name == 'push' }}
+          push: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
           tags: |
             marigold-dev/deku:latest
             marigold-dev/deku:${{ github.sha }}


### PR DESCRIPTION
This change will make sure we push new versions when a new push to main happens

<!---
  if some of the following sections doesn't apply,
  delete the section.

  Also feel free to delete the comments.
--->

## Problem

<!--- Restate the problem addressed by the PR here --->
We don't push deku images to the docker registry

## Solution

<!--- Restate the basic ideas behind your solution --->
<!--- Here it is also a good space to put details of your implementation --->

Fix the typo in the check so that it evaluates to true on the `main` branch
