### PR TITLE
Communicate with NodeJs over named pipes

### DIFF
--- a/bin/deku_node.re
+++ b/bin/deku_node.re
@@ -208,6 +208,7 @@ let handle_ticket_balance =
 
 let node = folder => {
   let node = Node_state.get_initial_state(~folder) |> Lwt_main.run;
+  Tezos_interop.Consensus.initialize_taquito(~data_folder=folder);
   Tezos_interop.Consensus.listen_operations(
     ~context=node.Node.State.interop_context, ~on_operation=operation =>
     Flows.received_tezos_operation(

--- a/helpers/dune
+++ b/helpers/dune
@@ -1,5 +1,5 @@
 (library
  (name helpers)
- (libraries lwt uri zarith hex digestif)
+ (libraries lwt lwt.unix uri zarith hex digestif)
  (preprocess
   (pps ppx_deriving_yojson)))

--- a/helpers/helpers.re
+++ b/helpers/helpers.re
@@ -6,6 +6,7 @@ module Option = Option_ext;
 module Yojson_ext = Yojson_ext;
 module Map = Map_ext;
 module Set = Set_ext;
+module Named_pipe = Named_pipe;
 module String_map =
   Map.Make_with_yojson({
     [@deriving yojson]

--- a/helpers/named_pipe.re
+++ b/helpers/named_pipe.re
@@ -1,0 +1,19 @@
+module StringMap = Map.Make(String);
+
+let make_pipe_pair = path => {
+  let permissions = 0o600;
+  if (!Sys.file_exists(path ++ "_read")) {
+    Unix.mkfifo(path ++ "_read", permissions);
+  };
+  if (!Sys.file_exists(path ++ "_write")) {
+    Unix.mkfifo(path ++ "_write", permissions);
+  };
+};
+
+let get_pipe_pair_channels = path => {
+  let read_fd = Unix.openfile(path ++ "_read", [Unix.O_RDONLY], 0o000);
+  let read_channel = Lwt_io.of_unix_fd(~mode=Input, read_fd);
+  let write_fd = Unix.openfile(path ++ "_write", [Unix.O_WRONLY], 0o000);
+  let write_channel = Lwt_io.of_unix_fd(~mode=Output, write_fd);
+  (read_channel, write_channel);
+};

--- a/helpers/named_pipe.rei
+++ b/helpers/named_pipe.rei
@@ -1,0 +1,9 @@
+/** [make_pipe_pair path] Makes two unix named pipes (FIFO pipes).
+    The path of the first is [path] suffixed with "_read", the path
+    of the second is [path] suffixed with "_write". */
+let make_pipe_pair: string => unit;
+
+/** [get_pipe_pair_channels path] returns a pair containing input and output channels
+    for the pipes created with [make_pipe_pair path]. */
+let get_pipe_pair_channels:
+  string => (Lwt_io.channel(Lwt_io.input), Lwt_io.channel(Lwt_io.output));

--- a/node/flows.re
+++ b/node/flows.re
@@ -197,7 +197,8 @@ let try_to_sign_block = (state, update_state, block) =>
 
 let commit_state_hash = state =>
   Tezos_interop.Consensus.commit_state_hash(
-    ~context=state.Node.interop_context,
+    ~data_folder=state.Node.data_folder,
+    ~context=state.interop_context,
   );
 let try_to_commit_state_hash = (~prev_validators, state, block, signatures) => {
   open Node;

--- a/tezos_interop/run_entrypoint.js
+++ b/tezos_interop/run_entrypoint.js
@@ -13,43 +13,61 @@ const { InMemorySigner } = require("@taquito/signer");
  * @property {string} destination
  * @property {string} entrypoint
  * @property {object} payload
- */
-/** @returns {Input} */
-const input = () => JSON.parse(fs.readFileSync(process.stdin.fd));
-
-/**
+ *
  * @typedef OutputFinished
  * @type {object}
  * @property {"applied" | "failed" | "skipped" | "backtracked" | "unknown"} status
  * @property {string} hash
- */
-/**
+ *
  * @typedef OutputError
  * @type {object}
  * @property {"error"} status
  * @property {string} error
+ *
+ * @param {Input}
+ * @returns {OutputFinished | OutputError}
  */
-/** @param {OutputFinished | OutputError} data */
-const output = (data) =>
-  fs.writeFileSync(process.stdout.fd, JSON.stringify(data, null, 2));
-
-const finished = (status, hash) => output({ status, hash });
-const error = (error) =>
-  output({ status: "error", error: JSON.stringify(error) });
-
-(async () => {
-  const { rpc_node, secret, confirmation, destination, entrypoint, payload } =
-    input();
+async function runTransaction({
+  rpc_node,
+  secret,
+  confirmation,
+  destination,
+  entrypoint,
+  payload,
+}) {
+  try {
+  } catch (error) {}
   const args = Object.entries(payload)
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([_, value]) => value);
   const Tezos = new TezosToolkit(rpc_node);
   const signer = await InMemorySigner.fromSecretKey(secret);
   Tezos.setProvider({ signer });
-
   const contract = await Tezos.contract.at(destination);
   const operation = await contract.methods[entrypoint](...args).send();
   await operation.confirmation(confirmation);
 
-  finished(operation.status, operation.hash);
-})().catch(error);
+  return { status: operation.status, hash: operation.hash };
+}
+
+const namedPipePath = process.argv[2];
+const chainToTaquito = fs.createReadStream(namedPipePath + "_write");
+const taquitoToChain = fs.createWriteStream(namedPipePath + "_read");
+
+async function run() {
+  for await (const data of chainToTaquito) {
+    const { nonce, ...json } = JSON.parse(data.toString());
+    try {
+      let result = await runTransaction(json);
+      let result_str = JSON.stringify({ ...result, nonce }) + "\n";
+      taquitoToChain.write(result_str);
+    } catch (error) {
+      console.error(error);
+      taquitoToChain.write("taquito error");
+    }
+  }
+}
+
+(async () => {
+  await run();
+})();

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -15,6 +15,7 @@ module Consensus: {
   /** ~signatures should be in the same order as the old validators */
   let commit_state_hash:
     (
+      ~data_folder: string,
       ~context: Context.t,
       ~block_height: int64,
       ~block_payload_hash: BLAKE2B.t,
@@ -39,6 +40,7 @@ module Consensus: {
   };
   let listen_operations:
     (~context: Context.t, ~on_operation: operation => unit) => unit;
+  let initialize_taquito: (~data_folder: string) => unit;
   let fetch_validators:
     (~context: Context.t) => Lwt.t(result(list(Key_hash.t), string));
 };


### PR DESCRIPTION
## Problem

In OCaml multicore, [Unix.fork may not be called after setting up a Domains pool](https://github.com/ocaml/ocaml/blob/001997e81342fd0d321fd877b73608150601e7d9/testsuite/tests/lib-unix/common/multicore_fork_domain_alone.ml). This is a problem for #147 , because in our current model, we use `Lwt_process.pmap` to spawn new NodeJS processes every time we commit to Tezos. 

## Solution

This PR transitions the NodeJS `run_transaction.js` script to be a long-lived process, communicating with the main thread via a [named pipes](https://man7.org/linux/man-pages/man7/fifo.7.html). 

This PR introduces quite a bit of complexity, and should eventually be superseded by a PR to completely replace the `run_transaction.js` script with OCaml code. However, part of this complexity is justified because we want to use named pipes when modularizing the state transition function to work with other languages. 

Some things to validate during review:
- Does Lwt automatically clean up the file descriptor references when we shut Deku down? So far I haven't noticed any issues here, but I want to make sure. 
- Am I reading the channel correctly? I determined the maximum size of a message sent by the NodeJS script is 98 bytes, so I just call `Lwt_io.read(~count=100, ...)` to fully consume it. This spares having a more complex protocol between the two processes (i.e, first sending the size of the payload, then sending the payload), but I want to make sure this doesn't bite us.
- It's possible for messages to come back to Deku main thread out of order. To handle this, I associate each payload sent to NodeJS with a nonce counter and store a promise resolution in a mutable map. Each message received from NodeJS contains a nonce, allowing us to resolve the correct promise. Suppose messages A and B are sent to NodeJS, and B finishes first. A will cause a read of the pipe, and will receive the result for B, lookup B's promise resolution, and resolve it with the right value. B will also cause a read, but will receive A, and resolve A's promise. This is entirely untested and it could be all wrong. Please look at it carefully.

## Related

- #147, #414
 