### PR TITLE
Ppx let binding

### DIFF
--- a/ppx_let_binding/.ocamlformat
+++ b/ppx_let_binding/.ocamlformat
@@ -1,0 +1,21 @@
+version = 0.19.0
+profile = conventional
+
+leading-nested-match-parens = false
+align-constructors-decl = true
+align-variants-decl = true
+space-around-variants = false
+space-around-arrays = false
+space-around-lists = false
+space-around-records = false
+break-before-in = auto
+break-infix = fit-or-vertical
+break-separators = after
+space-around-records = true
+break-cases = all
+cases-exp-indent = 2
+exp-grouping = preserve
+nested-match = align
+if-then-else = fit-or-vertical
+let-and = sparse
+type-decl = sparse

--- a/ppx_let_binding/dune
+++ b/ppx_let_binding/dune
@@ -1,0 +1,6 @@
+(library
+ (name ppx_let_binding)
+ (kind ppx_rewriter)
+ (libraries ppxlib)
+ (preprocess
+  (pps ppxlib.metaquot)))

--- a/ppx_let_binding/ppx_let_binding.ml
+++ b/ppx_let_binding/ppx_let_binding.ml
@@ -30,7 +30,34 @@ let sig_let_ident_rule =
   in
   Ppxlib.Context_free.Rule.extension extension
 
+(* let%ok p = e1 in e2 *)
+let make_let_binding loc name var value body =
+  let name = { txt = "let." ^ name; loc } in
+  let binding_op = Exp.binding_op name var value loc in
+  Exp.letop ~loc binding_op [] body
+
+let make_let_extension_rule name =
+  let expand ~ctxt expr =
+    let loc = Expansion_context.Extension.extension_point_loc ctxt in
+    match expr with
+    | [%expr
+        let [%p? var] = [%e? value] in
+        [%e? body]] ->
+      make_let_binding loc name var value body
+    | _ ->
+      Location.raise_errorf ~loc
+        "Extension %%%s can only be used with a let, e.g. let%%%s a = b in ..."
+        name name in
+  let extension =
+    Extension.V3.declare name Extension.Context.expression
+      Ast_pattern.(single_expr_payload __)
+      expand in
+  Ppxlib.Context_free.Rule.extension extension
+
+let let_extension_rules =
+  List.map make_let_extension_rule ["await"; "some"; "default"; "ok"; "assert"]
+
 let () =
   Driver.register_transformation
-    ~rules:[str_let_ident_rule; sig_let_ident_rule]
+    ~rules:(str_let_ident_rule :: sig_let_ident_rule :: let_extension_rules)
     "ppx_let_binding"

--- a/ppx_let_binding/ppx_let_binding.ml
+++ b/ppx_let_binding/ppx_let_binding.ml
@@ -1,0 +1,20 @@
+open Ppxlib
+open Ast_helper
+
+(* on structure [%%let ("ident", value)]*)
+let str_let_ident_rule =
+  let expand ~ctxt name value =
+    let loc = Expansion_context.Extension.extension_point_loc ctxt in
+    let pattern = Pat.var ~loc { txt = name; loc } in
+    [%stri let [%p pattern] = [%e value]] in
+
+  let pattern =
+    Ast_pattern.(single_expr_payload (pexp_tuple (estring __ ^:: __ ^:: nil)))
+  in
+  let extension =
+    Extension.V3.declare "let" Extension.Context.structure_item pattern expand
+  in
+  Ppxlib.Context_free.Rule.extension extension
+
+let () =
+  Driver.register_transformation ~rules:[str_let_ident_rule] "ppx_let_binding"

--- a/ppx_let_binding/ppx_let_binding.ml
+++ b/ppx_let_binding/ppx_let_binding.ml
@@ -16,5 +16,21 @@ let str_let_ident_rule =
   in
   Ppxlib.Context_free.Rule.extension extension
 
+(* on signature [%%let ("ident" : typ)]*)
+let sig_let_ident_rule =
+  let expand ~ctxt name typ =
+    let loc = Expansion_context.Extension.extension_point_loc ctxt in
+    let val_desc = Val.mk ~loc { txt = name; loc } typ in
+    Sig.value val_desc in
+
+  let pattern =
+    Ast_pattern.(single_expr_payload (pexp_constraint (estring __) __)) in
+  let extension =
+    Extension.V3.declare "let" Extension.Context.signature_item pattern expand
+  in
+  Ppxlib.Context_free.Rule.extension extension
+
 let () =
-  Driver.register_transformation ~rules:[str_let_ident_rule] "ppx_let_binding"
+  Driver.register_transformation
+    ~rules:[str_let_ident_rule; sig_let_ident_rule]
+    "ppx_let_binding"

--- a/ppx_let_binding/test/dune
+++ b/ppx_let_binding/test/dune
@@ -1,0 +1,10 @@
+(executable
+ (name ppx_let_binding_test)
+ (preprocess
+  (pps ppx_let_binding)))
+
+(rule
+ (alias runtest)
+ (deps ./ppx_let_binding_test.exe)
+ (action
+  (run ./ppx_let_binding_test.exe)))

--- a/ppx_let_binding/test/ppx_let_binding_test.ml
+++ b/ppx_let_binding/test/ppx_let_binding_test.ml
@@ -1,0 +1,13 @@
+module M : sig
+  [%%let ("let.some" : 'a option -> ('a -> 'b option) -> 'b option)]
+end = struct
+  [%%let "let.some", Option.bind]
+end
+
+open M
+
+let option_two =
+  let%some one = Some 1 in
+  Some (one + 1)
+
+let () = assert (option_two = Some 2)


### PR DESCRIPTION
## Problem
We want to migrate to OCaml syntax, but OCaml syntax does not support the custom let bindings that Reason does.

## Solution
This PR adds a PPX that allows users to define custom let expressions a la Reason. The only difference is that you have to replace the `.` with a `%` when you use the let expression

One issue is that we couldn't figure out a simple way to dynamically register the syntax extensions. Thus, we simply hard-coded a list of extensions to check for (the ones we currently use). This list can easily be extended, or if someone wants to put in the work to make it cleaner/more dynamic, they certainly can. But we felt this was good enough for a first pass.
