### PR TITLE
Rename `handle` to `withdrawal_handle`

### DIFF
--- a/src/bin/sidecli.ml
+++ b/src/bin/sidecli.ml
@@ -271,7 +271,7 @@ let withdraw_proof node_folder operation_hash callback =
   | Operation_is_not_a_withdraw ->
     let message = BLAKE2B.to_string operation_hash ^ " is not a withdraw" in
     await (`Error (false, message))
-  | Ok { handles_hash; handle; proof } ->
+  | Ok { withdrawal_handles_hash; withdrawal_handle; proof } ->
     let to_hex bytes = Hex.show (Hex.of_bytes bytes) in
     Format.printf
       {|(Pair (Pair %S
@@ -280,12 +280,12 @@ let withdraw_proof node_folder operation_hash callback =
       0x%s
       { %s })|}
       (Tezos.Address.to_string callback)
-      (Amount.to_int handle.amount)
-      (to_hex handle.ticket.data)
-      handle.id
-      (Tezos.Address.to_string handle.owner)
-      (Tezos.Address.to_string handle.ticket.ticketer)
-      (BLAKE2B.to_string handles_hash)
+      (Amount.to_int withdrawal_handle.amount)
+      (to_hex withdrawal_handle.ticket.data)
+      withdrawal_handle.id
+      (Tezos.Address.to_string withdrawal_handle.owner)
+      (Tezos.Address.to_string withdrawal_handle.ticket.ticketer)
+      (BLAKE2B.to_string withdrawal_handles_hash)
       (List.map
          (fun (left, right) ->
            Format.sprintf "        Pair 0x%s\n             0x%s"

--- a/src/core/ledger.mli
+++ b/src/core/ledger.mli
@@ -1,5 +1,5 @@
 open Crypto
-module Handle : sig
+module Withdrawal_handle : sig
   type t = private {
     hash : BLAKE2B.t;
     id : int;
@@ -26,8 +26,9 @@ val withdraw :
   Amount.t ->
   Ticket_id.t ->
   t ->
-  (t * Handle.t, [> `Not_enough_funds]) result
-val handles_find_proof : Handle.t -> t -> (BLAKE2B.t * BLAKE2B.t) list
-val handles_find_proof_by_id :
-  int -> t -> ((BLAKE2B.t * BLAKE2B.t) list * Handle.t) option
-val handles_root_hash : t -> BLAKE2B.t
+  (t * Withdrawal_handle.t, [> `Not_enough_funds]) result
+val withdrawal_handles_find_proof :
+  Withdrawal_handle.t -> t -> (BLAKE2B.t * BLAKE2B.t) list
+val withdrawal_handles_find_proof_by_id :
+  int -> t -> ((BLAKE2B.t * BLAKE2B.t) list * Withdrawal_handle.t) option
+val withdrawal_handles_root_hash : t -> BLAKE2B.t

--- a/src/core/state.ml
+++ b/src/core/state.ml
@@ -1,7 +1,8 @@
 open Helpers
 open Crypto
 type t = { ledger : Ledger.t } [@@deriving yojson]
-type receipt = Receipt_tezos_withdraw of Ledger.Handle.t [@@deriving yojson]
+type receipt = Receipt_tezos_withdraw of Ledger.Withdrawal_handle.t
+[@@deriving yojson]
 let empty = { ledger = Ledger.empty }
 let ledger t = t.ledger
 let hash t = to_yojson t |> Yojson.Safe.to_string |> BLAKE2B.hash

--- a/src/core/state.mli
+++ b/src/core/state.mli
@@ -1,6 +1,7 @@
 open Crypto
 type t [@@deriving yojson]
-type receipt = Receipt_tezos_withdraw of Ledger.Handle.t [@@deriving yojson]
+type receipt = Receipt_tezos_withdraw of Ledger.Withdrawal_handle.t
+[@@deriving yojson]
 val empty : t
 val ledger : t -> Ledger.t
 val hash : t -> BLAKE2B.t

--- a/src/node/flows.ml
+++ b/src/node/flows.ml
@@ -202,7 +202,8 @@ let try_to_commit_state_hash ~prev_validators state block signatures =
         | true -> Lwt.return_unit
         | false -> Lwt_unix.sleep 120.0 in
       commit_state_hash state ~block_height:block.block_height
-        ~block_payload_hash:block.payload_hash ~handles_hash:block.handles_hash
+        ~block_payload_hash:block.payload_hash
+        ~withdrawal_handles_hash:block.withdrawal_handles_hash
         ~state_hash:block.state_root_hash ~validators ~signatures)
 let rec try_to_apply_block state update_state block =
   let%assert () =
@@ -387,19 +388,19 @@ let register_uri state update_state ~uri ~signature =
 let request_withdraw_proof state ~hash =
   match state.Node.recent_operation_receipts |> BLAKE2B.Map.find_opt hash with
   | None -> Networking.Withdraw_proof.Unknown_operation
-  | Some (Receipt_tezos_withdraw handle) ->
+  | Some (Receipt_tezos_withdraw withdrawal_handle) ->
     let last_block_hash = state.Node.protocol.last_block_hash in
-    let handles_hash =
+    let withdrawal_handles_hash =
       match
         Block_pool.find_block ~hash:last_block_hash state.Node.block_pool
       with
       | None -> assert false
-      | Some block -> block.Block.handles_hash in
+      | Some block -> block.Block.withdrawal_handles_hash in
     let proof =
       state.Node.protocol.core_state
       |> Core.State.ledger
-      |> Ledger.handles_find_proof handle in
-    Ok { handles_hash; handle; proof }
+      |> Ledger.withdrawal_handles_find_proof withdrawal_handle in
+    Ok { withdrawal_handles_hash; withdrawal_handle; proof }
 let request_ticket_balance state ~ticket ~address =
   state.Node.protocol.core_state
   |> Core.State.ledger

--- a/src/node/networking.ml
+++ b/src/node/networking.ml
@@ -113,8 +113,8 @@ module Withdraw_proof = struct
   type request = { operation_hash : BLAKE2B.t } [@@deriving yojson]
   type response =
     | Ok                          of {
-        handles_hash : BLAKE2B.t;
-        handle : Ledger.Handle.t;
+        withdrawal_handles_hash : BLAKE2B.t;
+        withdrawal_handle : Ledger.Withdrawal_handle.t;
         proof : (BLAKE2B.t * BLAKE2B.t) list;
       }
     | Unknown_operation

--- a/src/protocol/block.ml
+++ b/src/protocol/block.ml
@@ -5,7 +5,7 @@ type t = {
   hash : BLAKE2B.t;
   payload_hash : BLAKE2B.t;
   state_root_hash : BLAKE2B.t;
-  handles_hash : BLAKE2B.t;
+  withdrawal_handles_hash : BLAKE2B.t;
   validators_hash : BLAKE2B.t;
   previous_hash : BLAKE2B.t;
   author : Key_hash.t;
@@ -14,8 +14,8 @@ type t = {
 }
 [@@deriving yojson]
 let hash, verify =
-  let apply f ~state_root_hash ~handles_hash ~validators_hash ~previous_hash
-      ~author ~block_height ~operations =
+  let apply f ~state_root_hash ~withdrawal_handles_hash ~validators_hash
+      ~previous_hash ~author ~block_height ~operations =
     let to_yojson =
       [%to_yojson:
         BLAKE2B.t
@@ -28,7 +28,7 @@ let hash, verify =
     let json =
       to_yojson
         ( state_root_hash,
-          handles_hash,
+          withdrawal_handles_hash,
           validators_hash,
           previous_hash,
           author,
@@ -38,24 +38,24 @@ let hash, verify =
     let block_payload_hash = BLAKE2B.hash payload in
     let hash =
       Tezos.Deku.Consensus.hash_block ~block_height ~block_payload_hash
-        ~state_root_hash ~handles_hash ~validators_hash in
+        ~state_root_hash ~withdrawal_handles_hash ~validators_hash in
     let hash = BLAKE2B.hash (BLAKE2B.to_raw_string hash) in
     f (hash, block_payload_hash) in
   let hash = apply Fun.id in
   let verify ~hash:expected_hash =
     apply (fun (hash, _payload_hash) -> hash = expected_hash) in
   (hash, verify)
-let make ~state_root_hash ~handles_hash ~validators_hash ~previous_hash ~author
-    ~block_height ~operations =
+let make ~state_root_hash ~withdrawal_handles_hash ~validators_hash
+    ~previous_hash ~author ~block_height ~operations =
   let hash, payload_hash =
-    hash ~state_root_hash ~handles_hash ~validators_hash ~previous_hash ~author
-      ~block_height ~operations in
+    hash ~state_root_hash ~withdrawal_handles_hash ~validators_hash
+      ~previous_hash ~author ~block_height ~operations in
   {
     hash;
     payload_hash;
     previous_hash;
     state_root_hash;
-    handles_hash;
+    withdrawal_handles_hash;
     validators_hash;
     author;
     block_height;
@@ -66,7 +66,8 @@ let of_yojson json =
   let%ok () =
     match
       verify ~hash:block.hash ~state_root_hash:block.state_root_hash
-        ~handles_hash:block.handles_hash ~validators_hash:block.validators_hash
+        ~withdrawal_handles_hash:block.withdrawal_handles_hash
+        ~validators_hash:block.validators_hash
         ~previous_hash:block.previous_hash ~author:block.author
         ~block_height:block.block_height ~operations:block.operations
     with
@@ -77,7 +78,7 @@ let compare a b = BLAKE2B.compare a.hash b.hash
 let genesis =
   make ~previous_hash:(BLAKE2B.hash "tuturu")
     ~state_root_hash:(BLAKE2B.hash "mayuushi")
-    ~handles_hash:(BLAKE2B.hash "desu")
+    ~withdrawal_handles_hash:(BLAKE2B.hash "desu")
     ~validators_hash:(Validators.hash Validators.empty)
     ~block_height:0L ~operations:[]
     ~author:(Key_hash.of_key Wallet.genesis_wallet)
@@ -87,8 +88,8 @@ let produce ~state ~next_state_root_hash =
       next_state_root_hash in
   make ~previous_hash:state.Protocol_state.last_block_hash
     ~state_root_hash:next_state_root_hash
-    ~handles_hash:
-      (Core.State.ledger state.core_state |> Ledger.handles_root_hash)
+    ~withdrawal_handles_hash:
+      (Core.State.ledger state.core_state |> Ledger.withdrawal_handles_root_hash)
     ~validators_hash:(Validators.hash state.validators)
     ~block_height:(Int64.add state.block_height 1L)
 open Protocol_signature.Make (struct

--- a/src/protocol/block.mli
+++ b/src/protocol/block.mli
@@ -3,7 +3,7 @@ type t = private {
   hash : BLAKE2B.t;
   payload_hash : BLAKE2B.t;
   state_root_hash : BLAKE2B.t;
-  handles_hash : BLAKE2B.t;
+  withdrawal_handles_hash : BLAKE2B.t;
   validators_hash : BLAKE2B.t;
   previous_hash : BLAKE2B.t;
   author : Key_hash.t;

--- a/src/tezos/deku.ml
+++ b/src/tezos/deku.ml
@@ -7,11 +7,11 @@ module Consensus = struct
     list (List.map key_hash validators) |> hash_packed_data
   let hash hash = bytes (BLAKE2B.to_raw_string hash |> Bytes.of_string)
   let hash_block ~block_height ~block_payload_hash ~state_root_hash
-      ~handles_hash ~validators_hash =
+      ~withdrawal_handles_hash ~validators_hash =
     pair
       (pair
          (pair (int (Z.of_int64 block_height)) (hash block_payload_hash))
-         (pair (hash handles_hash) (hash state_root_hash)))
+         (pair (hash withdrawal_handles_hash) (hash state_root_hash)))
       (hash validators_hash)
     |> hash_packed_data
   let hash_withdraw_handle ~id ~owner ~amount ~ticketer ~data =

--- a/src/tezos/deku.mli
+++ b/src/tezos/deku.mli
@@ -5,7 +5,7 @@ module Consensus : sig
     block_height:int64 ->
     block_payload_hash:BLAKE2B.t ->
     state_root_hash:BLAKE2B.t ->
-    handles_hash:BLAKE2B.t ->
+    withdrawal_handles_hash:BLAKE2B.t ->
     validators_hash:BLAKE2B.t ->
     BLAKE2B.t
   val hash_withdraw_handle :

--- a/src/tezos_interop/tezos_interop.ml
+++ b/src/tezos_interop/tezos_interop.ml
@@ -203,13 +203,13 @@ module Consensus = struct
   open Michelson.Michelson_v1_primitives
   open Tezos_micheline
   let commit_state_hash ~context ~block_height ~block_payload_hash ~state_hash
-      ~handles_hash ~validators ~signatures =
+      ~withdrawal_handles_hash ~validators ~signatures =
     let module Payload = struct
       type t = {
         block_height : int64;
         block_payload_hash : BLAKE2B.t;
         signatures : string option list;
-        handles_hash : BLAKE2B.t;
+        withdrawal_handles_hash : BLAKE2B.t;
         state_hash : BLAKE2B.t;
         validators : string list;
         current_validator_keys : string option list;
@@ -234,7 +234,7 @@ module Consensus = struct
         block_height;
         block_payload_hash;
         signatures;
-        handles_hash;
+        withdrawal_handles_hash;
         state_hash;
         validators;
         current_validator_keys;

--- a/src/tezos_interop/tezos_interop.mli
+++ b/src/tezos_interop/tezos_interop.mli
@@ -15,7 +15,7 @@ module Consensus : sig
     block_height:int64 ->
     block_payload_hash:BLAKE2B.t ->
     state_hash:BLAKE2B.t ->
-    handles_hash:BLAKE2B.t ->
+    withdrawal_handles_hash:BLAKE2B.t ->
     validators:Key_hash.t list ->
     signatures:(Key.t * Signature.t) option list ->
     unit Lwt.t

--- a/tests/test_tezos_interop.re
+++ b/tests/test_tezos_interop.re
@@ -737,7 +737,7 @@ describe("consensus", ({test, _}) => {
           hash_exn(
             "bdd051ddb07925a0d88dc27583e38ae560aa1b4429cc93b9ec35dacdbd74ffb2",
           ),
-        ~handles_hash=
+        ~withdrawal_handles_hash=
           hash_exn(
             "0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8",
           ),


### PR DESCRIPTION
## Problem

Soon, we'll add a ticket table (#388), which will create a notion of "ticket handles". This conflicts with the current usage of "handle", which currently refers to the handles used for withdrawal.

## Solution

Rename all current usages of "handle" to "withdrawal_handle"


 