### PR TITLE
Rename "source" to "sender" to match tezos

### DIFF
--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -205,7 +205,7 @@ let create_transaction =
       ~block_height=block_level,
       ~data=
         Core.User_operation.make(
-          ~source=wallet.address,
+          ~sender=wallet.address,
           Transaction({destination: received_address, amount, ticket}),
         ),
     );
@@ -302,7 +302,7 @@ let withdraw =
       ~block_height=block_level,
       ~data=
         Core.User_operation.make(
-          ~source=wallet.address,
+          ~sender=wallet.address,
           Tezos_withdraw({owner: tezos_address, amount, ticket}),
         ),
     );

--- a/core/ledger.re
+++ b/core/ledger.re
@@ -59,25 +59,25 @@ let balance = (address, ticket, t) =>
   Address_and_ticket_map.find_opt(address, ticket, t.ledger)
   |> Option.value(~default=Amount.zero);
 
-let assert_available = (~source, ~amount: Amount.t) =>
-  if (source >= amount) {
+let assert_available = (~sender, ~amount: Amount.t) =>
+  if (sender >= amount) {
     Ok();
   } else {
     Error(`Not_enough_funds);
   };
 
-let transfer = (~source, ~destination, amount, ticket, t) => {
+let transfer = (~sender, ~destination, amount, ticket, t) => {
   open Amount;
 
-  let source_balance = balance(source, ticket, t);
-  let.ok () = assert_available(~source=source_balance, ~amount);
+  let sender_balance = balance(sender, ticket, t);
+  let.ok () = assert_available(~sender=sender_balance, ~amount);
 
   let destination_balance = balance(destination, ticket, t);
 
   Ok({
     ledger:
       t.ledger
-      |> Address_and_ticket_map.add(source, ticket, source_balance - amount)
+      |> Address_and_ticket_map.add(sender, ticket, sender_balance - amount)
       |> Address_and_ticket_map.add(
            destination,
            ticket,
@@ -102,11 +102,11 @@ let deposit = (destination, amount, ticket, t) => {
     handles: t.handles,
   };
 };
-let withdraw = (~source, ~destination, amount, ticket, t) => {
+let withdraw = (~sender, ~destination, amount, ticket, t) => {
   open Amount;
   let owner = destination;
-  let source_balance = balance(source, ticket, t);
-  let.ok () = assert_available(~source=source_balance, ~amount);
+  let sender_balance = balance(sender, ticket, t);
+  let.ok () = assert_available(~sender=sender_balance, ~amount);
 
   let (handles, handle) =
     Handle_tree.add(
@@ -119,7 +119,7 @@ let withdraw = (~source, ~destination, amount, ticket, t) => {
   let t = {
     ledger:
       t.ledger
-      |> Address_and_ticket_map.add(source, ticket, source_balance - amount),
+      |> Address_and_ticket_map.add(sender, ticket, sender_balance - amount),
     handles,
   };
   Ok((t, handle));

--- a/core/ledger.rei
+++ b/core/ledger.rei
@@ -17,14 +17,14 @@ type t;
 let empty: t;
 let balance: (Address.t, Ticket_id.t, t) => Amount.t;
 let transfer:
-  (~source: Address.t, ~destination: Address.t, Amount.t, Ticket_id.t, t) =>
+  (~sender: Address.t, ~destination: Address.t, Amount.t, Ticket_id.t, t) =>
   result(t, [> | `Not_enough_funds]);
 
 // on chain ops
 let deposit: (Address.t, Amount.t, Ticket_id.t, t) => t;
 let withdraw:
   (
-    ~source: Address.t,
+    ~sender: Address.t,
     ~destination: Tezos.Address.t,
     Amount.t,
     Ticket_id.t,

--- a/core/state.re
+++ b/core/state.re
@@ -36,15 +36,15 @@ let apply_tezos_operation = (t, tezos_operation) => {
 };
 let apply_user_operation = (t, user_operation) => {
   open User_operation;
-  let {hash: _, source, initial_operation} = user_operation;
+  let {hash: _, sender, initial_operation} = user_operation;
   switch (initial_operation) {
   | Transaction({destination, amount, ticket}) =>
     let.ok ledger =
-      Ledger.transfer(~source, ~destination, amount, ticket, t.ledger);
+      Ledger.transfer(~sender, ~destination, amount, ticket, t.ledger);
     Ok(({ledger: ledger}, None));
   | Tezos_withdraw({owner, amount, ticket}) =>
     let.ok (ledger, handle) =
-      Ledger.withdraw(~source, ~destination=owner, amount, ticket, t.ledger);
+      Ledger.withdraw(~sender, ~destination=owner, amount, ticket, t.ledger);
     Ok(({ledger: ledger}, Some(Receipt_tezos_withdraw(handle))));
   };
 };

--- a/core/user_operation.re
+++ b/core/user_operation.re
@@ -16,38 +16,38 @@ type initial_operation =
 [@deriving yojson]
 type t = {
   hash: BLAKE2B.t,
-  source: Address.t,
+  sender: Address.t,
   initial_operation,
 };
 let equal = (a, b) => BLAKE2B.equal(a.hash, b.hash);
 let compare = (a, b) => BLAKE2B.compare(a.hash, b.hash);
 
 let (hash, verify) = {
-  let to_yojson = (source, initial_operation) =>
-    [%to_yojson: (Address.t, initial_operation)]((source, initial_operation))
+  let to_yojson = (sender, initial_operation) =>
+    [%to_yojson: (Address.t, initial_operation)]((sender, initial_operation))
     |> Yojson.Safe.to_string;
-  let hash = (source, initial_operation) =>
-    to_yojson(source, initial_operation) |> BLAKE2B.hash;
-  let verify = (hash, source, initial_operation) =>
-    to_yojson(source, initial_operation) |> BLAKE2B.verify(~hash);
+  let hash = (sender, initial_operation) =>
+    to_yojson(sender, initial_operation) |> BLAKE2B.hash;
+  let verify = (hash, sender, initial_operation) =>
+    to_yojson(sender, initial_operation) |> BLAKE2B.verify(~hash);
   (hash, verify);
 };
 
-let make = (~source, initial_operation) => {
-  let hash = hash(source, initial_operation);
-  {hash, source, initial_operation};
+let make = (~sender, initial_operation) => {
+  let hash = hash(sender, initial_operation);
+  {hash, sender, initial_operation};
 };
 
-let verify = (hash, source, initial_operation) => {
+let verify = (hash, sender, initial_operation) => {
   let.assert () = (
     "Invalid_user_operation_hash",
-    verify(hash, source, initial_operation),
+    verify(hash, sender, initial_operation),
   );
-  Ok({hash, source, initial_operation});
+  Ok({hash, sender, initial_operation});
 };
 
 let of_yojson = json => {
   let.ok t = of_yojson(json);
-  let.ok t = verify(t.hash, t.source, t.initial_operation);
+  let.ok t = verify(t.hash, t.sender, t.initial_operation);
   Ok(t);
 };

--- a/core/user_operation.rei
+++ b/core/user_operation.rei
@@ -16,8 +16,8 @@ type initial_operation =
 type t =
   pri {
     hash: BLAKE2B.t,
-    source: Address.t,
+    sender: Address.t,
     initial_operation,
   };
 
-let make: (~source: Address.t, initial_operation) => t;
+let make: (~sender: Address.t, initial_operation) => t;

--- a/protocol/protocol_operation.re
+++ b/protocol/protocol_operation.re
@@ -58,7 +58,7 @@ module Core_user = {
     let signature = Signature.sign(secret, hash);
     // TODO: this can only happen through a bug
     //       maybe the API should enforce it
-    assert(Address.matches_key(key, data.source));
+    assert(Address.matches_key(key, data.sender));
     {hash, key, signature, nonce, block_height, data};
   };
 
@@ -69,7 +69,7 @@ module Core_user = {
     );
     let.assert () = (
       "Invalid core_user key",
-      Address.matches_key(key, data.source),
+      Address.matches_key(key, data.sender),
     );
     let.assert () = (
       "Invalid core_user signature",

--- a/tests/test_ledger.re
+++ b/tests/test_ledger.re
@@ -84,7 +84,7 @@ describe("ledger", ({test, _}) => {
     let (t, (t1, t2), (a, b)) = setup_two();
     let c = make_address();
 
-    let t = transfer(~source=a, ~destination=b, Amount.of_int(1), t1, t);
+    let t = transfer(~sender=a, ~destination=b, Amount.of_int(1), t1, t);
     expect.result(t).toBeOk();
     let t = Result.get_ok(t);
     expect_balance(a, t1, 99, t);
@@ -94,7 +94,7 @@ describe("ledger", ({test, _}) => {
     expect_balance(c, t1, 0, t);
     expect_balance(c, t2, 0, t);
 
-    let t = transfer(~source=b, ~destination=a, Amount.of_int(3), t2, t);
+    let t = transfer(~sender=b, ~destination=a, Amount.of_int(3), t2, t);
     expect.result(t).toBeOk();
     let t = Result.get_ok(t);
     expect_balance(a, t1, 99, t);
@@ -104,7 +104,7 @@ describe("ledger", ({test, _}) => {
     expect_balance(c, t1, 0, t);
     expect_balance(c, t2, 0, t);
 
-    let t = transfer(~source=b, ~destination=c, Amount.of_int(5), t2, t);
+    let t = transfer(~sender=b, ~destination=c, Amount.of_int(5), t2, t);
     expect.result(t).toBeOk();
     let t = Result.get_ok(t);
     expect_balance(a, t1, 99, t);
@@ -114,7 +114,7 @@ describe("ledger", ({test, _}) => {
     expect_balance(c, t1, 0, t);
     expect_balance(c, t2, 5, t);
 
-    let t = transfer(~source=a, ~destination=c, Amount.of_int(99), t1, t);
+    let t = transfer(~sender=a, ~destination=c, Amount.of_int(99), t1, t);
     expect.result(t).toBeOk();
     let t = Result.get_ok(t);
     expect_balance(a, t1, 0, t);
@@ -125,19 +125,19 @@ describe("ledger", ({test, _}) => {
     expect_balance(c, t2, 5, t);
 
     {
-      let t = transfer(~source=b, ~destination=c, Amount.of_int(202), t1, t);
+      let t = transfer(~sender=b, ~destination=c, Amount.of_int(202), t1, t);
       expect.result(t).toBeError();
       expect.equal(Result.get_error(t), `Not_enough_funds);
     };
     {
       let d = make_address();
-      let t = transfer(~source=d, ~destination=c, Amount.of_int(1), t2, t);
+      let t = transfer(~sender=d, ~destination=c, Amount.of_int(1), t2, t);
       expect.result(t).toBeError();
       expect.equal(Result.get_error(t), `Not_enough_funds);
     };
     {
       let t3 = make_ticket();
-      let t = transfer(~source=a, ~destination=b, Amount.of_int(1), t3, t);
+      let t = transfer(~sender=a, ~destination=b, Amount.of_int(1), t3, t);
       expect.result(t).toBeError();
       expect.equal(Result.get_error(t), `Not_enough_funds);
     };
@@ -162,7 +162,7 @@ describe("ledger", ({test, _}) => {
     let (t, (t1, t2), (a, b)) = setup_two();
     let destination = make_tezos_address();
 
-    let t = withdraw(~source=a, ~destination, Amount.of_int(10), t1, t);
+    let t = withdraw(~sender=a, ~destination, Amount.of_int(10), t1, t);
     expect.result(t).toBeOk();
     let (t, handle) = Result.get_ok(t);
     expect_balance(a, t1, 90, t);
@@ -173,7 +173,7 @@ describe("ledger", ({test, _}) => {
     expect.equal(handle.owner, destination);
     expect.equal(handle.amount, Amount.of_int(10));
 
-    let t = withdraw(~source=b, ~destination, Amount.of_int(9), t2, t);
+    let t = withdraw(~sender=b, ~destination, Amount.of_int(9), t2, t);
     expect.result(t).toBeOk();
     let (t, handle) = Result.get_ok(t);
     expect_balance(a, t1, 90, t);
@@ -184,7 +184,7 @@ describe("ledger", ({test, _}) => {
     expect.equal(handle.owner, destination);
     expect.equal(handle.amount, Amount.of_int(9));
 
-    let t = withdraw(~source=a, ~destination, Amount.of_int(8), t2, t);
+    let t = withdraw(~sender=a, ~destination, Amount.of_int(8), t2, t);
     expect.result(t).toBeOk();
     let (t, handle) = Result.get_ok(t);
     expect_balance(a, t1, 90, t);
@@ -196,17 +196,17 @@ describe("ledger", ({test, _}) => {
     expect.equal(handle.amount, Amount.of_int(8));
 
     {
-      let t = withdraw(~source=a, ~destination, Amount.of_int(91), t1, t);
+      let t = withdraw(~sender=a, ~destination, Amount.of_int(91), t1, t);
       expect.result(t).toBeError();
     };
     {
-      let t = withdraw(~source=b, ~destination, Amount.of_int(203), t1, t);
+      let t = withdraw(~sender=b, ~destination, Amount.of_int(203), t1, t);
       expect.result(t).toBeError();
     };
     {
       let c = make_address();
 
-      let t = withdraw(~source=c, ~destination, Amount.of_int(1), t1, t);
+      let t = withdraw(~sender=c, ~destination, Amount.of_int(1), t1, t);
       expect.result(t).toBeError();
     };
     ();
@@ -217,14 +217,14 @@ describe("ledger", ({test, _}) => {
     {
       // two tickets with same data
       let t1' = make_ticket(~data=t1.data, ());
-      let t = transfer(~source=a, ~destination=b, Amount.of_int(1), t1', t);
+      let t = transfer(~sender=a, ~destination=b, Amount.of_int(1), t1', t);
       expect.result(t).toBeError();
       expect.equal(Result.get_error(t), `Not_enough_funds);
     };
     {
       // two tickets with same ticketer
       let t1' = make_ticket(~ticketer=t1.ticketer, ());
-      let t = transfer(~source=a, ~destination=b, Amount.of_int(1), t1', t);
+      let t = transfer(~sender=a, ~destination=b, Amount.of_int(1), t1', t);
       expect.result(t).toBeError();
       expect.equal(Result.get_error(t), `Not_enough_funds);
     };


### PR DESCRIPTION
## Problem

In `user_operation`, operations have a `source` field that represents the contract that triggered the operation. This should probably be renamed to `sender`, because likely once contracts land this field will semantically behave like tezos's `sender` parameter. (That is, the contract that directly triggered the operation, rather than the contract at the root of the who-triggered-who graph.)

While doing this I felt like the `source` field in many of the operations on Ledger should be renamed to `sender` too. If you disagree with this, just let me know and I'll undo that.

## Solution

Rename source to sender.