### PR TITLE
Defining data structures for a new consensus algorithm

### DIFF
--- a/src/node/tendermint_internals.ml
+++ b/src/node/tendermint_internals.ml
@@ -1,0 +1,158 @@
+open Crypto
+open Protocol
+open Validators
+
+type value =
+  | Block of Protocol.Block.t
+  | Nil
+[@@deriving yojson]
+
+let string_of_value = function
+  | Nil -> "nil"
+  | Block b ->
+    Printf.sprintf "block %s" (Crypto.BLAKE2B.to_string b.Protocol.Block.hash)
+
+let repr_of_value v = v
+
+let produce_value : (State.t -> value) ref = ref (fun _ -> assert false)
+
+let is_valid state value =
+  match value with
+  | Nil -> false
+  | Block block ->
+    let all_operations_properly_signed _block = true in
+    block.Block.block_height >= state.State.protocol.block_height
+    && all_operations_properly_signed block
+
+let on_block ~nil_default f = function
+  | Nil -> nil_default
+  | Block b -> f b
+
+let block b = Block b
+let nil = Nil
+
+let update_value value round =
+  match value with
+  | Nil -> failwith "Can't update nil value"
+  | Block b -> Block (Protocol.Block.update_round b ~consensus_round:round)
+
+type height = int64 [@@deriving yojson]
+
+type round = int [@@deriving yojson]
+
+type consensus_step =
+  | Proposal
+  | Prevote
+  | Precommit
+
+let string_of_step = function
+  | Proposal -> "Proposal"
+  | Prevote -> "Prevote"
+  | Precommit -> "Precommit"
+
+type sidechain_consensus_op =
+  | ProposalOP  of (height * round * value * round)
+  | PrevoteOP   of (height * round * value)
+  | PrecommitOP of (height * round * value)
+[@@deriving yojson]
+
+let step_of_op = function
+  | ProposalOP _ -> Proposal
+  | PrevoteOP _ -> Prevote
+  | PrecommitOP _ -> Precommit
+
+let string_of_op = function
+  | ProposalOP (height, round, value, vround) ->
+    Printf.sprintf "<PROPOSAL, %Ld, %d, %s, %d>" height round
+      (string_of_value value) vround
+  | PrevoteOP (height, round, value) ->
+    Printf.sprintf "<PREVOTE, %Ld, %d, %s>" height round (string_of_value value)
+  | PrecommitOP (height, round, value) ->
+    Printf.sprintf "<PRECOMMIT, %Ld, %d, %s>" height round
+      (string_of_value value)
+
+let height = function
+  | ProposalOP (h, _, _, _)
+  | PrevoteOP (h, _, _)
+  | PrecommitOP (h, _, _) ->
+    h
+
+let round = function
+  | ProposalOP (_, r, _, _)
+  | PrevoteOP (_, r, _)
+  | PrecommitOP (_, r, _) ->
+    r
+
+let value_of_op = function
+  | ProposalOP (_, _, v, _)
+  | PrevoteOP (_, _, v)
+  | PrecommitOP (_, _, v) ->
+    v
+
+let hash_of_value = function
+  | Nil -> Crypto.BLAKE2B.hash ""
+  | Block b -> b.Block.hash
+
+let hash_of_consensus_op consensus_op sender =
+  let s1 = string_of_op consensus_op in
+  let s2 = Crypto.Key_hash.to_string sender in
+  Crypto.BLAKE2B.hash (s1 ^ s2)
+
+let hash_of_consensus_value consensus_op =
+  let _, _, value =
+    match consensus_op with
+    | ProposalOP (h, r, v, _)
+    | PrevoteOP (h, r, v)
+    | PrecommitOP (h, r, v) ->
+      (h, r, v) in
+  hash_of_value value
+
+type consensus_state = {
+  mutable height : height;
+  mutable round : round;
+  mutable step : consensus_step;
+  mutable locked_value : value;
+  mutable locked_round : round;
+  mutable valid_value : value;
+  mutable valid_round : round;
+}
+
+let fresh_state height =
+  {
+    height;
+    round = 0;
+    step = Proposal;
+    locked_value = nil;
+    locked_round = -1;
+    valid_value = nil;
+    valid_round = -1;
+  }
+
+let short name =
+  let name = Crypto.Key_hash.to_string name in
+  String.sub name (String.length name - 6) 6
+
+let debug state msg =
+  let self = Crypto.Key_hash.to_string state.State.identity.t in
+  let self = String.sub self (String.length self - 6) 6 in
+  prerr_endline ("*** " ^ self ^ "   " ^ msg)
+
+let is_allowed_proposer (global_state : State.t) (height : height)
+    (round : round) (address : Key_hash.t) =
+  let protocol_state = global_state.protocol in
+  let proposer = proposer protocol_state.validators height round in
+  let b = Key_hash.equal address proposer.address in
+  b
+
+let i_am_proposer (global_state : State.t) (height : height) (round : round) =
+  is_allowed_proposer global_state height round global_state.identity.t
+
+let get_weight (global_state : State.t) (address : Key_hash.t) =
+  if Validators.is_validator global_state.protocol.validators address then
+    1
+  else
+    0
+
+let proposal_timeout = 5
+let prevote_timeout = 10
+let precommit_timeout = 15

--- a/src/node/tendermint_internals.mli
+++ b/src/node/tendermint_internals.mli
@@ -1,0 +1,94 @@
+open Crypto
+
+type height = int64 [@@deriving yojson]
+
+type round = int [@@deriving yojson]
+(** At a specific (chain) height, Tendermint's consensus algorithm may run several rounds.*)
+
+(** Tendermint sometimes decides on a `Nil` value. *)
+type value =
+  | Block of Protocol.Block.t
+  | Nil
+[@@deriving yojson]
+
+val repr_of_value : value -> value
+(* TODO: ConsensusStep2 Tendermint uses repr of values instead of values. *)
+
+(* FIXME: ConsensusStep2 this is copied bad design. *)
+val produce_value : (State.t -> value) ref
+
+val is_valid : State.t -> value -> bool
+(** Ensures a value going through Tendermint is valid. TODO: ConsensusStep2 actually verify signatures, logging system. *)
+
+val on_block : nil_default:'a -> (Protocol.Block.t -> 'a) -> value -> 'a
+
+val block : Protocol.Block.t -> value
+
+val nil : value
+
+val update_value : value -> round -> value
+
+type consensus_step =
+  | Proposal
+  | Prevote
+  | Precommit
+      (** Tendermint's consensus goes through 3 steps at each round. Used inside a consensus instance in a node. *)
+
+val string_of_step : consensus_step -> string
+
+(** Tendermint's consensus step-communication with other nodes. Two first fields are height and
+    round of when the operation was sent. *)
+type sidechain_consensus_op =
+  | ProposalOP  of (height * round * value * round)
+  | PrevoteOP   of (height * round * value)
+  | PrecommitOP of (height * round * value)
+[@@deriving yojson]
+
+val step_of_op : sidechain_consensus_op -> consensus_step
+
+val string_of_op : sidechain_consensus_op -> string
+
+val height : sidechain_consensus_op -> height
+
+val round : sidechain_consensus_op -> round
+
+val value_of_op : sidechain_consensus_op -> value
+
+val hash_of_value : value -> BLAKE2B.t
+
+val hash_of_consensus_op : sidechain_consensus_op -> Key_hash.t -> BLAKE2B.t
+(** Hash of a consensus_op (including the step) + sender. *)
+
+val hash_of_consensus_value : sidechain_consensus_op -> BLAKE2B.t
+(** Hash of a value+height+round. If the value is not Nil, returns the state_root_hash of the block.
+    Unlike hash_of_consensus_op, does not discriminate the steps. *)
+
+(* TODO: ConsensusStep2 remove mutable. *)
+type consensus_state = {
+  mutable height : height;
+  mutable round : round;
+  mutable step : consensus_step;
+  mutable locked_value : value;
+  mutable locked_round : round;
+  mutable valid_value : value;
+  mutable valid_round : round;
+}
+
+val fresh_state : height -> consensus_state
+
+val short : Key_hash.t -> string
+
+val debug : State.t -> string -> unit
+
+val is_allowed_proposer : State.t -> height -> round -> Key_hash.t -> bool
+(** Verifies that the Key_hash.t matches the one expected by protocol for this height and round. *)
+
+val i_am_proposer : State.t -> height -> round -> bool
+(** True if the node is the proposer for this (height, round) according to proposer selection. *)
+
+val get_weight : State.t -> Key_hash.t -> int
+(** Implemented as Proof-of-Authority. *)
+
+val proposal_timeout : int
+val prevote_timeout : int
+val precommit_timeout : int

--- a/src/protocol/block.mli
+++ b/src/protocol/block.mli
@@ -8,12 +8,18 @@ type t = private {
   previous_hash : BLAKE2B.t;
   author : Key_hash.t;
   block_height : int64;
+  consensus_round : int;
   operations : Protocol_operation.t list;
 }
 [@@deriving yojson, ord]
 val sign : key:Secret.t -> t -> Protocol_signature.t
 val verify : signature:Protocol_signature.t -> t -> bool
 val genesis : t
+
+val update_round : t -> consensus_round:int -> t
+(** [update_round block round] changes the value of [block.consensus_round] and recomputes the hash
+    *)
+
 val produce :
   state:Protocol_state.t ->
   next_state_root_hash:BLAKE2B.t option ->

--- a/src/protocol/validators.ml
+++ b/src/protocol/validators.ml
@@ -52,3 +52,18 @@ let remove validator t =
   let hash = hash_validators validators in
   { current; validators; length; hash }
 let hash t = t.hash
+
+(** Round-robin proposer as used in Tendermint consensus. *)
+let proposer t height round =
+  let validators = t.validators in
+  let n = List.length validators in
+  (* n should stay small enough *)
+  let i1 = Int64.rem height (Int64.of_int n) in
+  let i1 = Int64.to_int i1 in
+  let i = (i1 + (round mod n)) mod n in
+  List.nth validators i
+
+(** Verifies if someone is a validator as required in Tendermint consensus. *)
+let is_validator t (x : Key_hash.t) =
+  let addresses = List.map (fun v -> v.address) t.validators in
+  List.mem x addresses

--- a/src/protocol/validators.mli
+++ b/src/protocol/validators.mli
@@ -16,3 +16,5 @@ val empty : t
 val add : validator -> t -> t
 val remove : validator -> t -> t
 val hash : t -> BLAKE2B.t
+val proposer : t -> int64 -> int -> validator
+val is_validator : t -> Key_hash.t -> bool

--- a/src/tezos/deku.ml
+++ b/src/tezos/deku.ml
@@ -6,13 +6,13 @@ module Consensus = struct
   let hash_validators validators =
     list (List.map key_hash validators) |> hash_packed_data
   let hash hash = bytes (BLAKE2B.to_raw_string hash |> Bytes.of_string)
-  let hash_block ~block_height ~block_payload_hash ~state_root_hash
-      ~withdrawal_handles_hash ~validators_hash =
+  let hash_block ~block_height ~consensus_round ~block_payload_hash
+      ~state_root_hash ~withdrawal_handles_hash ~validators_hash =
     pair
       (pair
          (pair (int (Z.of_int64 block_height)) (hash block_payload_hash))
-         (pair (hash withdrawal_handles_hash) (hash state_root_hash)))
-      (hash validators_hash)
+         (pair (int (Z.of_int consensus_round)) (hash withdrawal_handles_hash)))
+      (pair (hash state_root_hash) (hash validators_hash))
     |> hash_packed_data
   let hash_withdraw_handle ~id ~owner ~amount ~ticketer ~data =
     pair

--- a/src/tezos/deku.mli
+++ b/src/tezos/deku.mli
@@ -3,6 +3,7 @@ module Consensus : sig
   val hash_validators : Key_hash.t list -> BLAKE2B.t
   val hash_block :
     block_height:int64 ->
+    consensus_round:int ->
     block_payload_hash:BLAKE2B.t ->
     state_root_hash:BLAKE2B.t ->
     withdrawal_handles_hash:BLAKE2B.t ->

--- a/tests/test_tezos_interop.ml
+++ b/tests/test_tezos_interop.ml
@@ -567,7 +567,7 @@ let () =
             "6d6ecacbc858e3a89d87f0d9bd76b0c11b07aa95191129104395d17c6c96d36b");
       test "hash_block" (fun { expect; _ } ->
           let hash =
-            hash_block ~block_height:121L
+            hash_block ~block_height:121L ~consensus_round:0
               ~block_payload_hash:
                 (hash_exn
                    "2d92960a592c56de3046e200969c230a2eda71fc4b775e0cc09a189e5ddc5dbd")
@@ -583,7 +583,7 @@ let () =
           in
           let hash = BLAKE2B.to_string hash in
           (expect.string hash).toEqual
-            "7cb600c19817b899d4c28c521dd9ebf95f688e1444afe7d0e7740bebe848b030");
+            "305db8c9f9100ade89982d6d07e51991679b7128b43f20fa2bcb733743fa6098");
       test "hash_withdraw_handle" (fun { expect; _ } ->
           let hash =
             hash_withdraw_handle ~id:(Z.of_int 0)


### PR DESCRIPTION
(Edit from April 5 by @aguillon. This PR and the following ones are all joint work with @AngryStitch.)

## Problem

Change Deku's consensus algorithm.

## Solution

This is the first of 4 PRs aiming to implement Tendermint into Deku. Here we mostly give basic definitions that are then going to be used in the algorithm.

Please note that we don't have tests, we know that and @AngryStitch is in the process of fixing it. Moreover, this PR is not directly testable, but I'll provide instructions to help with testing in a later PR.

### Chosen consensus algorithm

The chosen algorithm is Tendermint's consensus as defined by [Algorithm 1, page 6](https://arxiv.org/pdf/1807.04938.pdf). We will refer to Tendermint's consensus as "Tendermint".

Tendermint achieves consensus through a 3 step process (Proposal, Prevote, Precommit) and works in rounds. It uses locking rules to avoid committing 2 different blocks at a same height. (See [here](https://marigold.gitbook.io/marigold/consensus/details-on-algorithms/tendermint))

### Top level types used by Tendermint

As stated in  [Algorithm 1, page 6](https://arxiv.org/pdf/1807.04938.pdf), Tendermint decides on a `value` (`src/node/tendermint_internals.ml`) at a `height`  and a `round`. The height is the chain height (called `level` in Tezos). Tendermint uses rounds to know who is the block producer. If for some reason the consensus fails at a given round, then a new round should start, with a different block producer.

A `value` can be `Nil` sometimes. It's Tendermint way of not deciding, for instance not to break lock rules.

Although the round is only important for Tendermint and probably shouldn't appear in the definition of the blocks, this makes it easier to compute the hash of a block. Why, may you ask, would you need the round to compute the hash? Because it is important that each validator signs the right block at the right round (when the algorithm succeeds), as it is linked to who is producing the block (and thus potentially rewards, security, etc.).

### `Consensus_state` (`src/node/tendermint_internals.ml`)

Every Tendermint instance has a `consensus_state`: 
```
type consensus_state = {
  mutable height : height;
  mutable round : round;
  mutable step : consensus_step;
  mutable locked_value : value;
  mutable locked_round : round;
  mutable valid_value : value;
  mutable valid_round : round;
}
```

that will allow it to enforce locking rules.

@EduardoRFS suggested making these fields non-mutable: this is delayed to a later PR, as some other things.