### PR TITLE
Async State Hashing

### DIFF
--- a/src/bin/deku_node.ml
+++ b/src/bin/deku_node.ml
@@ -58,21 +58,12 @@ let handle_block_level =
     (module Networking.Block_level)
     (fun _update_state _request ->
       Ok { level = Flows.find_block_level (Server.get_state ()) })
-let latest_snapshot = ref None
 let handle_protocol_snapshot =
   handle_request
     (module Networking.Protocol_snapshot)
     (fun _update_state () ->
       let State.{ snapshots; _ } = Server.get_state () in
-      let%ok snapshot =
-        match Snapshots.get_current_snapshot snapshots with
-        | Some snapshot ->
-          latest_snapshot := Some snapshot;
-          Ok snapshot
-        | None ->
-        match !latest_snapshot with
-        | Some latest_snapshot -> Ok latest_snapshot
-        | None -> Error `Node_not_yet_initialized in
+      let%ok snapshot = Snapshots.get_most_recent_snapshot snapshots in
       Ok
         Networking.Protocol_snapshot.
           {

--- a/src/bin/node_state.ml
+++ b/src/bin/node_state.ml
@@ -72,14 +72,11 @@ let get_initial_state ~folder =
       let%await prev_protocol =
         Files.State_bin.read ~file:prev_epoch_state_bin in
       let hash, data = Protocol.hash prev_protocol in
-      let snapshots =
-        Snapshots.add_snapshot
-          ~new_snapshot:
-            (let open Snapshots in
-            { hash; data })
-          ~block_height:prev_protocol.block_height node.snapshots
-        |> Snapshots.start_new_epoch in
-      await snapshots
+      let snapshot_ref, snapshots =
+        Snapshots.add_snapshot_ref ~block_height:prev_protocol.block_height
+          node.snapshots in
+      let () = Snapshots.set_snapshot_ref snapshot_ref { hash; data } in
+      await (Snapshots.start_new_epoch snapshots)
     else
       await node.snapshots in
   let node = { node with snapshots; protocol } in

--- a/src/node/dune
+++ b/src/node/dune
@@ -1,5 +1,5 @@
 (library
  (name node)
- (libraries protocol uri helpers piaf metrics)
+ (libraries protocol uri helpers piaf domainslib metrics)
  (preprocess
   (pps ppx_deriving_yojson ppx_deriving.ord ppx_let_binding)))

--- a/src/node/flows.ml
+++ b/src/node/flows.ml
@@ -2,6 +2,7 @@ open Helpers
 open Crypto
 open Protocol
 open Building_blocks
+open Domainslib
 module Node = State
 let write_state_to_file path protocol =
   let protocol_bin = Marshal.to_string protocol [] in
@@ -39,6 +40,7 @@ let string_of_error = function
   | `Not_all_blocks_are_signed -> "Not_all_blocks_are_signed"
   | `State_root_not_the_expected -> "State_root_not_the_expected"
   | `Snapshots_with_invalid_hash -> "Snapshots_with_invalid_hash"
+  | `Node_not_yet_initialized -> "Node_not_yet_initialized"
 
 let print_error err =
   Format.eprintf "\027[31mError: %s\027[m\n%!" (string_of_error err)
@@ -58,6 +60,7 @@ type ignore =
 let reset_timeout = (ref (fun () -> assert false) : (unit -> unit) ref)
 let get_state = (ref (fun () -> assert false) : (unit -> State.t) ref)
 let set_state = (ref (fun _ -> assert false) : (State.t -> unit) ref)
+let get_task_pool = (ref (fun () -> assert false) : (unit -> Task.pool) ref)
 let received_block' =
   (ref (fun _ -> assert false)
     : (Node.t ->
@@ -208,14 +211,21 @@ let try_to_commit_state_hash ~prev_validators state block signatures =
         ~block_payload_hash:block.payload_hash
         ~withdrawal_handles_hash:block.withdrawal_handles_hash
         ~state_hash:block.state_root_hash ~validators ~signatures)
+let hash_new_state_root state protocol update_state =
+  let task_pool = !get_task_pool () in
+  let snapshot_ref, snapshots =
+    Snapshots.add_snapshot_ref ~block_height:protocol.block_height
+      state.Node.snapshots in
+  let _task : unit Task.promise =
+    Task.async task_pool (fun () ->
+        let hash, data = Protocol.hash protocol in
+        Snapshots.set_snapshot_ref snapshot_ref { hash; data }) in
+  update_state { state with snapshots }
+
 let rec try_to_apply_block state update_state block =
   let%assert () =
     ( `Block_not_signed_enough_to_apply,
       Block_pool.is_signed ~hash:block.Block.hash state.Node.block_pool ) in
-  let%assert () =
-    ( `Invalid_state_root_hash,
-      block_matches_current_state_root_hash state block
-      || block_matches_next_state_root_hash state block ) in
   let prev_protocol = state.protocol in
   let is_new_state_root_hash =
     not (BLAKE2B.equal state.protocol.state_root_hash block.state_root_hash)
@@ -224,15 +234,22 @@ let rec try_to_apply_block state update_state block =
   write_state_to_file (state.Node.data_folder ^ "/state.bin") state.protocol;
   !reset_timeout ();
   let state = clean state update_state block in
-  if is_new_state_root_hash then (
-    write_state_to_file
-      (state.data_folder ^ "/prev_epoch_state.bin")
-      prev_protocol;
-    match Block_pool.find_signatures ~hash:block.hash state.block_pool with
-    | Some signatures when Signatures.is_self_signed signatures ->
-      try_to_commit_state_hash ~prev_validators:prev_protocol.validators state
-        block signatures
-    | _ -> ());
+  let state =
+    if is_new_state_root_hash then (
+      write_state_to_file
+        (state.data_folder ^ "/prev_epoch_state.bin")
+        prev_protocol;
+      let state = hash_new_state_root state prev_protocol update_state in
+      (match
+         Block_pool.find_signatures ~hash:block.hash state.Node.block_pool
+       with
+      | Some signatures when Signatures.is_self_signed signatures ->
+        try_to_commit_state_hash ~prev_validators:prev_protocol.validators state
+          block signatures
+      | _ -> ());
+      state)
+    else
+      state in
   match
     Block_pool.find_next_block_to_apply ~hash:block.Block.hash state.block_pool
   with

--- a/src/node/flows.ml
+++ b/src/node/flows.ml
@@ -227,6 +227,13 @@ let rec try_to_apply_block state update_state block =
     ( `Block_not_signed_enough_to_apply,
       Block_pool.is_signed ~hash:block.Block.hash state.Node.block_pool ) in
   let prev_protocol = state.protocol in
+  (* If the [block.state_root_hash] is not equal to either the
+     current state root hash or the next calculated state root hash, then
+     the node has become out of sync with the chain. In this case we will not sign
+     blocks, but will still apply blocks with enough signatures.
+     TODO: we currently stay out of sync until the next state root hash update that
+     we finish on time. But it would be good to be able to get back in sync
+     as soon as we finish hashing. See https://github.com/marigold-dev/deku/pull/250 *)
   let is_new_state_root_hash =
     not (BLAKE2B.equal state.protocol.state_root_hash block.state_root_hash)
   in

--- a/src/node/server.ml
+++ b/src/node/server.ml
@@ -36,6 +36,7 @@ let get_task_pool () =
   match !task_pool with
   | Some pool -> pool
   | None ->
+    (* TODO: proper number for additional domains *)
     let pool = Domainslib.Task.setup_pool ~num_additional_domains:4 () in
     let () = task_pool := Some pool in
     pool

--- a/src/node/server.ml
+++ b/src/node/server.ml
@@ -29,6 +29,18 @@ let rec reset_timeout server =
      | Error `Not_current_block_producer -> ());
      reset_timeout server;
      Lwt.return_unit)
+
+let task_pool = ref None
+
+let get_task_pool () =
+  match !task_pool with
+  | Some pool -> pool
+  | None ->
+    let pool = Domainslib.Task.setup_pool ~num_additional_domains:4 () in
+    let () = task_pool := Some pool in
+    pool
+
 let () = Flows.reset_timeout := fun () -> reset_timeout (get ())
 let () = Flows.get_state := get_state
 let () = Flows.set_state := set_state
+let () = Flows.get_task_pool := get_task_pool

--- a/src/node/snapshots.ml
+++ b/src/node/snapshots.ml
@@ -52,7 +52,7 @@ let add_snapshot_ref ~block_height t =
       additional_blocks = t.additional_blocks;
     } )
 let set_snapshot_ref ref_ snapshot =
-  Format.printf "\027[36m New protocol snapshot hash: %s\027[m\n%!"
+  Format.eprintf "\027[36m New protocol snapshot hash: %s\027[m\n%!"
     (snapshot.hash |> BLAKE2B.to_string);
   Atomic.set ref_ (Some snapshot)
 let start_new_epoch t =

--- a/src/node/snapshots.ml
+++ b/src/node/snapshots.ml
@@ -74,6 +74,7 @@ let start_new_epoch t =
     }
   | [] -> failwith "You must add a snapshot before you can start a new epoch"
 
+(* THIS IS GLOBAL STATE OUTSIDE OF ./server.ml. CAUTION *)
 let latest_finished_snapshot = ref None
 
 let get_most_recent_snapshot t =

--- a/src/node/snapshots.ml
+++ b/src/node/snapshots.ml
@@ -73,7 +73,19 @@ let start_new_epoch t =
       additional_blocks;
     }
   | [] -> failwith "You must add a snapshot before you can start a new epoch"
-let get_current_snapshot t = Atomic.get t.current_snapshot
+
+let latest_finished_snapshot = ref None
+
+let get_most_recent_snapshot t =
+  match Atomic.get t.current_snapshot with
+  | Some snapshot ->
+    latest_finished_snapshot := Some snapshot;
+    Ok snapshot
+  | None ->
+  match !latest_finished_snapshot with
+  | Some latest_finished_snapshot -> Ok latest_finished_snapshot
+  | None -> Error `Node_not_yet_initialized
+
 let get_next_snapshot t =
   let%some _, snapshot = List.nth_opt t.next_snapshots 0 in
   Atomic.get snapshot

--- a/src/node/snapshots.ml
+++ b/src/node/snapshots.ml
@@ -6,17 +6,24 @@ type snapshot = {
   data : string;
 }
 [@@deriving yojson]
+type snapshot_ref = snapshot option Atomic.t
 type t = {
-  current_snapshot : snapshot;
-  next_snapshots : (int64 * snapshot) list;
+  current_snapshot : snapshot_ref;
+  next_snapshots : (int64 * snapshot_ref) list;
   last_block : Block.t;
   last_block_signatures : Signatures.t;
   additional_blocks : Block.t list;
 }
 let make ~initial_snapshot ~initial_block ~initial_signatures =
   {
-    current_snapshot = { hash = initial_block.Block.state_root_hash; data = "" };
-    next_snapshots = [(initial_block.block_height, initial_snapshot)];
+    current_snapshot =
+      Atomic.make
+        (* TODO: if a snapshot is requested before first epoch starts, we will send meaningless data.
+           We need to have logic in the snapshot request handler such that we send a 503 error or something
+           instead of sending bad data. *)
+        (Some { hash = initial_block.Block.state_root_hash; data = "" });
+    next_snapshots =
+      [(initial_block.block_height, Atomic.make (Some initial_snapshot))];
     last_block = initial_block;
     last_block_signatures = initial_signatures;
     additional_blocks = [];
@@ -34,16 +41,20 @@ let append_block ~pool (block, signatures) t =
       last_block_signatures = signatures;
       additional_blocks = blocks @ [t.last_block] @ t.additional_blocks;
     }
-let add_snapshot ~new_snapshot ~block_height t =
-  Format.eprintf "\027[36mNew protocol snapshot hash: %s\027[m\n%!"
-    (new_snapshot.hash |> BLAKE2B.to_string);
-  {
-    next_snapshots = t.next_snapshots @ [(block_height, new_snapshot)];
-    current_snapshot = t.current_snapshot;
-    last_block = t.last_block;
-    last_block_signatures = t.last_block_signatures;
-    additional_blocks = t.additional_blocks;
-  }
+let add_snapshot_ref ~block_height t =
+  let atom = Atomic.make None in
+  ( atom,
+    {
+      next_snapshots = t.next_snapshots @ [(block_height, atom)];
+      current_snapshot = t.current_snapshot;
+      last_block = t.last_block;
+      last_block_signatures = t.last_block_signatures;
+      additional_blocks = t.additional_blocks;
+    } )
+let set_snapshot_ref ref_ snapshot =
+  Format.printf "\027[36m New protocol snapshot hash: %s\027[m\n%!"
+    (snapshot.hash |> BLAKE2B.to_string);
+  Atomic.set ref_ (Some snapshot)
 let start_new_epoch t =
   let rec truncate_additional_blocks block_height blocks =
     match blocks with
@@ -62,6 +73,7 @@ let start_new_epoch t =
       additional_blocks;
     }
   | [] -> failwith "You must add a snapshot before you can start a new epoch"
+let get_current_snapshot t = Atomic.get t.current_snapshot
 let get_next_snapshot t =
   let%some _, snapshot = List.nth_opt t.next_snapshots 0 in
-  Some snapshot
+  Atomic.get snapshot

--- a/src/node/snapshots.mli
+++ b/src/node/snapshots.mli
@@ -5,9 +5,10 @@ type snapshot = {
   data : string;
 }
 [@@deriving yojson]
+type snapshot_ref
 type t = private {
-  current_snapshot : snapshot;
-  next_snapshots : (int64 * snapshot) list;
+  current_snapshot : snapshot_ref;
+  next_snapshots : (int64 * snapshot_ref) list;
   last_block : Block.t;
   last_block_signatures : Signatures.t;
   additional_blocks : Block.t list;
@@ -21,6 +22,8 @@ val make :
 val append_block : pool:Block_pool.t -> Block.t * Signatures.t -> t -> t
   [@@ocaml.doc " this should be called when a block is received "]
 
-val add_snapshot : new_snapshot:snapshot -> block_height:int64 -> t -> t
+val add_snapshot_ref : block_height:int64 -> t -> snapshot_ref * t
+val set_snapshot_ref : snapshot_ref -> snapshot -> unit
 val start_new_epoch : t -> t
+val get_current_snapshot : t -> snapshot option
 val get_next_snapshot : t -> snapshot option

--- a/src/node/snapshots.mli
+++ b/src/node/snapshots.mli
@@ -25,5 +25,6 @@ val append_block : pool:Block_pool.t -> Block.t * Signatures.t -> t -> t
 val add_snapshot_ref : block_height:int64 -> t -> snapshot_ref * t
 val set_snapshot_ref : snapshot_ref -> snapshot -> unit
 val start_new_epoch : t -> t
-val get_current_snapshot : t -> snapshot option
+val get_most_recent_snapshot :
+  t -> (snapshot, [> `Node_not_yet_initialized]) result
 val get_next_snapshot : t -> snapshot option

--- a/src/node/state.ml
+++ b/src/node/state.ml
@@ -70,14 +70,7 @@ let apply_block state block =
     then
       state.snapshots
     else
-      let hash, data = Protocol.hash prev_protocol in
-      state.snapshots
-      |> Snapshots.start_new_epoch
-      |> Snapshots.add_snapshot
-           ~new_snapshot:
-             (let open Snapshots in
-             { hash; data })
-           ~block_height:prev_protocol.block_height in
+      Snapshots.start_new_epoch state.snapshots in
   let recent_operation_receipts =
     List.fold_left
       (fun results (hash, receipt) -> BLAKE2B.Map.add hash receipt results)
@@ -150,8 +143,33 @@ let load_snapshot ~snapshot ~additional_blocks ~last_block
       last_applied_block_timestamp = 0.0;
       last_seen_membership_change_timestamp = 0.0;
     } in
+  (* TODO: this causes syncing to fail unless the snapshot is newer than the
+     current block height, which is not always true (i.e, if you restart
+     a node that's in sync very quickly. We need to have a more discerning
+     validation here. *)
   let%assert () =
     (`Invalid_snapshot_height, protocol.block_height > t.protocol.block_height)
   in
   let t = { t with protocol; block_pool } in
-  List.fold_left_ok apply_block t all_blocks
+  (* TODO: it doesn't seem valid to add a snapshot here based on the information received
+     from our (untrusted) peer; however, that's exactly what we're doing here. Supposing
+     the peer sending the snapshot is dishonest, we will then start propogating a bad snapshot.
+     In the future, we should only add snapshots once we're in sync. *)
+  List.fold_left_ok
+    (fun prev_state block ->
+      let%ok state = apply_block prev_state block in
+      if
+        BLAKE2B.equal prev_state.protocol.state_root_hash
+          state.protocol.state_root_hash
+      then
+        Ok state
+      else
+        (* TODO: this should be done in parallel, as otherwise the node
+           may not be able to load the snapshot fast enough. *)
+        let hash, data = Protocol.hash prev_state.protocol in
+        let snapshot_ref, snapshots =
+          Snapshots.add_snapshot_ref
+            ~block_height:prev_state.protocol.block_height state.snapshots in
+        let () = Snapshots.set_snapshot_ref snapshot_ref { hash; data } in
+        Ok { state with snapshots })
+    t all_blocks


### PR DESCRIPTION
## Depends

- [x] #413
- [x] #412
- [x] #501 

## Problem

Adds full async hashing per #147 . 



## Solution

In #412, we started storing a list of snapshots. In this PR, we instead store a list of mutable references to `option(snapshot)`'s. 
We hash the protocol's on different threads using `Domainslib.Task.async`,and then updates the references when done.

**This assumes Atomic.t works out of the box with multicore! Is this true?**

Reviewers probably want to check that I'm setting up `Domainslib.Task.setup_pool` correctly. I discovered that unless I call it after `Lwt_main.run`, `Lwt_main.run` fails with:
```
Unix.fork may not be called while other domains were created
```

There is some new complexity in `deku_node.ml`. Specifically, because the `snapshot.current_snapshot` may be `None`, we keep a ref of the last snapshot available, so we can always return a snapshot to those who ask. I believe it's important to always have the latest snapshot available to other nodes to minimize synchronization time. But if you can think of a cleaner way to do it than what I've done, please let me know.

This is still missing the recovery mechanism from #250 - I'll rebase that PR to this one.

## Related
- Supersedes #243