### PR TITLE
Add nix flake support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ npm i -g esy # on Ubuntu you might need --unsafe-perms to work around EACCES iss
 yarn global add esy
 ```
 
+Alternatively, you can use the `nix` package manager with
+[flakes enabled](https://nixos.wiki/wiki/Flakes#Installing_flakes) to enter an
+environment preloaded with the correct dependencies, including `esy`:
+```
+nix --experimental-features "nix-command flakes" run
+```
+
+(We suggest using this [binary cache repository](https://app.cachix.org/cache/anmonteiro) to reduce
+build times)
+
 #### Tmuxinator (optional)
 
 Tmuxinator manages running multiple commands in a terminal session. We

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,113 @@
+{
+  "nodes": {
+    "anmonteiro": {
+      "inputs": {
+        "flake-utils": "flake-utils"
+      },
+      "locked": {
+        "lastModified": 1641320806,
+        "narHash": "sha256-7j76oJuIr8ghfEVv7JnsCvXX8bh14C9Pzz9YB2+b42k=",
+        "owner": "anmonteiro",
+        "repo": "nix-overlays",
+        "rev": "7f1b5de5e07e9a5a082dfd7da5f9f8d6dac5c0c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "anmonteiro",
+        "repo": "nix-overlays",
+        "type": "github"
+      }
+    },
+    "esy-fhs": {
+      "inputs": {
+        "anmonteiro": "anmonteiro",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1641514639,
+        "narHash": "sha256-DnMSUjeM/ZiK1lZxDIF+hIpoR0R7CkvyTefqRQZ8coQ=",
+        "owner": "d4hines",
+        "repo": "esy-fhs",
+        "rev": "03931b4b9d137ced5e5ec8030b761b0ef6a7a820",
+        "type": "github"
+      },
+      "original": {
+        "owner": "d4hines",
+        "repo": "esy-fhs",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1637014545,
+        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1641555862,
+        "narHash": "sha256-AJK1Q5djPXs/ba3K6gHsVAer9yDPVLic78ZIDsFSkHU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d1acd89e0116ff88eba80541027429fc922612e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "esy-fhs": "esy-fhs",
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,19 @@
+{
+  description = "Deku development environment";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.esy-fhs.url = "github:d4hines/esy-fhs";
+  inputs.esy-fhs.inputs.nixpkgs.follows = "nixpkgs";
+  outputs = { self, nixpkgs, flake-utils, esy-fhs }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = import nixpkgs { inherit system; }; in
+      {
+        defaultApp = esy-fhs.lib.makeFHSApp {
+          inherit system;
+          extraPackages = with pkgs; [
+            ligo
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION

## Problem

There's no way to build Deku in Nix/NixOS.

Additionally, it would be nice to have the advantages nix provides (reproducible, declarative setup, etc).

## Solution

This PR adds a nix flake for a completely reproducible nix setup.

It's not full nix support, since nix and esy are not compatible. Instead, we use nix
to build a chroot environment with esy installed (this is how Steam and VS Code work on NixOS) .
Users can just do `nix run` to get dropped into an environment with esy installed, and then
do esy development workflow as usual. Additionally, we can install any nix package we want
by adding to the `extraPackages` list - notice `ligo` is installed this way.