### PR TITLE
change variants representation

### DIFF
--- a/ligolang/src/test/contracts/custom_variant_matching.mligo
+++ b/ligolang/src/test/contracts/custom_variant_matching.mligo
@@ -1,0 +1,11 @@
+type my_option = B of unit | A | C of string
+
+let a = C "test"
+
+let b = A
+
+let c () =
+  match b with
+    C _ -> 0
+  | A -> 1
+  | _ -> 2

--- a/ligolang/src/test/zinc_tests.ml
+++ b/ligolang/src/test/zinc_tests.ml
@@ -316,8 +316,7 @@ let get_contract_opt =
     ~expected_output:
       [
         Types.Stack_item.Variant
-          ( "Some",
-            Types.Stack_item.NonliteralValue (Contract ("whatever", None)) );
+          (0, Types.Stack_item.NonliteralValue (Contract ("whatever", None)));
       ]
 
 let match_on_sum =
@@ -333,16 +332,15 @@ let match_on_sum =
           Core (Access 0);
           Adt
             (MatchVariant
-               [
-                 ("Some", [ Core Grab; Core (Access 0); Core Return ]);
-                 ( "None",
-                   [
-                     Core Grab;
-                     Plain_old_data (String "Not a contract");
-                     Control_flow Failwith;
-                     Core Return;
-                   ] );
-               ]);
+               [|
+                 [ Core Grab; Core (Access 0); Core Return ];
+                 [
+                   Core Grab;
+                   Plain_old_data (String "Not a contract");
+                   Control_flow Failwith;
+                   Core Return;
+                 ];
+               |]);
         ] );
     ]
     ~expected_output:
@@ -409,30 +407,28 @@ let nontail_match =
           Plain_old_data (Num ~$4);
           Core Grab;
           Plain_old_data (Num ~$3);
-          Adt (MakeVariant "Some");
+          Adt (MakeVariant 0);
           Core Grab;
           Core (Access 0);
           Core Grab;
           Core (Access 0);
           Adt
             (MatchVariant
-               [
-                 ( "Some",
-                   [
-                     Core Grab;
-                     Plain_old_data (Num ~$5);
-                     Core (Access 0);
-                     Operation Add;
-                     Core EndLet;
-                   ] );
-                 ( "None",
-                   [
-                     Core Grab;
-                     Plain_old_data (String "should be some >:(");
-                     Control_flow Failwith;
-                     Core EndLet;
-                   ] );
-               ]);
+               [|
+                 [
+                   Core Grab;
+                   Plain_old_data (Num ~$5);
+                   Core (Access 0);
+                   Operation Add;
+                   Core EndLet;
+                 ];
+                 [
+                   Core Grab;
+                   Plain_old_data (String "should be some >:(");
+                   Control_flow Failwith;
+                   Core EndLet;
+                 ];
+               |]);
           Core EndLet;
           Core Grab;
           Core (Access 2);
@@ -457,16 +453,15 @@ let create_transaction =
           Core (Access 0);
           Adt
             (MatchVariant
-               [
-                 ("Some", [ Core Grab; Core (Access 0); Core EndLet ]);
-                 ( "None",
-                   [
-                     Core Grab;
-                     Plain_old_data (String "Not a contract");
-                     Control_flow Failwith;
-                     Core EndLet;
-                   ] );
-               ]);
+               [|
+                 [ Core Grab; Core (Access 0); Core EndLet ];
+                 [
+                   Core Grab;
+                   Plain_old_data (String "Not a contract");
+                   Control_flow Failwith;
+                   Core EndLet;
+                 ];
+               |]);
           Core EndLet;
           Core Grab;
           Core (Access 0);
@@ -498,16 +493,15 @@ let create_transaction_in_tuple =
           Core (Access 0);
           Adt
             (MatchVariant
-               [
-                 ("Some", [ Core Grab; Core (Access 0); Core EndLet ]);
-                 ( "None",
-                   [
-                     Core Grab;
-                     Plain_old_data (String "Not a contract");
-                     Control_flow Failwith;
-                     Core EndLet;
-                   ] );
-               ]);
+               [|
+                 [ Core Grab; Core (Access 0); Core EndLet ];
+                 [
+                   Core Grab;
+                   Plain_old_data (String "Not a contract");
+                   Control_flow Failwith;
+                   Core EndLet;
+                 ];
+               |]);
           Core EndLet;
           Core Grab;
           Plain_old_data (String "my string");
@@ -586,10 +580,10 @@ let bools_religo =
           Core (Access 0);
           Adt
             (MatchVariant
-               [
-                 ("False", [ Core Grab; Core (Access 3); Core Return ]);
-                 ("True", [ Core Grab; Core (Access 4); Core Return ]);
-               ]);
+               [|
+                 [ Core Grab; Core (Access 3); Core Return ];
+                 [ Core Grab; Core (Access 4); Core Return ];
+               |]);
         ] );
     ]
     ~expected_output:[ Types.Stack_item.Z (Plain_old_data (Bool false)) ]
@@ -618,10 +612,10 @@ let bools_ligo =
           Core (Access 0);
           Adt
             (MatchVariant
-               [
-                 ("False", [ Core Grab; Core (Access 3); Core Return ]);
-                 ("True", [ Core Grab; Core (Access 4); Core Return ]);
-               ]);
+               [|
+                 [ Core Grab; Core (Access 3); Core Return ];
+                 [ Core Grab; Core (Access 4); Core Return ];
+               |]);
         ] );
     ]
     ~expected_output:[ Types.Stack_item.Z (Plain_old_data (Bool false)) ]
@@ -795,17 +789,16 @@ let if_then_else =
           Core (Access 0);
           Adt
             (MatchVariant
-               [
-                 ("False", [ Core Grab; Core (Access 2); Core Return ]);
-                 ( "True",
-                   [
-                     Core Grab;
-                     Plain_old_data (Num ~$2);
-                     Core (Access 3);
-                     Operation Add;
-                     Core Return;
-                   ] );
-               ]);
+               [|
+                 [ Core Grab; Core (Access 2); Core Return ];
+                 [
+                   Core Grab;
+                   Plain_old_data (Num ~$2);
+                   Core (Access 3);
+                   Operation Add;
+                   Core Return;
+                 ];
+               |]);
         ] );
     ]
     ~expected_output:[ Types.Stack_item.Z (Plain_old_data (Num ~$4)) ]
@@ -835,10 +828,10 @@ let if_then_else_op =
           Core (Access 0);
           Adt
             (MatchVariant
-               [
-                 ("False", [ Core Grab; Core (Access 2); Core Return ]);
-                 ("True", [ Core Grab; Core (Access 3); Core Return ]);
-               ]);
+               [|
+                 [ Core Grab; Core (Access 2); Core Return ];
+                 [ Core Grab; Core (Access 3); Core Return ];
+               |]);
         ] );
     ]
     ~expected_output:[ Types.Stack_item.Z (Plain_old_data (Num ~$2)) ]
@@ -879,10 +872,10 @@ let if_then_else_op_function =
           Core (Access 0);
           Adt
             (MatchVariant
-               [
-                 ("False", [ Core Grab; Core (Access 7); Core Return ]);
-                 ("True", [ Core Grab; Core (Access 8); Core Return ]);
-               ]);
+               [|
+                 [ Core Grab; Core (Access 7); Core Return ];
+                 [ Core Grab; Core (Access 8); Core Return ];
+               |]);
         ] );
     ]
     ~initial_stack:
@@ -897,16 +890,16 @@ let if_then_else_op_function =
 let make_an_option =
   expect_simple_compile_to ~dialect:ReasonLIGO "make_an_option"
     [
-      ("a", [ Adt (MakeRecord 0); Adt (MakeVariant "None"); Core Return ]);
+      ("a", [ Adt (MakeRecord 0); Adt (MakeVariant 1); Core Return ]);
       ( "b",
         [
           Adt (MakeRecord 0);
           (* constructing None, from the definition of a *)
-          Adt (MakeVariant "None");
+          Adt (MakeVariant 1);
           Core Grab;
           Adt (MakeRecord 0);
           (* constructing Some *)
-          Adt (MakeVariant "Some");
+          Adt (MakeVariant 0);
           Core Return;
         ] );
     ]
@@ -914,16 +907,16 @@ let make_an_option =
 let make_a_custom_option =
   expect_simple_compile_to ~dialect:ReasonLIGO "make_a_custom_option"
     [
-      ("a", [ Adt (MakeRecord 0); Adt (MakeVariant "My_none"); Core Return ]);
+      ("a", [ Adt (MakeRecord 0); Adt (MakeVariant 0); Core Return ]);
       ( "b",
         [
           Adt (MakeRecord 0);
           (* constructing My_none, from the definition of a *)
-          Adt (MakeVariant "My_none");
+          Adt (MakeVariant 0);
           Core Grab;
           Adt (MakeRecord 0);
           (* constructing Some *)
-          Adt (MakeVariant "My_some");
+          Adt (MakeVariant 1);
           Core Return;
         ] );
     ]
@@ -945,6 +938,45 @@ let top_level_let_dependencies =
           Core Return;
         ] );
     ]
+
+let custom_variant_matching =
+  let open Z in
+  expect_simple_compile_to ~dialect:CameLIGO "custom_variant_matching"
+    [
+      ("a", [ Plain_old_data (String "test"); Adt (MakeVariant 2); Core Return ]);
+      ( "b",
+        [
+          Plain_old_data (String "test");
+          Adt (MakeVariant 2);
+          Core Grab;
+          Adt (MakeRecord 0);
+          Adt (MakeVariant 0);
+          Core Return;
+        ] );
+      ( "c",
+        [
+          Plain_old_data (String "test");
+          Adt (MakeVariant 2);
+          Core Grab;
+          Adt (MakeRecord 0);
+          Adt (MakeVariant 0);
+          Core Grab;
+          Core Grab;
+          Core (Access 1);
+          Core Grab;
+          Core (Access 0);
+          Adt
+            (MatchVariant
+               [|
+                 [ Core Grab; Plain_old_data (Num ~$1); Core Return ];
+                 [ Core Grab; Plain_old_data (Num ~$2); Core Return ];
+                 [ Core Grab; Plain_old_data (Num ~$0); Core Return ];
+               |]);
+        ] );
+    ]
+    ~expected_output:[ Z (Plain_old_data (Num ~$1)) ]
+    ~initial_stack:
+      [ Types.Stack_item.Z (Types.Zinc.Plain_old_data (Bool false)) ]
 
 let main =
   let open Test_helpers in
@@ -979,4 +1011,5 @@ let main =
       test_w "top_level_let_dependencies" top_level_let_dependencies;
       test_w "nontail_match" nontail_match;
       test_w "super_simple_contract" super_simple_contract;
+      test_w "custom_variant_matching" custom_variant_matching;
     ]

--- a/zinc/lib/zinc_interpreter/Zinc_interpreter.mli
+++ b/zinc/lib/zinc_interpreter/Zinc_interpreter.mli
@@ -28,6 +28,7 @@ module Make (D : Domain_types) : sig
       (module Executor) ->
       Types.Interpreter_input.t ->
       Types.Interpreter_output.t
+
   end
 end
 

--- a/zinc/lib/zinc_types/Zinc_types.ml
+++ b/zinc/lib/zinc_types/Zinc_types.ml
@@ -66,10 +66,10 @@ module Make (D : Domain_types) = struct
     [@@deriving show {with_path = false}, eq, yojson]
 
     and adt =
-      | MakeRecord of int
+      | MakeRecord of label
       | RecordAccess of label
-      | MakeVariant of variant_label
-      | MatchVariant of (variant_label * t) list
+      | MakeVariant of label
+      | MatchVariant of t LMap.t
     [@@deriving show {with_path = false}, eq, yojson]
 
     and operation = Eq | Add | Cons | HashKey | Or | And | Not
@@ -129,7 +129,7 @@ module Make (D : Domain_types) = struct
       | Clos of Clos.t
       | Record of Stack_item.t LMap.t
       | List of Stack_item.t list
-      | Variant of variant_label * Stack_item.t
+      | Variant of label * Stack_item.t
 
     include Zinc_types_intf.With_default_derivation with type t := t
   end = struct
@@ -139,7 +139,7 @@ module Make (D : Domain_types) = struct
       | Clos of Clos.t
       | Record of Stack_item.t LMap.t
       | List of Stack_item.t list
-      | Variant of variant_label * Stack_item.t
+      | Variant of label * Stack_item.t
     [@@deriving show {with_path = false}, eq, yojson]
 
     let to_string = show
@@ -152,7 +152,7 @@ module Make (D : Domain_types) = struct
       | Clos of Clos.t
       | Record of t LMap.t
       | List of t list
-      | Variant of variant_label * t
+      | Variant of label * t
       | Marker of Zinc.t * Env_item.t list
 
     include Zinc_types_intf.With_default_derivation with type t := t
@@ -163,7 +163,7 @@ module Make (D : Domain_types) = struct
       | Clos of Clos.t
       | Record of t LMap.t
       | List of t list
-      | Variant of variant_label * t
+      | Variant of label * t
       | Marker of Zinc.t * Env_item.t list
     [@@deriving show {with_path = false}, eq, yojson]
 

--- a/zinc/lib/zinc_types/zinc_types_intf.ml
+++ b/zinc/lib/zinc_types/zinc_types_intf.ml
@@ -161,10 +161,10 @@ module type S = sig
       | Chain_id of Chain_id.t
 
     and adt =
-      | MakeRecord of int
-      | RecordAccess of int
-      | MakeVariant of variant_label
-      | MatchVariant of (variant_label * t) list
+      | MakeRecord of label
+      | RecordAccess of label
+      | MakeVariant of label
+      | MatchVariant of t LMap.t
 
     and operation = Eq | Add | Cons | HashKey | Or | And | Not
 
@@ -206,9 +206,9 @@ module type S = sig
       | Z of Zinc.instruction
       | NonliteralValue of Zinc.nonliteral_value
       | Clos of Clos.t
-      | Record of Stack_item.t array
+      | Record of Stack_item.t LMap.t
       | List of Stack_item.t list
-      | Variant of string * Stack_item.t
+      | Variant of Zinc_utils.label * Stack_item.t
 
     include With_default_derivation with type t := t
   end
@@ -218,9 +218,9 @@ module type S = sig
       | Z of Zinc.instruction
       | NonliteralValue of Zinc.nonliteral_value
       | Clos of Clos.t
-      | Record of t array
+      | Record of t LMap.t
       | List of t list
-      | Variant of string * t
+      | Variant of Zinc_utils.label * t
       | Marker of Zinc.t * Env_item.t list
 
     include With_default_derivation with type t := t

--- a/zinc/lib/zinc_utils/Zinc_utils.ml
+++ b/zinc/lib/zinc_utils/Zinc_utils.ml
@@ -21,15 +21,14 @@ end
 
 type label = int [@@deriving show {with_path = false}, eq, yojson]
 
-type variant_label = string [@@deriving show {with_path = false}, eq, yojson]
-
 module LMap = struct
   type 'a t = 'a array [@@deriving yojson, ord, eq, show]
 
   let of_list (lst : 'a list) : 'a t = lst |> Array.of_list
 
   let find arr item =
-    try Some (Array.get arr item) with Invalid_argument _ -> None
+    try Array.get arr item
+    with Invalid_argument _ -> failwith "field not found"
 
   let add _k v array = Array.concat [array; [|v|]]
 

--- a/zinc/tests/test_sample.ml
+++ b/zinc/tests/test_sample.ml
@@ -1,4 +1,3 @@
-(*
 [@@@warning "-40"]
 
 module Zinc_types = Zinc_types.Raw
@@ -14,15 +13,15 @@ let zinc =
       Core (Access 0);
       Adt
         (MatchVariant
-           [
-             ("Some", [Core Grab; Core (Access 0)]);
-             ( "None",
+           [|
+             ( [Core Grab; Core (Access 0)]);
+             (
                [
                  Core Grab;
                  Plain_old_data (String "Not a contract");
                  Control_flow Failwith;
                ] );
-           ]);
+           |]);
       Core EndLet;
       Core Grab;
       Plain_old_data (String "my string");
@@ -51,170 +50,323 @@ let%expect_test _ =
   let open Zinc_interpreter.Dummy in
   let open Interpreter in
   let zinc = Types.Zinc.of_yojson zinc |> Result.get_ok in
-  let run_resutl =
-    try eval (module Executor) (initial_state zinc)
-    with Failure x -> Failure x
-  in
+  let run_resutl = eval (module Executor) (initial_state zinc) in
   Types.Interpreter_output.to_string run_resutl |> print_endline ;
   [%expect
     {|
-       interpreting:
-       code:  [(Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV));
-         (Core Grab); (Core (Access 0)); (Domain_specific_operation Contract_opt);
-         (Core Grab); (Core (Access 0));
-         (Adt
-            (MatchVariant
-               [("Some", [(Core Grab); (Core (Access 0))]);
-                 ("None",
-                  [(Core Grab); (Plain_old_data (String "Not a contract"));
-                    (Control_flow Failwith)])
-                 ]));
-         (Core EndLet); (Core Grab); (Plain_old_data (String "my string"));
-         (Plain_old_data
-            (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
-         (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
-         (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
-         (Core Return)]
-       env:   []
-       stack: []
-       interpreting:
-       code:  [(Core Grab); (Core (Access 0)); (Domain_specific_operation Contract_opt);
-         (Core Grab); (Core (Access 0));
-         (Adt
-            (MatchVariant
-               [("Some", [(Core Grab); (Core (Access 0))]);
-                 ("None",
-                  [(Core Grab); (Plain_old_data (String "Not a contract"));
-                    (Control_flow Failwith)])
-                 ]));
-         (Core EndLet); (Core Grab); (Plain_old_data (String "my string"));
-         (Plain_old_data
-            (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
-         (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
-         (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
-         (Core Return)]
-       env:   []
-       stack: [(Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
-       interpreting:
-       code:  [(Core (Access 0)); (Domain_specific_operation Contract_opt); (Core Grab);
-         (Core (Access 0));
-         (Adt
-            (MatchVariant
-               [("Some", [(Core Grab); (Core (Access 0))]);
-                 ("None",
-                  [(Core Grab); (Plain_old_data (String "Not a contract"));
-                    (Control_flow Failwith)])
-                 ]));
-         (Core EndLet); (Core Grab); (Plain_old_data (String "my string"));
-         (Plain_old_data
-            (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
-         (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
-         (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
-         (Core Return)]
-       env:   [(Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
-       stack: []
-       interpreting:
-       code:  [(Domain_specific_operation Contract_opt); (Core Grab); (Core (Access 0));
-         (Adt
-            (MatchVariant
-               [("Some", [(Core Grab); (Core (Access 0))]);
-                 ("None",
-                  [(Core Grab); (Plain_old_data (String "Not a contract"));
-                    (Control_flow Failwith)])
-                 ]));
-         (Core EndLet); (Core Grab); (Plain_old_data (String "my string"));
-         (Plain_old_data
-            (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
-         (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
-         (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
-         (Core Return)]
-       env:   [(Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
-       stack: [(Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
-       interpreting:
-       code:  [(Core Grab); (Core (Access 0));
-         (Adt
-            (MatchVariant
-               [("Some", [(Core Grab); (Core (Access 0))]);
-                 ("None",
-                  [(Core Grab); (Plain_old_data (String "Not a contract"));
-                    (Control_flow Failwith)])
-                 ]));
-         (Core EndLet); (Core Grab); (Plain_old_data (String "my string"));
-         (Plain_old_data
-            (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
-         (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
-         (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
-         (Core Return)]
-       env:   [(Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
-       stack: [(Variant ("None", (Record [||])))]
-       interpreting:
-       code:  [(Core (Access 0));
-         (Adt
-            (MatchVariant
-               [("Some", [(Core Grab); (Core (Access 0))]);
-                 ("None",
-                  [(Core Grab); (Plain_old_data (String "Not a contract"));
-                    (Control_flow Failwith)])
-                 ]));
-         (Core EndLet); (Core Grab); (Plain_old_data (String "my string"));
-         (Plain_old_data
-            (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
-         (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
-         (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
-         (Core Return)]
-       env:   [(Variant ("None", (Record [||])));
-         (Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
-       stack: []
-       interpreting:
-       code:  [(Adt
-           (MatchVariant
-              [("Some", [(Core Grab); (Core (Access 0))]);
-                ("None",
-                 [(Core Grab); (Plain_old_data (String "Not a contract"));
-                   (Control_flow Failwith)])
-                ]));
-         (Core EndLet); (Core Grab); (Plain_old_data (String "my string"));
-         (Plain_old_data
-            (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
-         (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
-         (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
-         (Core Return)]
-       env:   [(Variant ("None", (Record [||])));
-         (Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
-       stack: [(Variant ("None", (Record [||])))]
-       interpreting:
-       code:  [(Core Grab); (Plain_old_data (String "Not a contract"));
-         (Control_flow Failwith); (Core EndLet); (Core Grab);
-         (Plain_old_data (String "my string"));
-         (Plain_old_data
-            (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
-         (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
-         (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
-         (Core Return)]
-       env:   [(Variant ("None", (Record [||])));
-         (Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
-       stack: [(Record [||])]
-       interpreting:
-       code:  [(Plain_old_data (String "Not a contract")); (Control_flow Failwith);
-         (Core EndLet); (Core Grab); (Plain_old_data (String "my string"));
-         (Plain_old_data
-            (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
-         (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
-         (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
-         (Core Return)]
-       env:   [(Record [||]); (Variant ("None", (Record [||])));
-         (Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
-       stack: []
-       interpreting:
-       code:  [(Control_flow Failwith); (Core EndLet); (Core Grab);
-         (Plain_old_data (String "my string"));
-         (Plain_old_data
-            (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
-         (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
-         (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
-         (Core Return)]
-       env:   [(Record [||]); (Variant ("None", (Record [||])));
-         (Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
-       stack: [(Z (Plain_old_data (String "Not a contract")))]
-       (Failure "Not a contract") |}]
-*)
+          interpreting:
+          code:  [(Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV));
+            (Core Grab); (Core (Access 0)); (Domain_specific_operation Contract_opt);
+            (Core Grab); (Core (Access 0));
+            (Adt
+               (MatchVariant
+                  [|[(Core Grab); (Core (Access 0))];
+                    [(Core Grab); (Plain_old_data (String "Not a contract"));
+                      (Control_flow Failwith)]
+                    |]));
+            (Core EndLet); (Core Grab); (Plain_old_data (String "my string"));
+            (Plain_old_data
+               (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
+            (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
+            (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
+            (Core Return)]
+          env:   []
+          stack: []
+          interpreting:
+          code:  [(Core Grab); (Core (Access 0)); (Domain_specific_operation Contract_opt);
+            (Core Grab); (Core (Access 0));
+            (Adt
+               (MatchVariant
+                  [|[(Core Grab); (Core (Access 0))];
+                    [(Core Grab); (Plain_old_data (String "Not a contract"));
+                      (Control_flow Failwith)]
+                    |]));
+            (Core EndLet); (Core Grab); (Plain_old_data (String "my string"));
+            (Plain_old_data
+               (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
+            (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
+            (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
+            (Core Return)]
+          env:   []
+          stack: [(Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
+          interpreting:
+          code:  [(Core (Access 0)); (Domain_specific_operation Contract_opt); (Core Grab);
+            (Core (Access 0));
+            (Adt
+               (MatchVariant
+                  [|[(Core Grab); (Core (Access 0))];
+                    [(Core Grab); (Plain_old_data (String "Not a contract"));
+                      (Control_flow Failwith)]
+                    |]));
+            (Core EndLet); (Core Grab); (Plain_old_data (String "my string"));
+            (Plain_old_data
+               (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
+            (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
+            (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
+            (Core Return)]
+          env:   [(Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
+          stack: []
+          interpreting:
+          code:  [(Domain_specific_operation Contract_opt); (Core Grab); (Core (Access 0));
+            (Adt
+               (MatchVariant
+                  [|[(Core Grab); (Core (Access 0))];
+                    [(Core Grab); (Plain_old_data (String "Not a contract"));
+                      (Control_flow Failwith)]
+                    |]));
+            (Core EndLet); (Core Grab); (Plain_old_data (String "my string"));
+            (Plain_old_data
+               (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
+            (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
+            (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
+            (Core Return)]
+          env:   [(Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
+          stack: [(Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
+          interpreting:
+          code:  [(Core Grab); (Core (Access 0));
+            (Adt
+               (MatchVariant
+                  [|[(Core Grab); (Core (Access 0))];
+                    [(Core Grab); (Plain_old_data (String "Not a contract"));
+                      (Control_flow Failwith)]
+                    |]));
+            (Core EndLet); (Core Grab); (Plain_old_data (String "my string"));
+            (Plain_old_data
+               (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
+            (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
+            (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
+            (Core Return)]
+          env:   [(Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
+          stack: [(Variant (0,
+              (NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))
+              ))
+            ]
+          interpreting:
+          code:  [(Core (Access 0));
+            (Adt
+               (MatchVariant
+                  [|[(Core Grab); (Core (Access 0))];
+                    [(Core Grab); (Plain_old_data (String "Not a contract"));
+                      (Control_flow Failwith)]
+                    |]));
+            (Core EndLet); (Core Grab); (Plain_old_data (String "my string"));
+            (Plain_old_data
+               (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
+            (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
+            (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
+            (Core Return)]
+          env:   [(Variant (0,
+              (NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))
+              ));
+            (Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
+          stack: []
+          interpreting:
+          code:  [(Adt
+              (MatchVariant
+                 [|[(Core Grab); (Core (Access 0))];
+                   [(Core Grab); (Plain_old_data (String "Not a contract"));
+                     (Control_flow Failwith)]
+                   |]));
+            (Core EndLet); (Core Grab); (Plain_old_data (String "my string"));
+            (Plain_old_data
+               (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
+            (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
+            (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
+            (Core Return)]
+          env:   [(Variant (0,
+              (NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))
+              ));
+            (Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
+          stack: [(Variant (0,
+              (NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))
+              ))
+            ]
+          interpreting:
+          code:  [(Core Grab); (Core (Access 0)); (Core EndLet); (Core Grab);
+            (Plain_old_data (String "my string"));
+            (Plain_old_data
+               (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
+            (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
+            (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
+            (Core Return)]
+          env:   [(Variant (0,
+              (NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))
+              ));
+            (Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
+          stack: [(NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))]
+          interpreting:
+          code:  [(Core (Access 0)); (Core EndLet); (Core Grab);
+            (Plain_old_data (String "my string"));
+            (Plain_old_data
+               (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
+            (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
+            (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
+            (Core Return)]
+          env:   [(NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]));
+            (Variant (0,
+               (NonliteralValue
+                  (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))
+               ));
+            (Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
+          stack: []
+          interpreting:
+          code:  [(Core EndLet); (Core Grab); (Plain_old_data (String "my string"));
+            (Plain_old_data
+               (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
+            (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
+            (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
+            (Core Return)]
+          env:   [(NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]));
+            (Variant (0,
+               (NonliteralValue
+                  (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))
+               ));
+            (Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
+          stack: [(NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))]
+          interpreting:
+          code:  [(Core Grab); (Plain_old_data (String "my string"));
+            (Plain_old_data
+               (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
+            (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
+            (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
+            (Core Return)]
+          env:   [(Variant (0,
+              (NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))
+              ));
+            (Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
+          stack: [(NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))]
+          interpreting:
+          code:  [(Plain_old_data (String "my string"));
+            (Plain_old_data
+               (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
+            (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
+            (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
+            (Core Return)]
+          env:   [(NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]));
+            (Variant (0,
+               (NonliteralValue
+                  (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))
+               ));
+            (Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
+          stack: []
+          interpreting:
+          code:  [(Plain_old_data (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav));
+            (Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
+            (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
+            (Core Return)]
+          env:   [(NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]));
+            (Variant (0,
+               (NonliteralValue
+                  (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))
+               ));
+            (Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
+          stack: [(Z (Plain_old_data (String "my string")))]
+          interpreting:
+          code:  [(Core (Access 0)); (Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
+            (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
+            (Core Return)]
+          env:   [(NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]));
+            (Variant (0,
+               (NonliteralValue
+                  (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))
+               ));
+            (Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
+          stack: [(Z
+              (Plain_old_data
+                 (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav)));
+            (Z (Plain_old_data (String "my string")))]
+          interpreting:
+          code:  [(Plain_old_data (Mutez 10)); (Adt (MakeRecord 0));
+            (Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
+            (Core Return)]
+          env:   [(NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]));
+            (Variant (0,
+               (NonliteralValue
+                  (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))
+               ));
+            (Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
+          stack: [(NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]));
+            (Z
+               (Plain_old_data
+                  (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav)));
+            (Z (Plain_old_data (String "my string")))]
+          interpreting:
+          code:  [(Adt (MakeRecord 0)); (Domain_specific_operation MakeTransaction);
+            (Adt (MakeRecord 3)); (Core Return)]
+          env:   [(NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]));
+            (Variant (0,
+               (NonliteralValue
+                  (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))
+               ));
+            (Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
+          stack: [(Z (Plain_old_data (Mutez 10)));
+            (NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]));
+            (Z
+               (Plain_old_data
+                  (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav)));
+            (Z (Plain_old_data (String "my string")))]
+          interpreting:
+          code:  [(Domain_specific_operation MakeTransaction); (Adt (MakeRecord 3));
+            (Core Return)]
+          env:   [(NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]));
+            (Variant (0,
+               (NonliteralValue
+                  (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))
+               ));
+            (Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
+          stack: [(Record [||]); (Z (Plain_old_data (Mutez 10)));
+            (NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]));
+            (Z
+               (Plain_old_data
+                  (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav)));
+            (Z (Plain_old_data (String "my string")))]
+          interpreting:
+          code:  [(Adt (MakeRecord 3)); (Core Return)]
+          env:   [(NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]));
+            (Variant (0,
+               (NonliteralValue
+                  (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))
+               ));
+            (Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
+          stack: [(NonliteralValue
+              (Chain_operation
+                 (Transaction (10, ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))));
+            (Z
+               (Plain_old_data
+                  (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav)));
+            (Z (Plain_old_data (String "my string")))]
+          interpreting:
+          code:  [(Core Return)]
+          env:   [(NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]));
+            (Variant (0,
+               (NonliteralValue
+                  (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))
+               ));
+            (Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))]
+          stack: [(Record
+              [|(NonliteralValue
+                   (Chain_operation
+                      (Transaction (10, ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))));
+                (Z
+                   (Plain_old_data
+                      (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav)));
+                (Z (Plain_old_data (String "my string")))|])
+            ]
+          (Success (
+             [(NonliteralValue (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]));
+               (Variant (0,
+                  (NonliteralValue
+                     (Contract ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))
+                  ));
+               (Z (Plain_old_data (Address tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV)))],
+             [(Record
+                 [|(NonliteralValue
+                      (Chain_operation
+                         (Transaction (10,
+                            ["tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV",null]))));
+                   (Z
+                      (Plain_old_data
+                         (Key edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav)));
+                   (Z (Plain_old_data (String "my string")))|])
+               ]
+             )) |}]


### PR DESCRIPTION
## Problem

Currently variants are represented as `(string * Zinc.t) list`, and we can't match on custom variants

## Solution

change their representation to `Zinc.t Array.t`, and allow matching on custom variants
## Related
- #358 
 