### PR TITLE
Add endpoint to give information about expected gas cost of operation

### DIFF
--- a/bin/deku_node.re
+++ b/bin/deku_node.re
@@ -179,6 +179,18 @@ let handle_receive_consensus_operation =
       request.signature,
     )
   });
+let handle_operation_mock =
+  handle_request(
+    (module Networking.User_operation_mock),
+    (_, request) => {
+      let (gas_consumed, result) =
+        Flows.received_operation_mock_request(
+          Server.get_state(),
+          request.user_operation,
+        );
+      Ok(Networking.User_operation_mock.{gas_consumed, result});
+    },
+  );
 
 let handle_trusted_validators_membership =
   handle_request(
@@ -231,6 +243,7 @@ let node = folder => {
     |> handle_register_uri
     |> handle_receive_user_operation_gossip
     |> handle_receive_consensus_operation
+    |> handle_operation_mock
     |> handle_withdraw_proof
     |> handle_ticket_balance
     |> handle_trusted_validators_membership

--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -274,7 +274,7 @@ let create_transaction = {
   let ticket = {
     let doc = "The ticket to be transferred.";
     Arg.(
-      required & pos(4, some(ticket), None) & info([], ~docv="MSG", ~doc)
+      required & pos(4, some(ticket), None) & info([], ~docv="ticket", ~doc)
     );
   };
 
@@ -350,7 +350,7 @@ let withdraw = {
   let ticket = {
     let doc = "The ticket to be trasnsacted.";
     Arg.(
-      required & pos(4, some(ticket), None) & info([], ~docv="MSG", ~doc)
+      required & pos(4, some(ticket), None) & info([], ~docv="ticket", ~doc)
     );
   };
 

--- a/node/flows.re
+++ b/node/flows.re
@@ -449,6 +449,10 @@ let received_consensus_operation =
     );
   Ok();
 };
+let received_operation_mock_request = (_state, _operation) => {
+  // TODO: fix this
+  (0, Some());
+};
 
 let find_block_by_hash = (state, hash) =>
   Block_pool.find_block(~hash, state.Node.block_pool);

--- a/node/networking.re
+++ b/node/networking.re
@@ -168,6 +168,17 @@ module Consensus_operation_gossip = {
   type response = unit;
   let path = "/consensus-operation-gossip";
 };
+module User_operation_mock = {
+  [@deriving yojson]
+  type request = {user_operation: Protocol.Operation.Core_user.t};
+  [@deriving yojson]
+  type response = {
+    gas_consumed: int,
+    result: option(unit),
+  };
+
+  let path = "/user-operation-mock";
+};
 
 module Withdraw_proof = {
   [@deriving yojson]
@@ -235,3 +246,4 @@ let request_consensus_operation =
   request((module Consensus_operation_gossip));
 let request_trusted_validator_membership =
   request((module Trusted_validators_membership_change));
+let request_operation_mock = request((module User_operation_mock));

--- a/protocol/protocol.re
+++ b/protocol/protocol.re
@@ -56,8 +56,8 @@ let apply_core_user_operation = (state, user_operation) => {
     Core.State.apply_user_operation(state.core_state, data);
   Ok(({...state, core_state, included_user_operations}, receipt));
 };
-let apply_core_user_operation = (state, tezos_operation) =>
-  switch (apply_core_user_operation(state, tezos_operation)) {
+let apply_core_user_operation = (state, user_operation) =>
+  switch (apply_core_user_operation(state, user_operation)) {
   | Ok((state, receipts)) => (state, receipts)
   | Error(`Block_in_the_future | `Old_operation | `Duplicated_operation) => (
       state,


### PR DESCRIPTION
## Depends

<!--- All PR or issues that are required to be closed / merged before this can be merged --->
- [x] #417

## Problem

We want to have a way to show the user in the CLI whether or not the operation they're submitting will succeed. The CLI can't compute this itself, so we need to add an API endpoint to the node to communicate this information.

## Solution

Add an API endpoint that in the future can be extended to return information about gas cost and whether or not an operation was successful. 

## Related

- #415
 