### PR TITLE
feat: add docker-compose.yml and improve sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ esy test
 
 ### Running a sidechain
 
-For convenient local development, we have a included two components:
+For convenient local development, we have included two components:
 - A `docker-compose.yml` file that setups a local Tezos network
   using [Flextesa](https://tezos.gitlab.io/flextesa/) running in Docker.
   Additionally, the network sets up a [Better Call Dev](https://github.com/baking-bad/bcdhub) instance

--- a/README.md
+++ b/README.md
@@ -38,23 +38,31 @@ esy test
 
 ### Running a sidechain
 
-For convenient local development, we have a included a script `sandbox.sh` that
-automates the setup of a local Tezos network using [Flextesa](https://tezos.gitlab.io/flextesa/)
-running in Docker. Additionally, the script sets up a identities for a local Deku cluster.
-This script is the easiest way to get started with Deku; however, it uses unsafe
-configuration options to lower the required Tezos confirmations to 1. This setting greatly
-speeds up local development, **but is not at all safe for production**!
+For convenient local development, we have a included two components:
+- A `docker-compose.yml` file that setups a local Tezos network
+  using [Flextesa](https://tezos.gitlab.io/flextesa/) running in Docker.
+  Additionally, the network sets up a [Better Call Dev](https://github.com/baking-bad/bcdhub) instance
+  for introspection of the deployed contract and its operations. The BCD interace is available in
+  your browser at http://localhost:8000.
+- A script `./sandbox.sh` that sets up a identities for a local Deku cluster.
+  This script is the easiest way to get started with Deku; however, it uses unsafe
+  configuration options to lower the required Tezos confirmations to 1. This setting greatly
+  speeds up local development, **but is not at all safe for production**!
 
 #### Requirements
 
-The sandbox requires only Bash and [Docker](https://docs.docker.com/get-docker/) to be installed.
-
+The sandbox requires Bash, [Docker](https://docs.docker.com/get-docker/), and docker-compose to be installed,
+in addition to the usual Deku pre-requisites.
 #### Setup
+
+Run `docker-compose up -d` to start a Tezos network and the BCD interface. 
 
 Run `./sandbox.sh setup` to start a local Tezos sandbox network, setup three Deku validator node identities, and deploy
 a Deku consensus contract configured for these validators to the local sandbox.
 
 Run `./sandbox.sh tear-down` to kill the Tezos sandbox network and wipe the Deku state.
+
+Run `docker-compose down -v` to stop the Tezos network and destroy the BCD database.
 
 #### Start
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,138 @@
+# Adapted from https://github.com/baking-bad/bcdhub
+# Original License:
+#
+# MIT License
+# 
+# Copyright (c) 2020 Baking Bad, Artem Poltorzhitskiy, Roman Serikov, Michael Zaikin
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+version: "3.6"
+services:
+  elastic:
+    image: ghcr.io/baking-bad/bcdhub-elastic:master
+    restart: always
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    environment:
+      - bootstrap.memory_lock=true
+      - discovery.type=single-node
+      - "ES_JAVA_OPTS=-Xms256m -Xmx256m"
+    logging: &bcd-logging
+      options:
+        max-size: 10m
+        max-file: "5"
+
+  db:
+    image: postgres:12
+    shm_size: 1g
+    restart: always
+    environment:
+      - POSTGRES_USER=root
+      - POSTGRES_PASSWORD=root
+      - POSTGRES_DB=indexer
+      - PGDATA=/var/lib/postgresql/data/pgdata
+    volumes:
+      - db:/var/lib/postgresql/data
+    logging: *bcd-logging
+
+  api:
+    restart: always
+    image: ghcr.io/baking-bad/bcdhub-api:master
+    environment:
+      - BCD_ENV=sandbox
+      - GIN_MODE=debug
+      - POSTGRES_USER=root
+      - POSTGRES_PASSWORD=root
+      - SANDBOX_NODE_URI=http://sandbox:20000
+      - SANDBOX_IPFS_GATEWAY=https://cloudflare-ipfs.com
+    depends_on:
+      - elastic
+      - db
+    ports:
+      - 127.0.0.1:14000:14000
+    volumes:
+      - bcdshare:/etc/bcd
+    links:
+      - "flextesa:sandbox"
+    logging: *bcd-logging
+
+  indexer:
+    restart: always
+    image: ghcr.io/baking-bad/bcdhub-indexer:master
+    environment:
+      - BCD_ENV=sandbox
+      - POSTGRES_USER=root
+      - POSTGRES_PASSWORD=root
+      - SANDBOX_NODE_URI=http://sandbox:20000
+      - SANDBOX_IPFS_GATEWAY=https://cloudflare-ipfs.com
+    depends_on:
+      - db
+      - metrics
+    links:
+      - "flextesa:sandbox"
+    volumes:
+      - bcdshare:/etc/bcd
+    logging: *bcd-logging
+
+  metrics:
+    restart: always
+    image: ghcr.io/baking-bad/bcdhub-metrics:master
+    environment:
+      - BCD_ENV=sandbox
+      - POSTGRES_USER=root
+      - POSTGRES_PASSWORD=root
+      - SANDBOX_NODE_URI=http://sandbox:20000
+      - SANDBOX_IPFS_GATEWAY=https://cloudflare-ipfs.com
+    depends_on:
+      - elastic
+      - db
+    links:
+      - "flextesa:sandbox"
+    volumes:
+      - bcdshare:/etc/bcd
+    logging: *bcd-logging
+
+  flextesa:
+    restart: always
+    image: tqtezos/flextesa:20211206
+    command: hangzbox start
+    environment:
+      - block_time=4
+    ports:
+      - "20000:20000"
+    expose:
+      - 20000/tcp
+    logging: *bcd-logging
+
+  gui:
+    container_name: sandbox-gui
+    restart: always
+    image: bakingbad/bcdhub-gui:4.0
+    depends_on:
+      - api
+    ports:
+      - 127.0.0.1:8000:80
+    logging: *bcd-logging
+
+volumes:
+  esdata:
+  bcdshare:
+  db:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,11 +34,7 @@ services:
       - bootstrap.memory_lock=true
       - discovery.type=single-node
       - "ES_JAVA_OPTS=-Xms256m -Xmx256m"
-    logging: &bcd-logging
-      options:
-        max-size: 10m
-        max-file: "5"
-
+    
   db:
     image: postgres:12
     shm_size: 1g
@@ -50,7 +46,6 @@ services:
       - PGDATA=/var/lib/postgresql/data/pgdata
     volumes:
       - db:/var/lib/postgresql/data
-    logging: *bcd-logging
 
   api:
     restart: always
@@ -71,7 +66,6 @@ services:
       - bcdshare:/etc/bcd
     links:
       - "flextesa:sandbox"
-    logging: *bcd-logging
 
   indexer:
     restart: always
@@ -89,7 +83,6 @@ services:
       - "flextesa:sandbox"
     volumes:
       - bcdshare:/etc/bcd
-    logging: *bcd-logging
 
   metrics:
     restart: always
@@ -107,7 +100,6 @@ services:
       - "flextesa:sandbox"
     volumes:
       - bcdshare:/etc/bcd
-    logging: *bcd-logging
 
   flextesa:
     restart: always
@@ -119,7 +111,6 @@ services:
       - "20000:20000"
     expose:
       - 20000/tcp
-    logging: *bcd-logging
 
   gui:
     container_name: sandbox-gui
@@ -129,7 +120,6 @@ services:
       - api
     ports:
       - 127.0.0.1:8000:80
-    logging: *bcd-logging
 
 volumes:
   esdata:

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -18,7 +18,7 @@ sidecli() {
 }
 
 tezos-client() {
-  docker exec -it deku_flextesa_1 tezos-client "$@"
+  docker exec -it deku-flextesa-1 tezos-client "$@"
 }
 
 ligo() {

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -12,8 +12,8 @@ SECRET_KEY="edsk3QoqBuvdamxouPhin7swCvkQNgq4jP5KZPbwWNnwdZpSpJiEbq"
 
 DATA_DIRECTORY="data"
 
-SIDECLI=$(esy x which sidecli)
 sidecli() {
+  SIDECLI=$(esy x which sidecli)
   eval $SIDECLI '"$@"'
 }
 


### PR DESCRIPTION


## Problem

We currently create a new flextesa sandbox every time we run `./sandbox.sh setup`. This is unnecessarily slow.

## Solution

I've added a docker-compose file that creates a flextesa sandbox,
and also brings up a better-call-dev instance available at localhost:8000.
This is really nice for troubleshooting deku - i've been using it for a month or two and just didn't make the PR until now.

So the new workflow is:
- bring up a tezos network once with `docker-compose up -d`.
- Deploy as many deku cluseters as you want with `./sandbox.sh setup`
- If encouter issues with the better-call-dev database (which sometimes happesn when I restart my computer), tear down with `docker-compose down -v` (`-v` is important to stop the network as well).

Closes #422
 