### PR TITLE
Push docker image to correct registry in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,5 +35,5 @@ jobs:
           cache-to: type=gha,mode=max
           push: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
           tags: |
-            marigold-dev/deku:latest
-            marigold-dev/deku:${{ github.sha }}
+            ghcr.io/marigold-dev/deku:latest
+            ghcr.io/marigold-dev/deku:${{ github.sha }}


### PR DESCRIPTION
## Problem

<!--- Restate the problem addressed by the PR here --->

We are trying to push images to the hub.docker.io registry since that is the default but we're not authenticated with it

## Solution

<!--- Restate the basic ideas behind your solution --->
<!--- Here it is also a good space to put details of your implementation --->

We already authenticate with the github registry so we just had to ad `ghcr.io/` to the beginning of the tags.
 