### PR TITLE
Add logging of run_entrypoint.js output

### DIFF
--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -77,7 +77,9 @@ module Run_contract = {
         Yojson.Safe.to_string(input_to_yojson(input)),
       );
     switch (Yojson.Safe.from_string(output) |> output_of_yojson) {
-    | Ok(data) => await(data)
+    | Ok(data) =>
+      Format.printf("Commit operation result: %s\n%!", output);
+      await(data);
     | Error(error) => await(Error(error))
     };
   };


### PR DESCRIPTION
## Problem

There is currently no easy way to tell whether the block producer is actually communicating with the main chain or not.

## Solution

This PR adds a log to make it clear.

 