### PR TITLE
Refactor: move print_error from deku_node to flows

### DIFF
--- a/src/bin/deku_node.ml
+++ b/src/bin/deku_node.ml
@@ -6,38 +6,6 @@ open Bin_common
 let ignore_some_errors = function
   | Error #Flows.ignore -> Ok ()
   | v -> v
-let print_error err =
-  let open Format in
-  (match err with
-  | `Added_block_has_lower_block_height ->
-    eprintf "Added block has lower block height"
-  | `Added_block_not_signed_enough_to_desync ->
-    eprintf "Added_block_not_signed_enough_to_desync"
-  | `Added_signature_not_signed_enough_to_request ->
-    eprintf "Added_signature_not_signed_enough_to_request"
-  | `Already_known_block -> eprintf "Already_known_block"
-  | `Already_known_signature -> eprintf "Already_known_signature"
-  | `Block_not_signed_enough_to_apply ->
-    eprintf "Block_not_signed_enough_to_apply"
-  | `Failed_to_verify_payload -> eprintf "Failed to verify payload signature"
-  | `Invalid_address_on_main_operation ->
-    eprintf "Invalid_address_on_main_operation"
-  | `Invalid_block string -> eprintf "Invalid_block(%s)" string
-  | `Invalid_block_when_applying -> eprintf "Invalid_block_when_applying"
-  | `Invalid_nonce_signature -> eprintf "Invalid_nonce_signature"
-  | `Invalid_signature_author -> eprintf "Invalid_signature_author"
-  | `Invalid_signature_for_this_hash ->
-    eprintf "Invalid_signature_for_this_hash"
-  | `Invalid_state_root_hash -> eprintf "Invalid_state_root_hash"
-  | `Not_current_block_producer -> eprintf "Not_current_block_producer"
-  | `Not_a_json -> eprintf "Invalid json"
-  | `Not_a_valid_request err -> eprintf "Invalid request: %s" err
-  | `Pending_blocks -> eprintf "Pending_blocks"
-  | `Unknown_uri -> eprintf "Unknown_uri"
-  | `Not_a_user_opertaion -> eprintf "Not_a_user_opertaion"
-  | `Not_consensus_operation -> eprintf "Not_consensus_operation"
-  | `Invalid_signature -> eprintf "Invalid_signature");
-  eprintf "\n%!"
 let update_state state =
   Server.set_state state;
   state
@@ -58,7 +26,7 @@ let handle_request (type req res)
         let response = E.response_to_yojson response in
         await (Response.of_json ~status:`OK response)
       | Error err ->
-        print_error err;
+        Flows.print_error err;
         await (Response.make ~status:`Internal_server_error ()))
 let handle_received_block_and_signature =
   handle_request


### PR DESCRIPTION
## Problem

1. `print_error` should be re-usable in several modules
1. `print_error` is missing a few kinds of errors producable by the node
1. When we load snapshot, we supress errors, which is bad when debugging/troubleshooting.
1. Our error messages are just plain white text, no formatting. Lame.

## Solution

1.  Moved  function.
1.  Added missing errors
1. Use `print_error` to print errors when loading a snapshot.
1.  Add some formatting to the error message to make it stand out.

 