### PR TITLE
add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Convert from Reason to OCaml syntax
+2b69a2db076a48a7dcceeaf95aa3a7c2b037400a
+
+# Format the codebase
+47b08928f7fbbe510c32ba32936930d9a2f9dba2


### PR DESCRIPTION


<!---
  if some of the following sections doesn't apply,
  delete the section.

  Also feel free to delete the comments.
--->

## Problem

<!--- Restate the problem addressed by the PR here --->


Migrating to OCaml sytnax changed every file.

## Solution

Add a file listing which commits should be ignored in
git-blame. You must configure your local git to use
it with:

git config blame.ignoreRevsFile .git-blame-ignore-revs

See https://www.moxio.com/blog/43/ignoring-bulk-change-commits-with-git-blame


 