### PR TITLE
Store a list of snapshots

### DIFF
--- a/bin/deku_node.re
+++ b/bin/deku_node.re
@@ -138,7 +138,7 @@ let handle_protocol_snapshot =
     (_update_state, ()) => {
       let State.{snapshots, _} = Server.get_state();
       Ok({
-        snapshot: snapshots.last_snapshot,
+        snapshot: snapshots.current_snapshot,
         additional_blocks: snapshots.additional_blocks,
         last_block: snapshots.last_block,
         last_block_signatures:

--- a/bin/deku_node.re
+++ b/bin/deku_node.re
@@ -138,8 +138,7 @@ let handle_protocol_snapshot =
     (_update_state, ()) => {
       let State.{snapshots, _} = Server.get_state();
       Ok({
-        snapshot: snd(snapshots.Snapshots.last_snapshot),
-        snapshot_hash: fst(snapshots.last_snapshot),
+        snapshot: snapshots.last_snapshot,
         additional_blocks: snapshots.additional_blocks,
         last_block: snapshots.last_block,
         last_block_signatures:

--- a/bin/node_state.re
+++ b/bin/node_state.re
@@ -75,8 +75,8 @@ let get_initial_state = (~folder) => {
       let prev_epoch_state_bin = folder ++ "/prev_epoch_state.bin";
       let.await prev_protocol =
         Files.State_bin.read(~file=prev_epoch_state_bin);
-      let next_state_root = Protocol.hash(prev_protocol);
-      await((protocol, next_state_root));
+      let (hash, data) = Protocol.hash(prev_protocol);
+      await((protocol, Snapshots.{hash, data}));
     } else {
       await((node.protocol, node.next_state_root));
     };

--- a/bin/node_state.re
+++ b/bin/node_state.re
@@ -69,18 +69,35 @@ let get_initial_state = (~folder) => {
   };
   let state_bin = folder ++ "/state.bin";
   let.await state_bin_exists = Lwt_unix.file_exists(state_bin);
-  let.await (protocol, next_state_root) =
+
+  let.await protocol =
     if (state_bin_exists) {
-      let.await protocol = Files.State_bin.read(~file=state_bin);
-      let prev_epoch_state_bin = folder ++ "/prev_epoch_state.bin";
+      Files.State_bin.read(~file=state_bin);
+    } else {
+      await(node.protocol);
+    };
+
+  let prev_epoch_state_bin = folder ++ "/prev_epoch_state.bin";
+  let.await prev_epoch_state_bin_exists =
+    Lwt_unix.file_exists(prev_epoch_state_bin);
+  let.await snapshots =
+    if (state_bin_exists && prev_epoch_state_bin_exists) {
       let.await prev_protocol =
         Files.State_bin.read(~file=prev_epoch_state_bin);
       let (hash, data) = Protocol.hash(prev_protocol);
-      await((protocol, Snapshots.{hash, data}));
+      let snapshots =
+        Snapshots.add_snapshot(
+          ~new_snapshot=Snapshots.{hash, data},
+          ~block_height=prev_protocol.block_height,
+          node.snapshots,
+        )
+        |> Snapshots.start_new_epoch;
+      await(snapshots);
     } else {
-      await((node.protocol, node.next_state_root));
+      await(node.snapshots);
     };
-  let node = {...node, next_state_root, protocol};
+
+  let node = {...node, snapshots, protocol};
 
   await(node);
 };

--- a/node/building_blocks.re
+++ b/node/building_blocks.re
@@ -73,7 +73,7 @@ let block_has_signable_state_root_hash = (~current_time, state, block) => {
     if (BLAKE2B.equal(block.Block.state_root_hash, protocol.state_root_hash)) {
       time_since_last_epoch <= maximum_signable_time_between_epochs;
     } else {
-      BLAKE2B.equal(block.state_root_hash, state.next_state_root |> fst)
+      BLAKE2B.equal(block.state_root_hash, state.next_state_root.hash)
       && time_since_last_epoch >= minimum_signable_time_between_epochs;
     }
   );
@@ -159,7 +159,7 @@ let produce_block = state => {
     );
   let next_state_root_hash =
     if (start_new_epoch) {
-      Some(state.Node.next_state_root |> fst);
+      Some(state.Node.next_state_root.hash);
     } else {
       None;
     };

--- a/node/flows.re
+++ b/node/flows.re
@@ -142,16 +142,14 @@ Lwt.async_exception_hook :=
     }
   );
 let pending = ref(false);
-let load_snapshot = snapshot => {
+let load_snapshot = snapshot_data => {
   open Networking.Protocol_snapshot;
-
   let.ok state =
     Node.load_snapshot(
-      ~state_root_hash=snapshot.snapshot_hash,
-      ~state_root=snapshot.snapshot,
-      ~additional_blocks=snapshot.additional_blocks,
-      ~last_block=snapshot.last_block,
-      ~last_block_signatures=snapshot.last_block_signatures,
+      ~snapshot=snapshot_data.snapshot,
+      ~additional_blocks=snapshot_data.additional_blocks,
+      ~last_block=snapshot_data.last_block,
+      ~last_block_signatures=snapshot_data.last_block_signatures,
       get_state^(),
     );
   Ok(set_state^(state));
@@ -251,12 +249,11 @@ let rec try_to_apply_block = (state, update_state, block) => {
     Block_pool.is_signed(~hash=block.Block.hash, state.Node.block_pool),
   );
 
-  let (next_state_root_hash, _) = state.next_state_root;
   // TODO: in the future, we should stop the chain if this assert fails
   let.assert () = (
     `Invalid_state_root_hash,
     BLAKE2B.equal(state.protocol.state_root_hash, block.state_root_hash)
-    || BLAKE2B.equal(next_state_root_hash, block.state_root_hash),
+    || BLAKE2B.equal(state.next_state_root.hash, block.state_root_hash),
   );
 
   let prev_protocol = state.protocol;

--- a/node/flows.re
+++ b/node/flows.re
@@ -163,7 +163,8 @@ let request_protocol_snapshot = () =>
   });
 
 let request_previous_blocks = (state, block) =>
-  if (block.Block.state_root_hash == state.Node.protocol.state_root_hash) {
+  if (block_matches_current_state_root_hash(state, block)
+      || block_matches_next_state_root_hash(state, block)) {
     request_block(~hash=block.Block.previous_hash);
   } else if (! pending^) {
     pending := true;
@@ -252,8 +253,8 @@ let rec try_to_apply_block = (state, update_state, block) => {
   // TODO: in the future, we should stop the chain if this assert fails
   let.assert () = (
     `Invalid_state_root_hash,
-    BLAKE2B.equal(state.protocol.state_root_hash, block.state_root_hash)
-    || BLAKE2B.equal(state.next_state_root.hash, block.state_root_hash),
+    block_matches_current_state_root_hash(state, block)
+    || block_matches_next_state_root_hash(state, block),
   );
 
   let prev_protocol = state.protocol;

--- a/node/networking.re
+++ b/node/networking.re
@@ -121,8 +121,7 @@ module Protocol_snapshot = {
   type request = unit;
   [@deriving yojson]
   type response = {
-    snapshot: string,
-    snapshot_hash: BLAKE2B.t,
+    snapshot: Snapshots.snapshot,
     additional_blocks: list(Block.t),
     last_block: Block.t,
     // TODO: this is bad, Signatures.t is a private type and not a network one

--- a/node/snapshots.re
+++ b/node/snapshots.re
@@ -1,5 +1,6 @@
 open Crypto;
 open Protocol;
+open Helpers;
 
 [@deriving yojson]
 type snapshot = {
@@ -13,19 +14,27 @@ type snapshot = {
  this ensures that if last_block is signed the
  state snapshot will also be signed */
 type t = {
-  last_snapshot: snapshot,
-  last_snapshot_height: int64,
+  current_snapshot: snapshot,
+  next_snapshots: list((int64, snapshot)),
   last_block: Block.t,
   last_block_signatures: Signatures.t,
   additional_blocks: list(Block.t),
 };
 
 let make = (~initial_snapshot, ~initial_block, ~initial_signatures) => {
-  last_snapshot: initial_snapshot,
-  last_snapshot_height: 0L,
-  last_block: initial_block,
-  last_block_signatures: initial_signatures,
-  additional_blocks: [],
+  {
+    current_snapshot: {
+      hash: initial_block.Block.state_root_hash,
+      // TODO: if a snapshot is requested before first epoch starts, we will send meaningless data.
+      // We need to have logic in the snapshot request handler such that we send a 503 error or something
+      // instead of sending bad data.
+      data: "",
+    },
+    next_snapshots: [(initial_block.block_height, initial_snapshot)],
+    last_block: initial_block,
+    last_block_signatures: initial_signatures,
+    additional_blocks: [],
+  };
 };
 
 let append_block = (~pool, (block, signatures), t) =>
@@ -36,30 +45,55 @@ let append_block = (~pool, (block, signatures), t) =>
     let (blocks, (block, signatures)) =
       Block_pool.find_all_signed_blocks_above((block, signatures), pool);
     {
-      last_snapshot: t.last_snapshot,
-      last_snapshot_height: t.last_snapshot_height,
+      current_snapshot: t.current_snapshot,
+      next_snapshots: t.next_snapshots,
       last_block: block,
       last_block_signatures: signatures,
       additional_blocks: blocks @ [t.last_block] @ t.additional_blocks,
     };
   };
-let update = (~new_snapshot, ~applied_block_height, t) => {
+
+let add_snapshot = (~new_snapshot, ~block_height, t) => {
+  Format.printf(
+    "\x1b[36m New protocol snapshot hash: %s\x1b[m\n%!",
+    new_snapshot.hash |> BLAKE2B.to_string,
+  );
+  {
+    next_snapshots: t.next_snapshots @ [(block_height, new_snapshot)],
+    current_snapshot: t.current_snapshot,
+    last_block: t.last_block,
+    last_block_signatures: t.last_block_signatures,
+    additional_blocks: t.additional_blocks,
+  };
+};
+
+let start_new_epoch = t => {
   let rec truncate_additional_blocks = (block_height, blocks) =>
     switch (blocks) {
-    | [hd, ...tl] when hd.Block.block_height >= block_height => [
+    | [hd, ...tl] when hd.Block.block_height > block_height => [
         hd,
         ...truncate_additional_blocks(block_height, tl),
       ]
     | _ => []
     };
 
-  let additional_blocks =
-    truncate_additional_blocks(t.last_snapshot_height, t.additional_blocks);
-  {
-    last_snapshot: new_snapshot,
-    last_snapshot_height: applied_block_height,
-    last_block: t.last_block,
-    last_block_signatures: t.last_block_signatures,
-    additional_blocks,
+  switch (t.next_snapshots) {
+  | [(height, snapshot), ...tl] =>
+    let additional_blocks =
+      truncate_additional_blocks(height, t.additional_blocks);
+    {
+      current_snapshot: snapshot,
+      next_snapshots: tl,
+      last_block: t.last_block,
+      last_block_signatures: t.last_block_signatures,
+      additional_blocks,
+    };
+
+  | [] => failwith("You must add a snapshot before you can start a new epoch")
   };
+};
+
+let get_next_snapshot = t => {
+  let.some (_, snapshot) = List.nth_opt(t.next_snapshots, 0);
+  Some(snapshot);
 };

--- a/node/snapshots.re
+++ b/node/snapshots.re
@@ -1,13 +1,19 @@
 open Crypto;
 open Protocol;
 
+[@deriving yojson]
+type snapshot = {
+  hash: BLAKE2B.t,
+  data: string,
+};
+
 /*
  last_block should always have the same or
  bigger block_height than the state snapshot,
  this ensures that if last_block is signed the
  state snapshot will also be signed */
 type t = {
-  last_snapshot: (BLAKE2B.t, string),
+  last_snapshot: snapshot,
   last_snapshot_height: int64,
   last_block: Block.t,
   last_block_signatures: Signatures.t,

--- a/node/snapshots.rei
+++ b/node/snapshots.rei
@@ -1,9 +1,15 @@
 open Crypto;
 open Protocol;
 
+[@deriving yojson]
+type snapshot = {
+  hash: BLAKE2B.t,
+  data: string,
+};
+
 type t =
   pri {
-    last_snapshot: (BLAKE2B.t, string),
+    last_snapshot: snapshot,
     last_snapshot_height: int64,
     last_block: Block.t,
     last_block_signatures: Signatures.t,
@@ -12,7 +18,7 @@ type t =
 
 let make:
   (
-    ~initial_snapshot: (BLAKE2B.t, string),
+    ~initial_snapshot: snapshot,
     ~initial_block: Block.t,
     ~initial_signatures: Signatures.t
   ) =>
@@ -20,5 +26,4 @@ let make:
 
 /** this should be called when a block is received */
 let append_block: (~pool: Block_pool.t, (Block.t, Signatures.t), t) => t;
-let update:
-  (~new_snapshot: (BLAKE2B.t, string), ~applied_block_height: int64, t) => t;
+let update: (~new_snapshot: snapshot, ~applied_block_height: int64, t) => t;

--- a/node/snapshots.rei
+++ b/node/snapshots.rei
@@ -9,8 +9,8 @@ type snapshot = {
 
 type t =
   pri {
-    last_snapshot: snapshot,
-    last_snapshot_height: int64,
+    current_snapshot: snapshot,
+    next_snapshots: list((int64, snapshot)),
     last_block: Block.t,
     last_block_signatures: Signatures.t,
     additional_blocks: list(Block.t),
@@ -26,4 +26,7 @@ let make:
 
 /** this should be called when a block is received */
 let append_block: (~pool: Block_pool.t, (Block.t, Signatures.t), t) => t;
-let update: (~new_snapshot: snapshot, ~applied_block_height: int64, t) => t;
+// TODO: add_snapshot and start_new_epoch may be able to be fused into a single API since they should always happen together.
+let add_snapshot: (~new_snapshot: snapshot, ~block_height: int64, t) => t;
+let start_new_epoch: t => t;
+let get_next_snapshot: t => option(snapshot);

--- a/node/state.rei
+++ b/node/state.rei
@@ -22,7 +22,7 @@ type t = {
   block_pool: Block_pool.t,
   protocol: Protocol.t,
   snapshots: Snapshots.t,
-  next_state_root: (BLAKE2B.t, string),
+  next_state_root: Snapshots.snapshot,
   // networking
   uri_state: Uri_map.t(string),
   validators_uri: Address_map.t(Uri.t),
@@ -50,8 +50,7 @@ let apply_block:
 
 let load_snapshot:
   (
-    ~state_root_hash: BLAKE2B.t,
-    ~state_root: string,
+    ~snapshot: Snapshots.snapshot,
     ~additional_blocks: list(Block.t),
     ~last_block: Block.t,
     ~last_block_signatures: list(Signature.t),

--- a/node/state.rei
+++ b/node/state.rei
@@ -22,7 +22,6 @@ type t = {
   block_pool: Block_pool.t,
   protocol: Protocol.t,
   snapshots: Snapshots.t,
-  next_state_root: Snapshots.snapshot,
   // networking
   uri_state: Uri_map.t(string),
   validators_uri: Address_map.t(Uri.t),
@@ -64,5 +63,6 @@ let load_snapshot:
       | `Not_all_blocks_are_signed
       | `Snapshots_with_invalid_hash
       | `State_root_not_the_expected
+      | `Invalid_snapshot_height
     ],
   );


### PR DESCRIPTION
## Problem

This PR is another step towards #147. 

The problem is that we currently only store two snapshots: the latest in `state.snapshot` and the next one in `state.next_state_root`. With async state hashing we may need to store more. 
## Solution

To accomplish this, we push all snapshot logic into the snapshots module, removing the `next_state_root` property from the node state. We store all snapshots in a map, along with pointers to the current and next snapshot. We then move those pointers on each epoch. 
 