### PR TITLE
Exception for negative amounts (issue #399)

### DIFF
--- a/core/amount.re
+++ b/core/amount.re
@@ -6,12 +6,15 @@ let zero = 0;
 let (+) = (+);
 let (-) = (a, b) => {
   let t = a - b;
-  assert(t >= 0);
+  if (t < 0) {
+    raise(Invalid_argument("Negative amount"));
+  };
   t;
 };
 let of_int = t => {
-  // TODO: test this, should amount be non-zero?
-  assert(t >= 0);
+  if (t < 0) {
+    raise(Invalid_argument("Negative amount"));
+  };
   t;
 };
 let to_int = t => t;

--- a/tests/test_ledger.re
+++ b/tests/test_ledger.re
@@ -62,6 +62,12 @@ describe("ledger", ({test, _}) => {
         f(expect, expect_balance);
       },
     );
+  test("amount", (expect, _) => {
+    expect.equal(Amount.(of_int(0) + of_int(5)), Amount.of_int(5));
+    expect.fn(() => Amount.of_int(-1)).toThrowException(
+      Invalid_argument("Negative amount"),
+    );
+  });
   test("balance", (_, expect_balance) => {
     let (t, (t1, t2), (a, b)) = setup_two();
     expect_balance(a, t1, 100, t);


### PR DESCRIPTION
## Problem

We shouldn't be able to represent negative amounts. The previous code contained an assertion, a more explicit exception is probably better. Also, tests.

## Solution

Raise an Invalid_argument when trying to represent a negative amount.
 
 ## Related
 
 - Closes #399 