### PR TITLE
Fix main-chain communication

### DIFF
--- a/node/state.re
+++ b/node/state.re
@@ -111,6 +111,26 @@ let try_to_commit_state_hash = (~old_state, state, block, signatures) => {
            Address_map.find_opt(wallet, signatures_map),
          )
        );
+  let signatures_of_block =
+    Block_pool.find_signatures(~hash=block.Block.hash, state.block_pool)
+    |> Option.map(Signatures.to_list);
+
+  let current_validator_keys =
+    List.map(
+      ((signer_key, _signature_opt)) => {
+        let.some signatures_of_block = signatures_of_block;
+        let.some validator_signature =
+          List.find_opt(
+            s => {
+              let key_hash = Signature.address(s) |> Address.to_key_hash;
+              Key_hash.equal(signer_key, key_hash);
+            },
+            signatures_of_block,
+          );
+        some(Signature.public_key(validator_signature));
+      },
+      signatures,
+    );
 
   Lwt.async(() => {
     /* TODO: solve this magic number
@@ -128,6 +148,7 @@ let try_to_commit_state_hash = (~old_state, state, block, signatures) => {
       ~state_hash=block.state_root_hash,
       ~validators,
       ~signatures,
+      ~current_validator_keys,
     );
   });
 };

--- a/node/state.re
+++ b/node/state.re
@@ -141,7 +141,6 @@ let try_to_commit_state_hash = (~old_state, state, block, signatures) => {
         ? Lwt.return_unit : Lwt_unix.sleep(120.0);
     commit_state_hash(
       state,
-      ~block_hash=block.hash,
       ~block_height=block.block_height,
       ~block_payload_hash=block.payload_hash,
       ~handles_hash=block.handles_hash,

--- a/protocol/protocol_signature.re
+++ b/protocol/protocol_signature.re
@@ -11,6 +11,7 @@ type t = {
 };
 let public_key = t => t.public_key;
 let address = t => t.address;
+let signature = t => t.signature;
 
 let (to_yojson, of_yojson) = {
   module Serialized_data = {
@@ -40,7 +41,6 @@ let sign = (~key as secret, hash) => {
   let address = Address.of_key(public_key);
   {signature, public_key, address};
 };
-let signature_to_signature_by_address = t => (t.address, t.signature);
 let verify = (~signature, hash) =>
   Signature.verify(signature.public_key, signature.signature, hash);
 module type S = {

--- a/protocol/protocol_signature.rei
+++ b/protocol/protocol_signature.rei
@@ -6,11 +6,10 @@ type t;
 let compare: (t, t) => int;
 let public_key: t => Wallet.t;
 let address: t => Address.t;
+let signature: t => Signature.t;
 
 let sign: (~key: Secret.t, BLAKE2B.t) => t;
 let verify: (~signature: t, BLAKE2B.t) => bool;
-
-let signature_to_signature_by_address: t => (Address.t, Signature.t);
 
 module type S = {
   type value;

--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -246,7 +246,6 @@ module Consensus = {
   let commit_state_hash =
       (
         ~context,
-        ~block_hash,
         ~block_height,
         ~block_payload_hash,
         ~state_hash,
@@ -258,7 +257,6 @@ module Consensus = {
     module Payload = {
       [@deriving to_yojson]
       type t = {
-        block_hash: BLAKE2B.t,
         block_height: int64,
         block_payload_hash: BLAKE2B.t,
         signatures: list(option(string)),
@@ -282,7 +280,6 @@ module Consensus = {
       List.map(Option.map(Key.to_string), current_validator_keys);
 
     let payload = {
-      block_hash,
       block_height,
       block_payload_hash,
       signatures,

--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -252,7 +252,6 @@ module Consensus = {
         ~handles_hash,
         ~validators,
         ~signatures,
-        ~current_validator_keys,
       ) => {
     module Payload = {
       [@deriving to_yojson]
@@ -267,17 +266,20 @@ module Consensus = {
       };
     };
     open Payload;
-    let signatures =
-      // TODO: we should sort the map using the keys
+    let (current_validator_keys, signatures) =
       List.map(
-        ((_key, signature)) =>
-          Option.map(signature => Signature.to_string(signature), signature),
+        signature =>
+          switch (signature) {
+          | Some((key, signature)) =>
+            let key = Key.to_string(key);
+            let signature = Signature.to_string(signature);
+            (Some(key), Some(signature));
+          | None => (None, None)
+          },
         signatures,
-      );
+      )
+      |> List.split;
     let validators = List.map(Key_hash.to_string, validators);
-
-    let current_validator_keys =
-      List.map(Option.map(Key.to_string), current_validator_keys);
 
     let payload = {
       block_height,

--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -253,6 +253,7 @@ module Consensus = {
         ~handles_hash,
         ~validators,
         ~signatures,
+        ~current_validator_keys,
       ) => {
     module Payload = {
       [@deriving to_yojson]
@@ -264,6 +265,7 @@ module Consensus = {
         handles_hash: BLAKE2B.t,
         state_hash: BLAKE2B.t,
         validators: list(string),
+        current_validator_keys: list(option(string)),
       };
     };
     open Payload;
@@ -275,6 +277,10 @@ module Consensus = {
         signatures,
       );
     let validators = List.map(Key_hash.to_string, validators);
+
+    let current_validator_keys =
+      List.map(Option.map(Key.to_string), current_validator_keys);
+
     let payload = {
       block_hash,
       block_height,
@@ -283,6 +289,7 @@ module Consensus = {
       handles_hash,
       state_hash,
       validators,
+      current_validator_keys,
     };
     // TODO: what should this code do with the output? Retry?
     //      return back that it was a failure?

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -22,7 +22,8 @@ module Consensus: {
       ~state_hash: BLAKE2B.t,
       ~handles_hash: BLAKE2B.t,
       ~validators: list(Key_hash.t),
-      ~signatures: list((Key_hash.t, option(Signature.t)))
+      ~signatures: list((Key_hash.t, option(Signature.t))),
+      ~current_validator_keys: list(option(Key.t))
     ) =>
     Lwt.t(unit);
 

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -21,8 +21,7 @@ module Consensus: {
       ~state_hash: BLAKE2B.t,
       ~handles_hash: BLAKE2B.t,
       ~validators: list(Key_hash.t),
-      ~signatures: list((Key_hash.t, option(Signature.t))),
-      ~current_validator_keys: list(option(Key.t))
+      ~signatures: list(option((Key.t, Signature.t)))
     ) =>
     Lwt.t(unit);
 

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -16,7 +16,6 @@ module Consensus: {
   let commit_state_hash:
     (
       ~context: Context.t,
-      ~block_hash: BLAKE2B.t,
       ~block_height: int64,
       ~block_payload_hash: BLAKE2B.t,
       ~state_hash: BLAKE2B.t,


### PR DESCRIPTION
## Problem

Deku communication with the main chain is broken in two different ways on main:
1 The `current_validator_keys` introduced to consensus.mligo in #208 is not being sent by the Deku node
2 Ignoring that problem, Deku signatures are not recognized as valid by the main chain.
  - This latter point bears explanation. Conceptually, validators sign block hashes to show their approval of that block. But starting in #302, we replaced block hashing with a function that hashed the block twice. Thus validators started signing not the hash(block), but the hash(hash(block)). This was done to match the behavior of `CHECK_SIGNATURE` in Tezos, as mentioned in the PR. However, this introduced a bug - when sending the `block_hash` parameter, we were sending not the `hash(block)` but the `hash(hash(block))`. Tezos was then hashing this (to get `hash(hash(hash(block)))`) and checking the signature, which of course didn't match.  

## Solution

The solution 1 was to use the block pool to get the public keys associated with the signatures. The order is important, so we map the list of signatures directly to the list of keys asociated with those signatures to preserve this order.

The solution to 2 was to not send the block hash at all.  We are already calculating the block hash as part of the validation, so we just re-use that data and omit the block hash from our payload. We thus are signing the `hash(hash(block))` in deku, calculating `hash(block)` in the consensus contract, and then checking it with `CHECK_SIGNATURE`, which creates `hash(hash(block))` and checks that indeed signed it.

The two solutions are independent; however, testing them is not independent since the chain requires both to work, so I've included them both in this PR. I suggest reviewers look at 1 commit at a time. 

## Testing

Here's how I tested locally:
- I changed the `state_root_hash_epoch` in `protocol/block.re` from 60 seconds to 10 to speed things up.
- I started up the chain and let it produce a few blocks. I verified the transactions were applied in a local better-call.dev instance.
- I shut the chain down for 5 minutes
- I started the chain again and let it produce a few blocks, verifying them in bcd again.

Instead of using bcd, you can use the logging introduced in #397.
 
## Related
- #208 
- #302
 