### PR TITLE
tezos_interop: promote bundles

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bundle.js binary

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@ _esy
 node_modules
 data
 *.install
-*.bundle.js
-*.bundle.js.LICENSE.txt

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "sidechain",
   "esy": {
-    "build": "dune build -p #{self.name}",
+    "build": [
+      "dune build --profile=release @bundle",
+      "dune build -p #{self.name}"
+    ],
     "release": {
       "bin": [
         "sidecli",

--- a/tezos_interop/dune
+++ b/tezos_interop/dune
@@ -18,13 +18,12 @@
   ./listen_transactions.bundle.js
   ./fetch_storage.bundle.js
   ./run_entrypoint.bundle.js)
- (mode fallback)
+ (mode promote)
  (action
   (run webpack --env=%{profile})))
 
 (rule
  (deps ./webpack.config.js ./listen_transactions.js ./run_entrypoint.js)
  (alias fmt)
- (mode fallback)
  (action
   (run prettier -c %{deps})))

--- a/tezos_interop/dune
+++ b/tezos_interop/dune
@@ -19,6 +19,7 @@
   ./fetch_storage.bundle.js
   ./run_entrypoint.bundle.js)
  (mode promote)
+ (alias bundle)
  (action
   (run webpack --env=%{profile})))
 


### PR DESCRIPTION
## Problem

Currently the bundles are not promoted and because of that `ppx_blob` fails to load leading to some weird behavior on merlin, also prettier is not running because it's on fallback mode.

## Solution

Move the bundles to promote and remove fallback from prettier.