### PR TITLE
add Bytes.pack/unpack

### DIFF
--- a/ligolang/src/passes/13deku-zincing/compiler.ml
+++ b/ligolang/src/passes/13deku-zincing/compiler.ml
@@ -258,6 +258,8 @@ and compile_constant :
   | C_OR -> Operation Or :: k
   | C_AND -> Operation And :: k
   | C_NOT -> Operation Not :: k
+  | C_BYTES_UNPACK -> Operation Unpack :: k
+  | C_BYTES_PACK -> Operation Pack :: k
   | name ->
       failwith
         (Format.asprintf "Unsupported constant: %a" AST.PP.constant' name)

--- a/ligolang/src/test/zinc_tests.ml
+++ b/ligolang/src/test/zinc_tests.ml
@@ -946,10 +946,95 @@ let top_level_let_dependencies =
         ] );
     ]
 
+let pack_and_unpack =
+  let open Z in
+  expect_simple_compile_to ~dialect:CameLIGO "bytes_unpack"
+    [
+      ( "id_string",
+        [
+          Core Grab;
+          Core (Access 0);
+          Operation Pack;
+          Core Grab;
+          Core (Access 0);
+          Operation Unpack;
+          Core Return;
+        ] );
+      ( "id_int",
+        [
+          Core
+            (Closure
+               [
+                 Core Grab;
+                 Core (Access 0);
+                 Operation Pack;
+                 Core Grab;
+                 Core (Access 0);
+                 Operation Unpack;
+                 Core Return;
+               ]);
+          Core Grab;
+          Core Grab;
+          Core (Access 0);
+          Operation Pack;
+          Core Grab;
+          Core (Access 0);
+          Operation Unpack;
+          Core Return;
+        ] );
+      ( "id_address",
+        [
+          Core
+            (Closure
+               [
+                 Core Grab;
+                 Core (Access 0);
+                 Operation Pack;
+                 Core Grab;
+                 Core (Access 0);
+                 Operation Unpack;
+                 Core Return;
+               ]);
+          Core Grab;
+          Core
+            (Closure
+               [
+                 Core Grab;
+                 Core (Access 0);
+                 Operation Pack;
+                 Core Grab;
+                 Core (Access 0);
+                 Operation Unpack;
+                 Core Return;
+               ]);
+          Core Grab;
+          Core Grab;
+          Core (Access 0);
+          Operation Pack;
+          Core Grab;
+          Core (Access 0);
+          Operation Unpack;
+          Core Return;
+        ] );
+    ]
+    ~initial_stack:
+      [
+        Types.Stack_item.Z (Plain_old_data (String "test"));
+        Types.Stack_item.Z (Plain_old_data (Num ~$1));
+        Types.Stack_item.Z (Plain_old_data (Address "test"));
+      ]
+    ~expected_output:
+      [
+        Z (Plain_old_data (String "test"));
+        Z (Plain_old_data (Num ~$1));
+        Z (Plain_old_data (Address "test"));
+      ]
+
 let main =
   let open Test_helpers in
   test_suite "Zinc tests"
     [
+      test_w "bytes_unpack" pack_and_unpack;
       test_w "simple1" simple_1;
       test_w "simple2" simple_2;
       test_w "simple3" simple_3;

--- a/zinc/lib/zinc_types/Zinc_types.ml
+++ b/zinc/lib/zinc_types/Zinc_types.ml
@@ -72,7 +72,7 @@ module Make (D : Domain_types) = struct
       | MatchVariant of (variant_label * t) list
     [@@deriving show {with_path = false}, eq, yojson]
 
-    and operation = Eq | Add | Cons | HashKey | Or | And | Not
+    and operation = Eq | Add | Cons | HashKey | Or | And | Not | Pack | Unpack
     [@@deriving show {with_path = false}, eq, yojson]
 
     and domain_specific_operation = ChainID | Contract_opt | MakeTransaction

--- a/zinc/lib/zinc_types/zinc_types_intf.ml
+++ b/zinc/lib/zinc_types/zinc_types_intf.ml
@@ -166,7 +166,7 @@ module type S = sig
       | MakeVariant of variant_label
       | MatchVariant of (variant_label * t) list
 
-    and operation = Eq | Add | Cons | HashKey | Or | And | Not
+    and operation = Eq | Add | Cons | HashKey | Or | And | Not | Pack | Unpack
 
     and domain_specific_operation = ChainID | Contract_opt | MakeTransaction
 


### PR DESCRIPTION
## Problem

We need to add Bytes.{pack/unpack} to zinc

## Solution

add a yojson encoding for now, after this we could probably add internal specialized encoding and aligning with tezos for external interactions
## Related

- #300
 