### PR TITLE
Split address into implicit and contract address

### DIFF
--- a/src/bin/files.re
+++ b/src/bin/files.re
@@ -1,7 +1,6 @@
 open Helpers;
 open Node;
 open State;
-open Core;
 
 exception Invalid_json(string);
 let read_json = (of_yojson, ~file) => {
@@ -26,7 +25,7 @@ module Identity = {
 module Wallet = {
   [@deriving yojson]
   type t = {
-    address: Address.t,
+    address: Crypto.Key_hash.t,
     priv_key: Crypto.Secret.t,
   };
   let read = read_json(of_yojson);
@@ -35,7 +34,7 @@ module Wallet = {
 module Validators = {
   [@deriving yojson]
   type t = {
-    address: Address.t,
+    address: Crypto.Key_hash.t,
     uri: Uri.t,
   };
   let read =

--- a/src/bin/files.rei
+++ b/src/bin/files.rei
@@ -1,4 +1,3 @@
-open Core;
 open Node;
 open State;
 
@@ -11,7 +10,7 @@ module Identity: {
 
 module Wallet: {
   type t = {
-    address: Address.t,
+    address: Crypto.Key_hash.t,
     priv_key: Crypto.Secret.t,
   };
   let read: (~file: string) => Lwt.t(t);
@@ -19,8 +18,9 @@ module Wallet: {
 };
 
 module Validators: {
-  let read: (~file: string) => Lwt.t(list((Address.t, Uri.t)));
-  let write: (list((Address.t, Uri.t)), ~file: string) => Lwt.t(unit);
+  let read: (~file: string) => Lwt.t(list((Crypto.Key_hash.t, Uri.t)));
+  let write:
+    (list((Crypto.Key_hash.t, Uri.t)), ~file: string) => Lwt.t(unit);
 };
 
 module Interop_context: {

--- a/src/bin/node_state.re
+++ b/src/bin/node_state.re
@@ -1,5 +1,4 @@
 open Helpers;
-open Core;
 open Protocol;
 open Node;
 
@@ -27,7 +26,7 @@ let get_initial_state = (~folder) => {
       current_validators
       |> List.mapi((i, validator) => {
            (
-             Address.of_key_hash(validator),
+             validator,
              Printf.sprintf("http://localhost:444%d", i) |> Uri.of_string,
            )
          })

--- a/src/bin/sidecli.re
+++ b/src/bin/sidecli.re
@@ -157,12 +157,13 @@ let info_create_wallet = {
 };
 
 let create_wallet = () => {
-  let (key, address) = Address.Implicit.make();
+  let (secret, _key, key_hash) = Key_hash.make_ed25519();
 
-  let address_string = Address.to_string(address |> Address.of_key_hash);
+  let address_string = Address.to_string(key_hash |> Address.of_key_hash);
   let file = make_filename_from_address(address_string);
 
-  let.await () = Files.Wallet.write({priv_key: key, address}, ~file);
+  let.await () =
+    Files.Wallet.write({priv_key: secret, address: key_hash}, ~file);
   await(`Ok());
 };
 
@@ -543,7 +544,7 @@ let setup_identity = (node_folder, uri) => {
 
   let identity = {
     let (secret, key) = Crypto.Ed25519.generate();
-    let t = Address.Implicit.of_key(Ed25519(key));
+    let t = Key_hash.of_key(Ed25519(key));
     {uri, t, key: Ed25519(key), secret: Ed25519(secret)};
   };
   let.await () = write_identity(~node_folder, identity);

--- a/src/core/address.re
+++ b/src/core/address.re
@@ -1,23 +1,62 @@
 open Crypto;
-open Key_hash;
+open Helpers;
 
-[@deriving (eq, ord)]
-type t = Key_hash.t;
+module Implicit = {
+  open Key_hash;
 
-let of_key = of_key;
-let matches_key = (key, t) => equal(of_key(key), t);
+  let of_key = of_key;
+  let matches_key = (key, t) => equal(of_key(key), t);
 
-let make = () => {
-  let (key, pub_) = Ed25519.generate();
-  let wallet_address = of_key(Ed25519(pub_));
+  let make = () => {
+    let (key, pub_) = Ed25519.generate();
+    let wallet_address = of_key(Ed25519(pub_));
 
-  (Secret.Ed25519(key), wallet_address);
+    (Secret.Ed25519(key), wallet_address);
+  };
 };
-let to_key_hash = t => t;
-let of_key_hash = t => t;
 
-let to_string = to_string;
-let of_string = of_string;
+module Originated = {
+  open Tezos.Contract_hash;
+  type nonrec t = t;
 
-let to_yojson = to_yojson;
-let of_yojson = of_yojson;
+  let to_contract_hash = t => t;
+  let of_contract_hash = t => t;
+
+  let to_string = to_string;
+  let of_string = of_string;
+
+  let to_yojson = to_yojson;
+  let of_yojson = of_yojson;
+
+  let compare = compare;
+};
+
+[@deriving (yojson, ord)]
+type t =
+  | Implicit(Key_hash.t)
+  | Originated(Originated.t);
+
+let of_key_hash = implicit => Implicit(implicit);
+let to_key_hash = t =>
+  switch (t) {
+  | Implicit(implicit) => Some(implicit)
+  | _ => None
+  };
+
+let to_string =
+  fun
+  | Implicit(implicit) => Key_hash.to_string(implicit)
+  | Originated(contract_hash) =>
+    Tezos.Contract_hash.to_string(contract_hash);
+
+let of_string = {
+  let implicit = string => {
+    let.some key_hash = Key_hash.of_string(string);
+    Some(Implicit(key_hash));
+  };
+  let contract = string => {
+    let.some contract_hash = Tezos.Contract_hash.of_string(string);
+    Some(Originated(contract_hash));
+  };
+  Encoding_helpers.parse_string_variant([implicit, contract]);
+};

--- a/src/core/address.re
+++ b/src/core/address.re
@@ -16,22 +16,13 @@ module Implicit = {
 };
 
 module Originated = {
-  open Tezos.Contract_hash;
-  type nonrec t = t;
+  include Tezos.Contract_hash;
 
   let to_contract_hash = t => t;
   let of_contract_hash = t => t;
-
-  let to_string = to_string;
-  let of_string = of_string;
-
-  let to_yojson = to_yojson;
-  let of_yojson = of_yojson;
-
-  let compare = compare;
 };
 
-[@deriving (yojson, ord)]
+[@deriving (eq, ord, yojson)]
 type t =
   | Implicit(Key_hash.t)
   | Originated(Originated.t);

--- a/src/core/address.re
+++ b/src/core/address.re
@@ -1,31 +1,10 @@
 open Crypto;
 open Helpers;
 
-module Implicit = {
-  open Key_hash;
-
-  let of_key = of_key;
-  let matches_key = (key, t) => equal(of_key(key), t);
-
-  let make = () => {
-    let (key, pub_) = Ed25519.generate();
-    let wallet_address = of_key(Ed25519(pub_));
-
-    (Secret.Ed25519(key), wallet_address);
-  };
-};
-
-module Originated = {
-  include Tezos.Contract_hash;
-
-  let to_contract_hash = t => t;
-  let of_contract_hash = t => t;
-};
-
 [@deriving (eq, ord, yojson)]
 type t =
   | Implicit(Key_hash.t)
-  | Originated(Originated.t);
+  | Originated(Tezos.Contract_hash.t);
 
 let of_key_hash = implicit => Implicit(implicit);
 let to_key_hash = t =>
@@ -33,6 +12,13 @@ let to_key_hash = t =>
   | Implicit(implicit) => Some(implicit)
   | _ => None
   };
+
+let to_contract_hash = t =>
+  switch (t) {
+  | Implicit(_key_hash) => None
+  | Originated(contract_hash) => Some(contract_hash)
+  };
+let of_contract_hash = contract_hash => Originated(contract_hash);
 
 let to_string =
   fun

--- a/src/core/address.rei
+++ b/src/core/address.rei
@@ -1,28 +1,15 @@
 open Crypto;
 
 [@deriving (eq, ord, yojson)]
+// TODO: why is this type abstract?
 type t;
-
-module Implicit: {
-  let matches_key: (Key.t, Key_hash.t) => bool;
-
-  let of_key: Key.t => Key_hash.t;
-  let make: unit => (Secret.t, Key_hash.t);
-};
-
-module Originated: {
-  [@deriving (ord, yojson)]
-  type t;
-
-  let to_contract_hash: t => Tezos.Contract_hash.t;
-  let of_contract_hash: Tezos.Contract_hash.t => t;
-
-  let to_string: t => string;
-  let of_string: string => option(t);
-};
 
 let of_key_hash: Key_hash.t => t;
 let to_key_hash: t => option(Key_hash.t);
+
+/* TOOD: this should not be Tezos.Contract_hash.t */
+let of_contract_hash: Tezos.Contract_hash.t => t;
+let to_contract_hash: t => option(Tezos.Contract_hash.t);
 
 let to_string: t => string;
 let of_string: string => option(t);

--- a/src/core/address.rei
+++ b/src/core/address.rei
@@ -1,16 +1,28 @@
 open Crypto;
 
-[@deriving (eq, ord, yojson)]
+[@deriving (ord, yojson)]
 type t;
 
-let matches_key: (Key.t, t) => bool;
+module Implicit: {
+  let matches_key: (Key.t, Key_hash.t) => bool;
 
-let make: unit => (Secret.t, t);
+  let of_key: Key.t => Key_hash.t;
+  let make: unit => (Secret.t, Key_hash.t);
+};
 
-let of_key: Key.t => t;
+module Originated: {
+  [@deriving (ord, yojson)]
+  type t;
 
-let to_key_hash: t => Key_hash.t;
+  let to_contract_hash: t => Tezos.Contract_hash.t;
+  let of_contract_hash: Tezos.Contract_hash.t => t;
+
+  let to_string: t => string;
+  let of_string: string => option(t);
+};
+
 let of_key_hash: Key_hash.t => t;
+let to_key_hash: t => option(Key_hash.t);
 
 let to_string: t => string;
 let of_string: string => option(t);

--- a/src/core/address.rei
+++ b/src/core/address.rei
@@ -1,6 +1,6 @@
 open Crypto;
 
-[@deriving (ord, yojson)]
+[@deriving (eq, ord, yojson)]
 type t;
 
 module Implicit: {

--- a/src/core/ledger.re
+++ b/src/core/ledger.re
@@ -4,7 +4,7 @@ open Crypto;
 module Address_and_ticket_map = {
   [@deriving (ord, yojson)]
   type key = {
-    address: Address.t,
+    address: Key_hash.t,
     ticket: Ticket_id.t,
   };
   module Map =

--- a/src/core/ledger.rei
+++ b/src/core/ledger.rei
@@ -15,16 +15,16 @@ module Handle: {
 [@deriving yojson]
 type t;
 let empty: t;
-let balance: (Address.t, Ticket_id.t, t) => Amount.t;
+let balance: (Key_hash.t, Ticket_id.t, t) => Amount.t;
 let transfer:
-  (~sender: Address.t, ~destination: Address.t, Amount.t, Ticket_id.t, t) =>
+  (~sender: Key_hash.t, ~destination: Key_hash.t, Amount.t, Ticket_id.t, t) =>
   result(t, [> | `Not_enough_funds]);
 
 // on chain ops
-let deposit: (Address.t, Amount.t, Ticket_id.t, t) => t;
+let deposit: (Key_hash.t, Amount.t, Ticket_id.t, t) => t;
 let withdraw:
   (
-    ~sender: Address.t,
+    ~sender: Key_hash.t,
     ~destination: Tezos.Address.t,
     Amount.t,
     Ticket_id.t,

--- a/src/core/user_operation.re
+++ b/src/core/user_operation.re
@@ -4,7 +4,7 @@ open Crypto;
 [@deriving yojson]
 type initial_operation =
   | Transaction({
-      destination: Address.t,
+      destination: Key_hash.t,
       amount: Amount.t,
       ticket: Ticket_id.t,
     })

--- a/src/core/user_operation.rei
+++ b/src/core/user_operation.rei
@@ -2,7 +2,7 @@ open Crypto;
 
 type initial_operation =
   | Transaction({
-      destination: Address.t,
+      destination: Key_hash.t,
       amount: Amount.t,
       ticket: Ticket_id.t,
     })

--- a/src/crypto/key_hash.re
+++ b/src/crypto/key_hash.re
@@ -11,6 +11,14 @@ let of_key =
   | Key.Ed25519(key) => Ed25519(Ed25519.Key_hash.of_key(key))
   | Key.Secp256k1(key) => Secp256k1(Secp256k1.Key_hash.of_key(key))
   | Key.P256(key) => P256(P256.Key_hash.of_key(key));
+let matches_key = (key, t) => equal(of_key(key), t);
+
+let make_ed25519 = () => {
+  let (secret, key) = Ed25519.generate();
+  let key_hash = Ed25519.Key_hash.of_key(key);
+  (Secret.Ed25519(secret), Key.Ed25519(key), Ed25519(key_hash));
+};
+
 let to_string =
   fun
   | Ed25519(key_hash) => Ed25519.Key_hash.to_string(key_hash)

--- a/src/crypto/key_hash.rei
+++ b/src/crypto/key_hash.rei
@@ -5,6 +5,9 @@ type t =
   | P256(P256.Key_hash.t);
 
 let of_key: Key.t => t;
+let matches_key: (Key.t, t) => bool;
+
+let make_ed25519: unit => (Secret.t, Key.t, t);
 
 let encoding: Data_encoding.t(t);
 let to_string: t => string;

--- a/src/node/flows.re
+++ b/src/node/flows.re
@@ -216,9 +216,7 @@ let try_to_commit_state_hash = (~prev_validators, state, block, signatures) => {
   let validators =
     state.protocol.validators
     |> Validators.to_list
-    |> List.map(validator =>
-         Core.Address.to_key_hash(validator.Validators.address)
-       );
+    |> List.map(validator => validator.Validators.address);
   let signatures =
     prev_validators
     |> Validators.to_list
@@ -554,7 +552,7 @@ let trusted_validators_membership = (state, update_state, request) => {
     payload |> payload_to_yojson |> Yojson.Safe.to_string |> BLAKE2B.hash;
   let.assert () = (
     `Invalid_signature_author,
-    Core.Address.compare(state.Node.identity.t, Signature.address(signature))
+    Key_hash.compare(state.Node.identity.t, Signature.address(signature))
     == 0,
   );
   let.assert () = (

--- a/src/node/networking.re
+++ b/src/node/networking.re
@@ -188,7 +188,7 @@ module Withdraw_proof = {
 module Ticket_balance = {
   [@deriving yojson]
   type request = {
-    address: Address.t,
+    address: Key_hash.t,
     ticket: Ticket_id.t,
   };
   [@deriving yojson]
@@ -204,7 +204,7 @@ module Trusted_validators_membership_change = {
   [@deriving yojson]
   type payload = {
     action,
-    address: Address.t,
+    address: Key_hash.t,
   };
   [@deriving yojson]
   type request = {

--- a/src/node/state.re
+++ b/src/node/state.re
@@ -1,17 +1,16 @@
 open Helpers;
 open Crypto;
 open Protocol;
-open Core;
 
 [@deriving yojson]
 type identity = {
   secret: Secret.t,
   key: Key.t,
-  t: Address.t,
+  t: Key_hash.t,
   uri: Uri.t,
 };
 
-module Address_map = Map.Make(Address);
+module Address_map = Map.Make(Key_hash);
 module Uri_map = Map.Make(Uri);
 
 type t = {

--- a/src/node/state.rei
+++ b/src/node/state.rei
@@ -1,16 +1,15 @@
 open Crypto;
 open Protocol;
-open Core;
 
 [@deriving yojson]
 type identity = {
   secret: Secret.t,
   key: Key.t,
-  t: Address.t,
+  t: Key_hash.t,
   uri: Uri.t,
 };
 
-module Address_map: Map.S with type key = Address.t;
+module Address_map: Map.S with type key = Key_hash.t;
 module Uri_map: Map.S with type key = Uri.t;
 
 type t = {

--- a/src/node/trusted_validators_membership_change.re
+++ b/src/node/trusted_validators_membership_change.re
@@ -1,5 +1,3 @@
-open Core;
-
 [@deriving (yojson, ord)]
 type action =
   | Add
@@ -8,7 +6,7 @@ type action =
 [@deriving (yojson, ord)]
 type t = {
   action,
-  address: Address.t,
+  address: Crypto.Key_hash.t,
 };
 
 module Set =

--- a/src/protocol/block.re
+++ b/src/protocol/block.re
@@ -17,7 +17,7 @@ type t = {
   validators_hash: BLAKE2B.t,
   previous_hash: BLAKE2B.t,
   // block data
-  author: Address.t,
+  author: Key_hash.t,
   // TODO: do we need a block_height? What is the tradeoffs?
   // TODO: maybe it should be only for internal pagination and stuff like this
   block_height: int64,
@@ -46,7 +46,7 @@ let (hash, verify) = {
         BLAKE2B.t,
         BLAKE2B.t,
         // block data
-        Address.t,
+        Key_hash.t,
         int64,
         list(Protocol_operation.t),
       )
@@ -153,7 +153,7 @@ let genesis =
     ~validators_hash=Validators.hash(Validators.empty),
     ~block_height=0L,
     ~operations=[],
-    ~author=Address.of_key(Wallet.genesis_wallet),
+    ~author=Address.Implicit.of_key(Wallet.genesis_wallet),
   );
 
 let produce = (~state, ~next_state_root_hash) => {

--- a/src/protocol/block.re
+++ b/src/protocol/block.re
@@ -153,7 +153,7 @@ let genesis =
     ~validators_hash=Validators.hash(Validators.empty),
     ~block_height=0L,
     ~operations=[],
-    ~author=Address.Implicit.of_key(Wallet.genesis_wallet),
+    ~author=Key_hash.of_key(Wallet.genesis_wallet),
   );
 
 let produce = (~state, ~next_state_root_hash) => {

--- a/src/protocol/block.rei
+++ b/src/protocol/block.rei
@@ -1,5 +1,4 @@
 open Crypto;
-open Core;
 
 [@deriving (yojson, ord)]
 type t =
@@ -10,7 +9,7 @@ type t =
     handles_hash: BLAKE2B.t,
     validators_hash: BLAKE2B.t,
     previous_hash: BLAKE2B.t,
-    author: Address.t,
+    author: Key_hash.t,
     block_height: int64,
     operations: list(Protocol_operation.t),
   };
@@ -22,7 +21,7 @@ let produce:
   (
     ~state: Protocol_state.t,
     ~next_state_root_hash: option(BLAKE2B.t),
-    ~author: Address.t,
+    ~author: Key_hash.t,
     ~operations: list(Protocol_operation.t)
   ) =>
   t;

--- a/src/protocol/protocol_operation.re
+++ b/src/protocol/protocol_operation.re
@@ -56,7 +56,7 @@ module Core_user = {
     open User_operation;
     let key = Key.of_secret(secret);
     switch (Address.to_key_hash(data.sender)) {
-    | Some(sender) when Address.Implicit.matches_key(key, sender) =>
+    | Some(sender) when Key_hash.matches_key(key, sender) =>
       let hash = hash(~nonce, ~block_height, ~data);
       let signature = Signature.sign(secret, hash);
       {hash, key, signature, nonce, block_height, data};
@@ -82,7 +82,7 @@ module Core_user = {
 
     let.assert () = (
       "Invalid core_user key",
-      Address.Implicit.matches_key(key, sender),
+      Key_hash.matches_key(key, sender),
     );
     let.assert () = (
       "Invalid core_user signature",

--- a/src/protocol/protocol_signature.re
+++ b/src/protocol/protocol_signature.re
@@ -7,7 +7,7 @@ type t = {
   // TODO: what is the name of a signature?
   signature: Signature.t,
   public_key: Wallet.t,
-  address: Address.t,
+  address: Key_hash.t,
 };
 let public_key = t => t.public_key;
 let address = t => t.address;
@@ -29,7 +29,7 @@ let (to_yojson, of_yojson) = {
     });
   let of_yojson = json => {
     let.ok {signature, public_key} = Serialized_data.of_yojson(json);
-    let address = Address.of_key(public_key);
+    let address = Address.Implicit.of_key(public_key);
     Ok({signature, public_key, address});
   };
   (to_yojson, of_yojson);
@@ -38,7 +38,7 @@ let (to_yojson, of_yojson) = {
 let sign = (~key as secret, hash) => {
   let signature = Signature.sign(secret, hash);
   let public_key = Key.of_secret(secret);
-  let address = Address.of_key(public_key);
+  let address = Address.Implicit.of_key(public_key);
   {signature, public_key, address};
 };
 let verify = (~signature, hash) =>

--- a/src/protocol/protocol_signature.re
+++ b/src/protocol/protocol_signature.re
@@ -1,6 +1,5 @@
 open Helpers;
 open Crypto;
-open Core;
 
 [@deriving ord]
 type t = {
@@ -29,7 +28,7 @@ let (to_yojson, of_yojson) = {
     });
   let of_yojson = json => {
     let.ok {signature, public_key} = Serialized_data.of_yojson(json);
-    let address = Address.Implicit.of_key(public_key);
+    let address = Key_hash.of_key(public_key);
     Ok({signature, public_key, address});
   };
   (to_yojson, of_yojson);
@@ -38,7 +37,7 @@ let (to_yojson, of_yojson) = {
 let sign = (~key as secret, hash) => {
   let signature = Signature.sign(secret, hash);
   let public_key = Key.of_secret(secret);
-  let address = Address.Implicit.of_key(public_key);
+  let address = Key_hash.of_key(public_key);
   {signature, public_key, address};
 };
 let verify = (~signature, hash) =>

--- a/src/protocol/protocol_signature.rei
+++ b/src/protocol/protocol_signature.rei
@@ -1,11 +1,10 @@
 open Crypto;
-open Core;
 
 [@deriving yojson]
 type t;
 let compare: (t, t) => int;
 let public_key: t => Wallet.t;
-let address: t => Address.t;
+let address: t => Key_hash.t;
 let signature: t => Signature.t;
 
 let sign: (~key: Secret.t, BLAKE2B.t) => t;

--- a/src/protocol/validators.re
+++ b/src/protocol/validators.re
@@ -1,10 +1,9 @@
 open Helpers;
 open Crypto;
-open Core;
 
 // TODO: we should avoid dead validators to avoid double timeout, A(dead) -> B(dead) -> C
 [@deriving (eq, ord, yojson)]
-type validator = {address: Address.t};
+type validator = {address: Key_hash.t};
 
 [@deriving yojson]
 type t = {
@@ -38,7 +37,7 @@ let update_current = (address, t) => {
 
 let hash_validators = validators => {
   validators
-  |> List.map(validator => validator.address |> Address.to_key_hash)
+  |> List.map(validator => validator.address)
   |> Tezos.Deku.Consensus.hash_validators;
 };
 let empty = {

--- a/src/protocol/validators.rei
+++ b/src/protocol/validators.rei
@@ -1,8 +1,7 @@
 open Crypto;
-open Core;
 
 [@deriving (eq, ord, yojson)]
-type validator = {address: Address.t};
+type validator = {address: Key_hash.t};
 
 [@deriving yojson]
 type t;
@@ -17,7 +16,7 @@ let length: t => int;
   best: O(1)
   worst: O(n) */
 let after_current: (int, t) => option(validator);
-let update_current: (Address.t, t) => t;
+let update_current: (Key_hash.t, t) => t;
 
 let empty: t;
 let add: (validator, t) => t;

--- a/tests/test_ledger.re
+++ b/tests/test_ledger.re
@@ -27,7 +27,10 @@ describe("ledger", ({test, _}) => {
       };
     Ticket_id.{ticketer, data};
   };
-  let make_address = () => snd(Address.Implicit.make());
+  let make_address = () => {
+    let (_secret, _key, key_hash) = Key_hash.make_ed25519();
+    key_hash;
+  };
   let make_tezos_address = () => {
     open Crypto;
     open Tezos;

--- a/tests/test_ledger.re
+++ b/tests/test_ledger.re
@@ -27,7 +27,7 @@ describe("ledger", ({test, _}) => {
       };
     Ticket_id.{ticketer, data};
   };
-  let make_address = () => snd(Address.make());
+  let make_address = () => snd(Address.Implicit.make());
   let make_tezos_address = () => {
     open Crypto;
     open Tezos;

--- a/tests/test_validators.re
+++ b/tests/test_validators.re
@@ -7,7 +7,7 @@ describe("validators", ({test, _}) => {
   let make_validator = () => {
     open Crypto;
     let (_key, wallet) = Ed25519.generate();
-    let address = Address.of_key(Ed25519(wallet));
+    let address = Address.Implicit.of_key(Ed25519(wallet));
     Validators.{address: address};
   };
   let setup_two = () => {

--- a/tests/test_validators.re
+++ b/tests/test_validators.re
@@ -1,13 +1,12 @@
 open Setup;
 open Protocol;
-open Core;
 open Validators;
 
 describe("validators", ({test, _}) => {
   let make_validator = () => {
     open Crypto;
     let (_key, wallet) = Ed25519.generate();
-    let address = Address.Implicit.of_key(Ed25519(wallet));
+    let address = Key_hash.of_key(Ed25519(wallet));
     Validators.{address: address};
   };
   let setup_two = () => {


### PR DESCRIPTION
## Depends

- [x] #396 

## Problem

Currently, address is assumed to be an implicit address. But now that we're adding contracts, an 'address' could also be a contract address. But most places of the code that talk about addresses currently really mean to talk about implicit addresses. 

## Solution

Move `Protocol.Address` into `Protocol.Address.Implicit`. Then, almost everywhere that currently references `Protocol.Address` should now reference `Protocol.Address.Implicit`. 