### PR TITLE
D4hines/clean-up-ocaml-syntax

### DIFF
--- a/reason-to-ocaml.sh
+++ b/reason-to-ocaml.sh
@@ -3,6 +3,7 @@ set -e
 
 if [ -z "$1" ]; then
     echo "Converts a ReasonML file (.re or .rei) into an OCaml file. Does not do the renaming."
+    echo "If the file is already an OCaml file, then it just fixes certain artifacts left over from Reason transformation."
     echo
     echo "(For tips on ignoring mass changes in Git Blame, check out https://www.moxio.com/blog/43/ignoring-bulk-change-commits-with-git-blame)"
     echo
@@ -35,7 +36,9 @@ fix_let_syntax_recursive() {
 files=("$@")
 for i in "${files[@]}"; do
     echo "$i: Converting syntax with refmt."
-    esy refmt --in-place --parse=re --print=ml $i
+    if [[ $i == *.re* ]]; then
+        esy refmt --in-place --parse=re --print=ml $i
+    fi
     echo "$i Stripping annotations"
     comby "[@reason.:[any]]" "" -i $i
     comby "[@explicit_:[any]]" "" -i $i

--- a/src/node/flows.ml
+++ b/src/node/flows.ml
@@ -254,20 +254,17 @@ and block_added_to_the_pool state update_state block =
     let state = try_to_sign_block state update_state block in
     try_to_apply_block state update_state block
   else
-    [%assert
-      let () =
-        ( `Added_block_not_signed_enough_to_desync,
-          Block_pool.is_signed ~hash:block.hash state.block_pool ) in
-      let%assert () =
-        ( `Added_block_has_lower_block_height,
-          block.block_height > state.protocol.block_height ) in
-      match
-        Block_pool.find_block ~hash:block.previous_hash state.block_pool
-      with
-      | Some block -> block_added_to_the_pool state update_state block
-      | None ->
-        request_previous_blocks state block;
-        Ok ()]
+    let%assert () =
+      ( `Added_block_not_signed_enough_to_desync,
+        Block_pool.is_signed ~hash:block.hash state.block_pool ) in
+    let%assert () =
+      ( `Added_block_has_lower_block_height,
+        block.block_height > state.protocol.block_height ) in
+    match Block_pool.find_block ~hash:block.previous_hash state.block_pool with
+    | Some block -> block_added_to_the_pool state update_state block
+    | None ->
+      request_previous_blocks state block;
+      Ok ()
 ;;
 block_added_to_the_pool' := block_added_to_the_pool
 let received_block state update_state block =

--- a/src/node/server.ml
+++ b/src/node/server.ml
@@ -19,17 +19,16 @@ let set_state state = (get ()).state <- state
 let rec reset_timeout server =
   Lwt.cancel server.timeout;
   server.timeout <-
-    [%await
-      let () = Lwt_unix.sleep 10.0 in
-      (match
-         try_to_produce_block server.state (fun state ->
-             server.state <- state;
-             state)
-       with
-      | Ok () -> ()
-      | Error `Not_current_block_producer -> ());
-      reset_timeout server;
-      Lwt.return_unit]
+    (let%await () = Lwt_unix.sleep 10.0 in
+     (match
+        try_to_produce_block server.state (fun state ->
+            server.state <- state;
+            state)
+      with
+     | Ok () -> ()
+     | Error `Not_current_block_producer -> ());
+     reset_timeout server;
+     Lwt.return_unit)
 ;;
 Flows.reset_timeout := fun () -> reset_timeout (get ());;
 Flows.get_state := get_state;;


### PR DESCRIPTION
## Problem

Not sure how, but when we migrated ocaml syntax in 2b69a2d, I missed a few let sytnax transformations. 

## Solution

I modified the script to work on ocaml files as well and reapplied it. I checked this time to see that all the `[%custom_thing let ...`'s were gone this time. 
