### PR TITLE
Executing Tendermint consensus (without committing the decided on block)

### DIFF
--- a/sandbox.sh
+++ b/sandbox.sh
@@ -22,7 +22,7 @@ SECRET_KEY="edsk3QoqBuvdamxouPhin7swCvkQNgq4jP5KZPbwWNnwdZpSpJiEbq"
 
 DATA_DIRECTORY="data"
 
-VALIDATORS=(0 1 2)
+VALIDATORS=(0 1 2 3)
 
 message() {
   echo "=========== $@ ==========="
@@ -94,6 +94,7 @@ create_new_deku_environment() {
   root_hash = {
     current_block_hash = 0x;
     current_block_height = 0;
+    current_block_round = 0;
     current_state_hash = 0x;
     current_handles_hash = 0x;
     current_validators = [

--- a/src/helpers/lwt_ext.ml
+++ b/src/helpers/lwt_ext.ml
@@ -1,4 +1,6 @@
 module Let_syntax = struct
   let await = Lwt.return
   [%%let "let.await", Lwt.bind]
+
+  let ( let* ) = Lwt.bind
 end

--- a/src/helpers/lwt_ext.mli
+++ b/src/helpers/lwt_ext.mli
@@ -1,4 +1,6 @@
 module Let_syntax : sig
   val await : 'a -> 'a Lwt.t
   [%%let ("let.await" : 'a Lwt.t -> ('a -> 'b Lwt.t) -> 'b Lwt.t)]
+
+  val ( let* ) : 'a Lwt.t -> ('a -> 'b Lwt.t) -> 'b Lwt.t
 end

--- a/src/helpers/result_ext.ml
+++ b/src/helpers/result_ext.ml
@@ -8,4 +8,17 @@ module Let_syntax = struct
       match bool with
       | true -> f ()
       | false -> Error message]
+
+  (* When let%assert is not available *)
+  let ensure (message, bool) =
+    match bool with
+    | true -> Lwt.return @@ Ok ()
+    | false -> Lwt.return @@ Error message
+
+  let ( let*? ) lwtx f =
+    let open Lwt.Syntax in
+    let* x = lwtx in
+    match x with
+    | Ok a -> f a
+    | Error e -> Lwt.return @@ Error e
 end

--- a/src/helpers/result_ext.mli
+++ b/src/helpers/result_ext.mli
@@ -7,4 +7,10 @@ module Let_syntax : sig
   ("let.ok" : ('a, 'b) result -> ('a -> ('c, 'b) result) -> ('c, 'b) result)]
   [%%let
   ("let.assert" : 'a * bool -> (unit -> ('b, 'a) result) -> ('b, 'a) result)]
+
+  val ensure : 'a * bool -> (unit, 'a) result Lwt.t
+  val ( let*? ) :
+    ('a, 'b) result Lwt.t ->
+    ('a -> ('c, 'b) result Lwt.t) ->
+    ('c, 'b) result Lwt.t
 end

--- a/src/node/flows.ml
+++ b/src/node/flows.ml
@@ -58,6 +58,9 @@ type ignore =
 let reset_timeout = (ref (fun () -> assert false) : (unit -> unit) ref)
 let get_state = (ref (fun () -> assert false) : (unit -> State.t) ref)
 let set_state = (ref (fun _ -> assert false) : (State.t -> unit) ref)
+let get_consensus = (ref (fun _ -> assert false) : (unit -> Tendermint.t) ref)
+let set_consensus = (ref (fun _ -> assert false) : (Tendermint.t -> unit) ref)
+
 let received_block' =
   (ref (fun _ -> assert false)
     : (Node.t ->

--- a/src/node/flows.ml
+++ b/src/node/flows.ml
@@ -33,12 +33,14 @@ let string_of_error = function
   | `Pending_blocks -> "Pending_blocks"
   | `Unknown_uri -> "Unknown_uri"
   | `Not_a_user_opertaion -> "Not_a_user_opertaion"
-  | `Not_consensus_operation -> "Not_consensus_operation"
+  | `Not_consensus_operation msg ->
+    Format.sprintf "Not_consensus_operation: %s" msg
   | `Invalid_signature -> "Invalid_signature"
   | `Invalid_snapshot_height -> "Invalid_snapshot_height"
   | `Not_all_blocks_are_signed -> "Not_all_blocks_are_signed"
   | `State_root_not_the_expected -> "State_root_not_the_expected"
   | `Snapshots_with_invalid_hash -> "Snapshots_with_invalid_hash"
+  | `Signed_by_unauthorized_validator -> "Signed_by_unauthorized_validator"
 
 let print_error err =
   Format.eprintf "\027[31mError: %s\027[m\n%!" (string_of_error err)
@@ -105,19 +107,22 @@ let rec request_block_by_hash tries ~hash =
     (fun _exn ->
       Printexc.print_backtrace stdout;
       request_block_by_hash (tries + 1) ~hash)
+
 let request_block ~hash =
-  Lwt.async (fun () ->
-      let%await block = request_block_by_hash 0 ~hash in
-      let state = !get_state () in
-      match
-        !received_block' state
-          (fun state ->
-            !set_state state;
-            state)
-          block
-      with
-      | Ok () -> await ()
-      | Error _err -> await ())
+  let%await block = request_block_by_hash 0 ~hash in
+  let state = !get_state () in
+  match
+    !received_block' state
+      (fun state ->
+        !set_state state;
+        state)
+      block
+  with
+  | Ok () -> await ()
+  | Error _err ->
+    Printf.eprintf "Error while requesting block!";
+    await ()
+
 let rec request_protocol_snapshot tries =
   if tries > 20 then raise Not_found;
   Lwt.catch
@@ -144,22 +149,30 @@ let load_snapshot snapshot_data =
       ~last_block_signatures:snapshot_data.last_block_signatures (!get_state ())
   in
   Ok (!set_state state)
+
 let request_protocol_snapshot () =
-  Lwt.async (fun () ->
-      let%await snapshot = request_protocol_snapshot 0 in
-      (match load_snapshot snapshot with
-      | Ok _ -> ()
-      | Error err -> print_error err);
-      await ())
+  let%await snapshot = request_protocol_snapshot 0 in
+  (match load_snapshot snapshot with
+  | Ok _ -> ()
+  | Error err -> print_error err);
+  await ()
+
 let request_previous_blocks state block =
-  if
-    block_matches_current_state_root_hash state block
-    || block_matches_next_state_root_hash state block
-  then
-    request_block ~hash:block.Block.previous_hash
-  else if not !pending then (
-    pending := true;
-    request_protocol_snapshot ())
+  let%await () =
+    if
+      block_matches_current_state_root_hash state block
+      || block_matches_next_state_root_hash state block
+    then
+      request_block ~hash:block.Block.previous_hash
+    else (
+      (* if not !pending then *)
+      pending := true;
+      (* let%await () = *)
+      request_protocol_snapshot ()
+      (* in
+         request_block ~hash:block.Block.previous_hash *)) in
+  await @@ !get_state ()
+
 let try_to_produce_block state update_state =
   let%assert () =
     ( `Not_current_block_producer,
@@ -178,11 +191,10 @@ let try_to_sign_block state update_state block =
     state
 let commit_state_hash state =
   Tezos_interop.Consensus.commit_state_hash ~context:state.Node.interop_context
-let try_to_commit_state_hash ~prev_validators state block signatures =
+let try_to_commit_state_hash ~prev_validators state block round signatures =
   let open Node in
   let signatures_map =
     signatures
-    |> Signatures.to_list
     |> List.map (fun signature ->
            let address = Signature.address signature in
            let key = Signature.public_key signature in
@@ -206,9 +218,10 @@ let try_to_commit_state_hash ~prev_validators state block signatures =
         | true -> Lwt.return_unit
         | false -> Lwt_unix.sleep 120.0 in
       commit_state_hash state ~block_height:block.block_height
-        ~block_payload_hash:block.payload_hash
+        ~block_payload_hash:block.payload_hash ~block_round:round
         ~withdrawal_handles_hash:block.withdrawal_handles_hash
         ~state_hash:block.state_root_hash ~validators ~signatures)
+
 let rec try_to_apply_block state update_state block =
   let%assert () =
     ( `Block_not_signed_enough_to_apply,
@@ -232,7 +245,8 @@ let rec try_to_apply_block state update_state block =
     match Block_pool.find_signatures ~hash:block.hash state.block_pool with
     | Some signatures when Signatures.is_self_signed signatures ->
       try_to_commit_state_hash ~prev_validators:prev_protocol.validators state
-        block signatures
+        block block.Block.consensus_round
+        (Signatures.to_list signatures)
     | _ -> ());
   match
     Block_pool.find_next_block_to_apply ~hash:block.Block.hash state.block_pool
@@ -240,7 +254,7 @@ let rec try_to_apply_block state update_state block =
   | Some block ->
     let state = try_to_sign_block state update_state block in
     try_to_apply_block state update_state block
-  | None -> try_to_produce_block state update_state
+  | None -> Ok ()
 
 and block_added_to_the_pool state update_state block =
   let state =
@@ -255,7 +269,6 @@ and block_added_to_the_pool state update_state block =
     | Some _signatures -> state
     | None -> state in
   if is_next state block then
-    let state = try_to_sign_block state update_state block in
     try_to_apply_block state update_state block
   else
     let%assert () =
@@ -267,7 +280,7 @@ and block_added_to_the_pool state update_state block =
     match Block_pool.find_block ~hash:block.previous_hash state.block_pool with
     | Some block -> block_added_to_the_pool state update_state block
     | None ->
-      request_previous_blocks state block;
+      ignore (request_previous_blocks state block);
       Ok ()
 let () = block_added_to_the_pool' := block_added_to_the_pool
 let received_block state update_state block =
@@ -293,7 +306,8 @@ let received_signature state update_state ~hash ~signature =
   match Block_pool.find_block ~hash state.Node.block_pool with
   | Some block -> block_added_to_the_pool state update_state block
   | None ->
-    request_block ~hash;
+    let _ = request_block ~hash in
+    (* FIXME: hackish? *)
     Ok ()
 let parse_internal_tezos_transaction transaction =
   match transaction with
@@ -375,6 +389,133 @@ let received_consensus_operation state update_state consensus_operation
         pending_operations = pending_operation :: state.pending_operations;
       }) in
   Ok ()
+
+let is_authorized_validator state ~signature =
+  let validators = state.Node.protocol.validators in
+  let public_key = Signature.public_key signature in
+  let key_hash = Key_hash.of_key public_key in
+  Validators.is_validator validators key_hash
+
+let already_committed state block =
+  state.Node.protocol.Protocol.last_block_hash = block.Block.hash
+
+(** Manages the block pool and signatures when we received a Precommit op (applies changes post-consensus) *)
+let received_precommit_block state update_state ~block ~sender:_ ~hash
+    ~hash_signature =
+  let module CI = Tendermint_internals in
+  let height, _ = (block.Block.block_height, block.Block.consensus_round) in
+  (* We check for the signature of the *hash* of the received hash, as this
+     is also what Tezos does. *)
+  let%assert () =
+    ( `Already_known_signature,
+      not (is_known_signature state ~hash ~signature:hash_signature) ) in
+
+  (* TODO: this saves signatures for blocks/hashes that are not valid for Tendermint.
+     - DDOS risk
+     - use case?  (if none: just save signatures when Tendermint agrees/is undecided) (possible use case: slashing?)*)
+  let state =
+    append_signature state update_state ~hash ~signature:hash_signature in
+  match Tendermint.get_block_opt (!get_consensus ()) height with
+  | Some (block, _) when not (block.Block.hash = hash) ->
+    Result.Error
+      (`Invalid_block
+        (Printf.sprintf
+           "Block hash does not match decision made by consensus, %s"
+           (Crypto.BLAKE2B.to_string block.Block.hash)))
+  (* TODO: move | Some (block, _round) when not (check_state_root_hash block) ->
+     Result.error `Invalid_state_root_hash *)
+  | Some (block, _) ->
+    (* Consensus has been reached normally for the received block *)
+    (* The block has been decided on, is valid, and we have enough signatures to commit *)
+    (* let state =
+       append_signature state update_state ~hash ~signature:hash_signature in *)
+    if not (already_committed state block) then
+      let state = Building_blocks.add_block_to_pool state update_state block in
+      (* commit ~block ~hash ~height ~round state update_state *)
+      block_added_to_the_pool state update_state block
+    else
+      Ok ()
+  | None ->
+    (* Consensus has not been reached yet *)
+    Ok ()
+
+let received_consensus_step state update_state operation sender hash
+    block_signature message_signature =
+  let open Tendermint in
+  let open Tendermint_internals in
+  (* TODO: put everything in Tendermint *)
+  let _check_state_root_hash block =
+    block_matches_current_state_root_hash state block
+    || block_matches_next_state_root_hash state block in
+
+  let*? () =
+    let hash = hash_of_consensus_op operation sender in
+    ensure
+      ( `Invalid_signature_for_this_hash,
+        Signature.verify ~signature:message_signature hash ) in
+
+  let*? () =
+    ensure
+      ( `Signed_by_unauthorized_validator,
+        is_authorized_validator state ~signature:message_signature ) in
+
+  (* FIXME: ConsensusStep2 this is a poor man's fast sync protocol. This should be implemented somewhere else, as
+     it creates a vulnerability and Tendermint can get stuck as it is implemented now. *)
+  let* state, _consensus =
+    let height = state.Node.protocol.Protocol.block_height in
+    match operation with
+    | ProposalOP (height', _, Block b, _) when height' > Int64.add height 1L ->
+      let* state = request_previous_blocks state b in
+      (* Start Tendermint process at the right height *)
+      let current_height = height' in
+      let consensus' = Tendermint.make state current_height in
+      !set_consensus consensus';
+      assert (Int64.add state.Node.protocol.Protocol.block_height 1L >= height');
+      Lwt.return (state, consensus')
+    | _ -> Lwt.return (state, !get_consensus ()) in
+
+  let*? () =
+    let op_height = Tendermint_internals.height operation in
+    let own_height = state.Node.protocol.Protocol.block_height in
+    ensure
+      ( `Not_consensus_operation
+          (Printf.sprintf "Wrong height for operation: %Ld, expected height %Ld"
+             op_height own_height),
+        Int64.abs (Int64.sub op_height own_height) <= 1L ) in
+
+  (* TODO: ConsensusStep2 if received a block, check state root hash *)
+  match is_valid_consensus_op state operation with
+  | Ok () ->
+    (* TODO: ConsensusStep2, check if already seen this message? AKA enforce unique in input_log? *)
+    (* TODO: ConsensusStep2: add and check sender signature? *)
+    let consensus = !get_consensus () in
+    let%await consensus = add_consensus_op consensus sender operation in
+
+    (* Execute the consensus step and updates the consensus state.
+       In the case this step is a PrecommitOP, we may need to commit the whole block
+       and then reexecute the consensus to decide if we propose a new block! *)
+    let consensus = exec_consensus consensus in
+    !set_consensus consensus;
+    Lwt.return
+      begin
+        match operation with
+        | PrecommitOP (_, _, Block b) ->
+          (* Implicitly updates the node state *)
+          let%ok () =
+            received_precommit_block state update_state ~block:b ~sender ~hash
+              ~hash_signature:block_signature in
+          (* Not very elegant. We'll probably hide this global state in the future. *)
+          let state = !get_state () in
+          let consensus = { consensus with Tendermint.node_state = state } in
+
+          (* Rexec the consensus in case we need to send a proposal *)
+          let consensus = exec_consensus consensus in
+          !set_consensus consensus;
+          Ok ()
+        | _ -> Ok ()
+      end
+  | Error msg -> Lwt.return (Error (`Not_consensus_operation msg))
+
 let find_block_by_hash state hash =
   Block_pool.find_block ~hash state.Node.block_pool
 let find_block_level state = state.State.protocol.block_height

--- a/src/node/networking.ml
+++ b/src/node/networking.ml
@@ -109,6 +109,20 @@ module Consensus_operation_gossip = struct
   type response = unit [@@deriving yojson]
   let path = "/consensus-operation-gossip"
 end
+
+module Consensus_operation = struct
+  type request = {
+    operation : Tendermint_internals.sidechain_consensus_op;
+    sender : Crypto.Key_hash.t;
+    hash : BLAKE2B.t;
+    block_signature : Signature.t;
+    operation_signature : Signature.t;
+  }
+  [@@deriving yojson]
+  type response = unit [@@deriving yojson]
+  let path = "/consensus"
+end [@deriving yojson]
+
 module Withdraw_proof = struct
   type request = { operation_hash : BLAKE2B.t } [@@deriving yojson]
   type response =
@@ -164,5 +178,7 @@ let broadcast_user_operation_gossip_to_list =
   broadcast_to_list (module User_operation_gossip)
 let request_user_operation_gossip = request (module User_operation_gossip)
 let request_consensus_operation = request (module Consensus_operation_gossip)
+let broadcast_consensus_op =
+  broadcast_to_validators (module Consensus_operation)
 let request_trusted_validator_membership =
   request (module Trusted_validators_membership_change)

--- a/src/node/server.ml
+++ b/src/node/server.ml
@@ -2,20 +2,34 @@ open Helpers
 open Flows
 type t = {
   mutable state : State.t;
+  mutable consensus : Tendermint.t;
   mutable timeout : unit Lwt.t;
 }
 let global_server = ref None
 let start ~initial =
+  let consensus =
+    Tendermint.make initial (Int64.add initial.protocol.block_height 1L) in
   match !global_server with
   | Some _ -> failwith "start should be called just once"
-  | None -> global_server := Some { state = initial; timeout = Lwt.return_unit }
+  | None ->
+    global_server :=
+      Some { state = initial; consensus; timeout = Lwt.return_unit }
 let get () =
   match !global_server with
   | Some state -> state
   | None -> failwith "get called before start"
 let get_port () = (get ()).state.identity.uri |> Uri.port
+
+let get_consensus () = (get ()).consensus
+let set_consensus consensus = (get ()).consensus <- consensus
 let get_state () = (get ()).state
-let set_state state = (get ()).state <- state
+let set_state state =
+  let server_state = get () in
+  let current_consensus = server_state.consensus in
+  server_state.state <- state;
+  server_state.consensus <-
+    { current_consensus with Tendermint.node_state = state }
+
 let rec reset_timeout server =
   Lwt.cancel server.timeout;
   server.timeout <-
@@ -29,6 +43,10 @@ let rec reset_timeout server =
      | Error `Not_current_block_producer -> ());
      reset_timeout server;
      Lwt.return_unit)
-let () = Flows.reset_timeout := fun () -> reset_timeout (get ())
-let () = Flows.get_state := get_state
-let () = Flows.set_state := set_state
+
+let _ = Flows.reset_timeout := fun () -> reset_timeout (get ())
+
+let _ = Flows.get_state := get_state
+let _ = Flows.set_state := set_state
+let _ = Flows.get_consensus := get_consensus
+let _ = Flows.set_consensus := set_consensus

--- a/src/node/tendermint.ml
+++ b/src/node/tendermint.ml
@@ -1,0 +1,206 @@
+open Helpers
+open Tendermint_internals
+open Tendermint_data
+open Tendermint_processes
+open Tendermint_helpers
+
+type t = {
+  identity : State.identity;
+  clocks : clock list IntSet.t;
+  consensus_states : consensus_state IntSet.t;
+  (* TODO: make non-mutable *)
+  mutable procs : (height * process) list;
+  node_state : State.t;
+  input_log : input_log;
+  output_log : OutputLog.t;
+}
+
+type should_restart_tendermint =
+  | DontRestart
+  | RestartAtHeight of height
+  | RestartAtRound  of round
+
+let make node_state current_height =
+  let identity = node_state.State.identity in
+  let clocks = IntSet.create 0 in
+  let new_state = fresh_state current_height in
+  let states = IntSet.create 0 in
+  IntSet.add states current_height new_state;
+  let procs = List.map (fun x -> (current_height, x)) all_processes in
+  let input_log = empty () in
+  let output_log = OutputLog.empty () in
+  {
+    identity;
+    clocks;
+    consensus_states = states;
+    node_state;
+    procs;
+    input_log;
+    output_log;
+  }
+
+let current_height node =
+  List.fold_left max 0L (IntSet.to_seq_keys node.consensus_states |> List.of_seq)
+
+(* FIXME: bad design *)
+let () =
+  produce_value := fun state -> block (Building_blocks.produce_block state)
+
+(** Process messages in the queue and decide actions; pure function, to be interpeted in Lwt later.
+    TODO: Ensures that messages received over network go through signature verification before adding them to input_log
+    FIXME: we're not empyting the input_log atm *)
+let tendermint_step node =
+  let open Tendermint_processes in
+  let rec exec_procs processes still_active network_actions =
+    match processes with
+    | ((height, process) as p) :: rest -> begin
+      let consensus_state = IntSet.find node.consensus_states height in
+      let round = consensus_state.Tendermint_internals.round in
+      let message_log = node.input_log in
+      let output = node.output_log in
+      match
+        process height round consensus_state message_log output node.node_state
+      with
+      (* The process precondition hasn't been activated *)
+      | None -> exec_procs rest (p :: still_active) network_actions
+      (* The process terminates with a network event *)
+      | Some (Broadcast t) -> exec_procs rest still_active (t :: network_actions)
+      (* The process terminates silently *)
+      | Some DoNothing -> exec_procs rest still_active network_actions
+      (* We accepted a block for the height *)
+      | Some (RestartTendermint (height, 0)) ->
+        (* Start new processes and forget about the older ones *)
+        (* TODO: this is only valid for the (current) restricted version of Tendermint which does not
+           support several cycles/heights running in parallel. *)
+        ([], [], RestartAtHeight height)
+      | Some (RestartTendermint (_height, round)) ->
+        ([], network_actions, RestartAtRound round)
+      (* Add a new clock to the scheduler *)
+      | Some (Schedule c) ->
+        let cs =
+          IntSet.find_opt node.clocks height |> Option.value ~default:[] in
+        IntSet.add node.clocks height (c :: cs);
+        exec_procs rest still_active network_actions
+    end
+    | [] -> (still_active, network_actions, DontRestart) in
+  let still_active, network_actions, should_restart =
+    exec_procs node.procs [] [] in
+  (* TODO: make non-mutable *)
+  node.procs <- still_active;
+  ({ node with procs = still_active }, List.rev network_actions, should_restart)
+(* List.rev: Do we really need order on the network? *)
+
+let add_to_input input_log height step content =
+  let index = (height, step) in
+  add input_log index content
+
+let is_valid_consensus_op state consensus_op =
+  (* TODO: ConsensusStep2 this is a filter for input log since it's only optimization (don't keep stuff from past)*)
+  let open Result in
+  let _all_operations_properly_signed = function
+    | _ -> true in
+  let h = height consensus_op in
+  let current_height = state.State.protocol.block_height in
+  if current_height > h then
+    let s =
+      Printf.sprintf
+        "new block has a lower height (%Ld) than the current state (%Ld)" h
+        current_height in
+    error s
+  else
+    ok ()
+
+(** Hashes stuff and broadcast the corresponding consensus operation *)
+let broadcast_op state consensus_op =
+  (* We need two hashes: one corresponding to the block, height and round, which will ultimately get
+     posted on Tezos; and one of the consensus operation *)
+  let node_address = state.State.identity.t in
+  let secret_key = state.State.identity.secret in
+  (* Hashing the operation *)
+  let operation_hash = hash_of_consensus_op consensus_op node_address in
+  let operation_signature =
+    Protocol.Signature.sign ~key:secret_key operation_hash in
+  (* Hash the value+height+round even if it's nil *)
+  let block_hash = hash_of_consensus_value consensus_op in
+  let block_signature = Protocol.Signature.sign ~key:secret_key block_hash in
+  Lwt.async (fun () ->
+      let%await () = Lwt_unix.sleep 0.3 in
+      Networking.broadcast_consensus_op state
+        {
+          operation = consensus_op;
+          sender = node_address;
+          hash = block_hash;
+          block_signature;
+          operation_signature;
+        })
+
+let add_consensus_op node sender op =
+  let input_log = node.input_log in
+  let input_log =
+    add_to_input input_log (height op) (step_of_op op) (content_of_op sender op)
+  in
+  Lwt.return { node with input_log }
+
+let rec exec_consensus node =
+  let node, network_actions, should_restart = tendermint_step node in
+
+  (* Send all actions over the network *)
+  List.iter (broadcast_op node.node_state) network_actions;
+  match (node.procs, should_restart) with
+  | _, RestartAtRound r ->
+    let cur_height = current_height node in
+    let cur_state = IntSet.find node.consensus_states cur_height in
+    cur_state.round <- r;
+    let new_processes = List.map (fun p -> (cur_height, p)) all_processes in
+    exec_consensus { node with procs = new_processes }
+  | [], RestartAtHeight new_height ->
+    let new_state = fresh_state new_height in
+    IntSet.add node.consensus_states new_height new_state;
+    let new_processes = List.map (fun p -> (new_height, p)) all_processes in
+    { node with procs = new_processes }
+  | _ ->
+    (* Start the clocks *)
+    IntSet.map_inplace
+      (fun _height clocks ->
+        List.map
+          (fun c -> start_clock node c.Clock.height c.Clock.round c)
+          clocks)
+      node.clocks;
+    node
+
+(* TODO: don't use async and global state,
+   maintain an internal list of clocks started at a given time and periodically call exec_consensus
+   from flows again? *)
+
+and start_clock node clock_height clock_round clock =
+  let open Lwt in
+  let open Tendermint_processes in
+  if clock.Clock.started then
+    clock
+  else begin
+    async (fun () ->
+        Lwt_unix.sleep (float_of_int clock.Clock.time) >>= fun () ->
+        (* Checks that the clock is still relevant *)
+        let current_height = current_height node in
+        (* FIXME: fragile code; we should fix the whole way we handle clocks with Lwt *)
+        let current_round =
+          (IntSet.find node.consensus_states current_height)
+            .Tendermint_internals.round in
+        if current_height > clock_height || current_round > clock_round then
+          Lwt.return_unit
+        else
+          let input_log = node.input_log in
+          let _ = add_to_input input_log clock_height clock.Clock.step Timeout in
+          let new_node = exec_consensus node in
+          (* TODO: make non-mutable *)
+          node.procs <- new_node.procs;
+          Lwt.return_unit);
+    { clock with started = true }
+  end
+
+let make_proposal height round b = ProposalOP (height, round, block b, -1)
+
+let get_block_opt cstate height =
+  match OutputLog.get cstate.output_log height with
+  | Some (Block b, round) -> Some (b, round)
+  | _ -> None

--- a/src/node/tendermint.mli
+++ b/src/node/tendermint.mli
@@ -1,0 +1,33 @@
+open Tendermint_helpers
+open Tendermint_processes
+open Tendermint_internals
+open Tendermint_data
+
+type t = {
+  identity : State.identity;
+  clocks : clock list IntSet.t;
+  consensus_states : consensus_state IntSet.t;
+  (* FIXME: ConsensusStep2 we don't want this to be mutable *)
+  mutable procs : (height * process) list;
+  node_state : State.t;
+  input_log : input_log;
+  output_log : OutputLog.t;
+}
+(** Tendermint simplification: as Deku is not going to run several
+   blockchain heights at the same time, we only consider one set of
+   states and clocks. *)
+
+val make : State.t -> height -> t
+
+val is_valid_consensus_op :
+  State.t -> sidechain_consensus_op -> (unit, string) result
+
+val add_consensus_op : t -> node_identifier -> sidechain_consensus_op -> t Lwt.t
+
+val exec_consensus : t -> t
+
+val make_proposal :
+  height -> round -> Protocol.Block.t -> sidechain_consensus_op
+
+val get_block_opt : t -> height -> (Protocol.Block.t * round) option
+(** Required to publish hash on Tezos *)

--- a/src/node/tendermint_data.ml
+++ b/src/node/tendermint_data.ml
@@ -1,0 +1,284 @@
+open Crypto
+open State
+open Tendermint_helpers
+open Tendermint_internals
+
+type elmt = value * round
+
+module MySet = Set.Make (struct
+  type t = elmt
+
+  let compare (v1, r1) (v2, r2) = compare (v1, r1) (v2, r2)
+end)
+
+type node_identifier = Key_hash.t
+
+type index_step = Tendermint_internals.consensus_step
+
+type index = height * index_step
+
+type proposal_content = {
+  process_round : round;
+  proposal : value;
+  process_valid_round : round;
+  sender : node_identifier;
+}
+
+type prevote_content = {
+  process_round : round;
+  repr_value : value;
+  sender : node_identifier;
+}
+
+type precommit_content = prevote_content
+
+type content =
+  | ProposalContent  of proposal_content
+  | PrevoteContent   of prevote_content
+  | PrecommitContent of precommit_content
+  | Timeout
+
+(* TODO: ensure PrevoteOP and PrecommitOP contains repr_values and not values. *)
+let content_of_op sender = function
+  | Tendermint_internals.ProposalOP
+      (_, process_round, proposal, process_valid_round) ->
+    ProposalContent { process_round; proposal; process_valid_round; sender }
+  | Tendermint_internals.PrevoteOP (_, process_round, repr_value) ->
+    PrevoteContent { process_round; repr_value; sender }
+  | Tendermint_internals.PrecommitOP (_, process_round, repr_value) ->
+    PrecommitContent { process_round; repr_value; sender }
+
+(* TODO: ensure there is no data duplication in input_log *)
+type input_log = {
+  msg_log : (index, content list) Hashtbl.t;
+  timeouts : (index, content) Hashtbl.t;
+      (* Making timeouts a separate queue because it's easier at the moment... *)
+}
+let empty () : input_log =
+  { msg_log = Hashtbl.create 0; timeouts = Hashtbl.create 0 }
+
+let add (input_log : input_log) (index : index) (c : content) =
+  match c with
+  | Timeout ->
+    Hashtbl.replace input_log.timeouts index c;
+    input_log
+  | c -> (
+    let previous =
+      match Hashtbl.find_opt input_log.msg_log index with
+      | Some ls -> ls
+      | None -> [] in
+    match List.find_opt (fun elem -> elem = c) previous with
+    | Some _ -> input_log (* Do not add same content twice *)
+    | None ->
+      Hashtbl.replace input_log.msg_log index (c :: previous);
+      input_log)
+
+let remove (input_log : input_log) (index : index) =
+  Hashtbl.remove input_log.msg_log index;
+  Hashtbl.remove input_log.timeouts index
+
+let prune (input_log : input_log) (height : height) =
+  let _ =
+    [Proposal; Prevote; Precommit]
+    (* Should we make sure all h < height are emptied here? *)
+    |> List.map (fun step -> (height, step))
+    |> List.map (fun index -> remove input_log index) in
+  ()
+
+let map_option f ls =
+  let rec aux = function
+    | [] -> []
+    | x :: xs ->
+    match f x with
+    | Some y -> y :: aux xs
+    | None -> aux xs in
+  aux ls
+
+let contains_timeout input_log height step =
+  match Hashtbl.find_opt input_log.timeouts (height, step) with
+  | None -> false
+  | Some _ ->
+    Hashtbl.remove input_log.timeouts (height, step);
+    true
+
+(** Tendermint's output_log AKA decision log*)
+module OutputLog = struct
+  type t = (height, value * round) Hashtbl.t
+
+  let empty () : t = Hashtbl.create 0
+
+  let contains_nil (table : t) (height : height) =
+    Hashtbl.find_opt table height |> Option.is_some |> not
+
+  let set t height value round =
+    assert (contains_nil t height);
+    Hashtbl.add t height (value, round)
+
+  let get (table : t) (height : height) = Hashtbl.find_opt table height
+
+  let contains_block (t : t) height block =
+    match Hashtbl.find_opt t height with
+    | None -> false
+    | Some (block', _) -> block = block'
+end
+
+(************************************ Selection on input_log ************************************)
+
+let on_proposal (f : proposal_content -> 'a option) = function
+  | ProposalContent x -> f x
+  | _ -> raise (Invalid_argument "Must be called on ProposalContent only")
+
+let select_matching_step (msg_log : input_log) (i : index) (s : consensus_step)
+    (p : 'b -> 'a option) =
+  match i with
+  | _, step when step <> s -> raise (Invalid_argument "Bad step")
+  | _h, _step ->
+    let found =
+      try Hashtbl.find msg_log.msg_log i |> map_option p with
+      | Not_found -> [] in
+    found
+
+let select_matching_prevote (msg_log : input_log) (i : index)
+    (p : content -> 'a option) =
+  select_matching_step msg_log i Prevote p
+let select_matching_proposal (msg_log : input_log) (i : index)
+    (p : content -> 'a option) =
+  select_matching_step msg_log i Proposal p
+
+let select_matching_precommit (msg_log : input_log) (i : index)
+    (p : content -> 'a option) =
+  select_matching_step msg_log i Precommit p
+
+let select_proposal_process_round_matching_proposer (msg_log : input_log)
+    (consensus_state : consensus_state) (global_state : State.t) =
+  let index = (consensus_state.height, Proposal) in
+  let selected =
+    select_matching_proposal msg_log index
+      (on_proposal (fun c ->
+           if
+             is_allowed_proposer global_state consensus_state.height
+               consensus_state.round c.sender
+           then
+             Some (c.proposal, c.process_round)
+           else
+             None)) in
+  MySet.of_list selected
+
+let select_proposal_valid_round_matching_proposer (msg_log : input_log)
+    (consensus_state : consensus_state) (global_state : State.t) : MySet.t =
+  let index = (consensus_state.height, Proposal) in
+  let selected =
+    select_matching_proposal msg_log index
+      (on_proposal (fun c ->
+           if
+             is_allowed_proposer global_state consensus_state.height
+               consensus_state.round c.sender
+           then
+             Some (c.proposal, c.process_valid_round)
+           else
+             None)) in
+  MySet.of_list selected
+
+let select_proposal_matching_several_rounds (msg_log : input_log)
+    (consensus_state : consensus_state) (global_state : State.t) : MySet.t =
+  let index = (consensus_state.height, Proposal) in
+  let selected =
+    select_matching_proposal msg_log index
+      (on_proposal (fun c ->
+           if
+             is_allowed_proposer global_state consensus_state.height
+               consensus_state.round c.sender
+           then
+             Some (c.proposal, c.process_round)
+           else
+             None)) in
+  MySet.of_list selected
+
+(** Helper function to compute the required weight threshold *)
+let compute_threshold ?(f = 2.) global_state =
+  let open Protocol.Validators in
+  let validators = length global_state.protocol.validators |> float_of_int in
+  (f *. (validators -. 1.) /. 3.) +. 1.
+
+let count_prevotes ?prevote_selection (msg_log : input_log)
+    (consensus_state : consensus_state) (global_state : State.t) : MySet.t =
+  let prevote_selection =
+    match prevote_selection with
+    | None -> (
+      function
+      | PrevoteContent content
+        when content.process_round = consensus_state.round ->
+        Some
+          ( (content.repr_value, content.process_round),
+            get_weight global_state content.sender )
+      | PrevoteContent _ -> None
+      | _ -> failwith "This should never happen, it's prevotes")
+    | Some p -> p in
+  let threshold = compute_threshold global_state in
+  let index = (consensus_state.height, Prevote) in
+  let all_prevotes = select_matching_prevote msg_log index prevote_selection in
+  let filtered = Counter.filter_threshold all_prevotes ~threshold in
+  MySet.of_list filtered
+
+(** Selects (repr_value, process_round) from Precommit data if the pair has
+   enough cumulated weight. *)
+let count_precommits (msg_log : input_log) (consensus_state : consensus_state)
+    (global_state : State.t) =
+  let threshold = compute_threshold global_state in
+  let index = (consensus_state.height, Precommit) in
+  let all_precommits =
+    select_matching_precommit msg_log index (fun x -> Option.some @@ x) in
+  let precommits_with_weights =
+    List.map
+      (function
+        | PrecommitContent content ->
+          ( (content.repr_value, content.process_round),
+            get_weight global_state content.sender )
+        | _ -> failwith "This should never happen, it's precommits")
+      all_precommits in
+  let filtered = Counter.filter_threshold precommits_with_weights ~threshold in
+  MySet.of_list filtered
+
+let count_all_actions ?(threshold_f = 2.) (msg_log : input_log)
+    (consensus_state : consensus_state) (global_state : State.t) =
+  let threshold = compute_threshold ~f:threshold_f global_state in
+  let index_proposal = (consensus_state.height, Proposal) in
+  let index_prevote = (consensus_state.height, Prevote) in
+  let index_precommit = (consensus_state.height, Precommit) in
+  let proposals =
+    select_matching_proposal msg_log index_proposal (fun x -> Option.some x)
+  in
+  let prevotes =
+    select_matching_prevote msg_log index_prevote (fun x -> Option.some x) in
+  let precommits =
+    select_matching_precommit msg_log index_precommit (fun x -> Option.some x)
+  in
+  let proposals_with_weights =
+    List.map
+      (function
+        | ProposalContent content ->
+          ((nil, content.process_round), get_weight global_state content.sender)
+        | _ -> failwith "This should never happen, it's proposals")
+      proposals in
+  let prevotes_with_weights =
+    List.map
+      (function
+        | PrevoteContent content ->
+          ((nil, content.process_round), get_weight global_state content.sender)
+        | _ -> failwith "This should never happen, it's prevotes")
+      prevotes in
+  let precommits_with_weights =
+    List.map
+      (function
+        | PrecommitContent content ->
+          ((nil, content.process_round), get_weight global_state content.sender)
+        | _ -> failwith "This should never happen, it's precommits")
+      precommits in
+  let filtered =
+    Counter.filter_threshold
+      (List.concat
+         [
+           proposals_with_weights; prevotes_with_weights; precommits_with_weights;
+         ])
+      ~threshold in
+  MySet.of_list filtered

--- a/src/node/tendermint_data.mli
+++ b/src/node/tendermint_data.mli
@@ -1,0 +1,115 @@
+(** Tendermint input_log and output_log.
+    Holds all the querying function on the input_log required by Tendermint subprocesses. *)
+
+open Crypto
+open Tendermint_internals
+
+type elmt = value * round
+
+module MySet : Set.S with type elt := elmt
+
+(* FIXME: ConsensusStep2 Tendermint we could do better *)
+type node_identifier = Key_hash.t
+
+type index_step = consensus_step
+
+type index = height * index_step
+(** Tendermint input is indexed by height and consensus step. *)
+
+type proposal_content = private {
+  process_round : round; (* Round of the process that sent the PROPOSAL *)
+  proposal : value;
+  process_valid_round : round;
+  (* "Locked round" (see paper) of the PRECOMMIT of this value; -1 when the value has notbeen locked before *)
+  sender : node_identifier;
+}
+(** Proposal messages carry more relevant information: the process_round, the
+   proposed value, the last known valid round and, the sender *)
+
+type prevote_content = {
+  process_round : round; (* Round of the process that sent the PREVOTE *)
+  repr_value : value;
+  sender : node_identifier;
+}
+(** Prevote and Precommit messages only carry the process_round, a representation
+   of the value being dealt with, and the sender. *)
+
+type precommit_content = prevote_content
+
+(* FIXME: ConsensusStep2 we can do better than this now that we know the requirements:
+    - find a way for "tendermint processes" to register to the input log
+    - find a different way of handling clocks and timeouts? *)
+type content =
+  | ProposalContent  of proposal_content
+  | PrevoteContent   of prevote_content
+  | PrecommitContent of precommit_content
+  | Timeout
+(* Used to trigger actions on timeouts *)
+
+val content_of_op : node_identifier -> sidechain_consensus_op -> content
+
+(* TODO: ConsensusStep2 ensure there is no data duplication in input_log *)
+type input_log = {
+  msg_log : (index, content list) Hashtbl.t;
+  timeouts : (index, content) Hashtbl.t;
+      (* Making timeouts a separate queue because it's easier at the moment... *)
+}
+
+val empty : unit -> input_log
+
+val contains_timeout : input_log -> height -> consensus_step -> bool
+
+val add : input_log -> index -> content -> input_log
+
+val prune : input_log -> height -> unit
+
+module OutputLog : sig
+  type t = (height, value * round) Hashtbl.t
+
+  val empty : unit -> t
+
+  val contains_nil : t -> height -> bool
+
+  val set : t -> height -> value -> round -> unit
+
+  val get : t -> height -> (value * round) option
+
+  val contains_block : t -> height -> value -> bool
+end
+
+(* Data selection *)
+
+val count_prevotes :
+  ?prevote_selection:(content -> (elmt * round) option) ->
+  input_log ->
+  consensus_state ->
+  State.t ->
+  MySet.t
+(** Selects (repr_value, process_round) from Prevote data if the pair has enough
+   cumulated weight.*)
+
+val count_precommits : input_log -> consensus_state -> State.t -> MySet.t
+(** Selects (repr_value, process_round) from Precommit data if the pair has
+   enough cumulated weight. *)
+
+val select_proposal_process_round_matching_proposer :
+  input_log -> consensus_state -> State.t -> MySet.t
+(** Selects (proposal_value, process_round) from Proposal data if the sender
+   matches authorized proposer of current (height, round). *)
+
+val select_proposal_valid_round_matching_proposer :
+  input_log -> consensus_state -> State.t -> MySet.t
+(** Selects (proposal_value, process_valid_round) from Proposal data if the
+   sender matches authorized poposer of current (height, round). *)
+
+val select_proposal_matching_several_rounds :
+  input_log -> consensus_state -> State.t -> MySet.t
+(** Selects (proposal_value, process_round) from Proposal data if the sender
+   matches authorized proposer of current (height, round). *)
+
+val count_all_actions :
+  ?threshold_f:float -> input_log -> consensus_state -> State.t -> MySet.t
+(* Selects (Value.nil, process_round) from Proposal, Prevote, and Precommit data
+   if the pair has enough cumulated weight.
+   We are not interested in getting a real value here, just checking the weight
+   of all actions as this is failure detection. *)

--- a/src/node/tendermint_helpers.ml
+++ b/src/node/tendermint_helpers.ml
@@ -1,0 +1,56 @@
+open Tendermint_internals
+module type COUNTER = sig
+  type 'a t
+
+  val make : 'a t
+
+  val inc : 'a t -> 'a -> int -> 'a t
+
+  val get : 'a t -> 'a -> int
+
+  val count : ('a * int) list -> 'a t
+
+  val cut : 'a t -> threshold:float -> 'a t
+
+  val filter_threshold : ('a * int) list -> threshold:float -> 'a list
+end
+
+module Counter : COUNTER = struct
+  (* Why is this not in stdlib??? *)
+  type 'a t = ('a * int) list
+
+  let make = []
+
+  let inc t key n =
+    let rec aux = function
+      | (k, v) :: xs when k = key -> (k, n + v) :: xs
+      | c :: xs -> c :: aux xs
+      | [] -> [(key, n)] in
+    aux t
+
+  let get t key = List.assoc key t
+
+  let count (ls : ('a * int) list) : 'a t =
+    List.fold_left (fun counter (x, n) -> inc counter x n) make ls
+
+  let cut t ~(threshold : float) =
+    List.filter (fun (_a, b) -> float_of_int b >= threshold) t
+
+  let filter_threshold (ls : ('a * int) list) ~(threshold : float) =
+    let counted = count ls in
+    let filtered = cut counted ~threshold in
+    List.map fst filtered
+end
+
+module HeightHash = struct
+  type t = height
+  let equal i j = i = j
+  let hash i = Int64.(logand i max_int |> to_int)
+end
+
+(* FIXME: find another name *)
+module IntSet = struct
+  include Hashtbl.Make (HeightHash)
+
+  let map_inplace f t = filter_map_inplace (fun x y -> Option.some (f x y)) t
+end

--- a/src/node/tendermint_helpers.mli
+++ b/src/node/tendermint_helpers.mli
@@ -1,0 +1,26 @@
+open Tendermint_internals
+
+module type COUNTER = sig
+  type 'a t
+
+  val make : 'a t
+
+  val inc : 'a t -> 'a -> int -> 'a t
+
+  val get : 'a t -> 'a -> int
+
+  val count : ('a * int) list -> 'a t
+
+  val cut : 'a t -> threshold:float -> 'a t
+
+  val filter_threshold : ('a * int) list -> threshold:float -> 'a list
+end
+
+module Counter : COUNTER
+
+(* FIXME: find another name *)
+module IntSet : sig
+  include Hashtbl.S with type key = height
+
+  val map_inplace : (height -> 'a -> 'a) -> 'a t -> unit
+end

--- a/src/node/tendermint_internals.ml
+++ b/src/node/tendermint_internals.ml
@@ -1,0 +1,158 @@
+open Crypto
+open Protocol
+open Validators
+
+type value =
+  | Block of Protocol.Block.t
+  | Nil
+[@@deriving yojson]
+
+let string_of_value = function
+  | Nil -> "nil"
+  | Block b ->
+    Printf.sprintf "block %s" (Crypto.BLAKE2B.to_string b.Protocol.Block.hash)
+
+let repr_of_value v = v
+
+let produce_value : (State.t -> value) ref = ref (fun _ -> assert false)
+
+let is_valid state value =
+  match value with
+  | Nil -> false
+  | Block block ->
+    let all_operations_properly_signed _block = true in
+    block.Block.block_height >= state.State.protocol.block_height
+    && all_operations_properly_signed block
+
+let on_block ~nil_default f = function
+  | Nil -> nil_default
+  | Block b -> f b
+
+let block b = Block b
+let nil = Nil
+
+let update_value value round =
+  match value with
+  | Nil -> failwith "Can't update nil value"
+  | Block b -> Block (Protocol.Block.update_round b ~consensus_round:round)
+
+type height = int64 [@@deriving yojson]
+
+type round = int [@@deriving yojson]
+
+type consensus_step =
+  | Proposal
+  | Prevote
+  | Precommit
+
+let string_of_step = function
+  | Proposal -> "Proposal"
+  | Prevote -> "Prevote"
+  | Precommit -> "Precommit"
+
+type sidechain_consensus_op =
+  | ProposalOP  of (height * round * value * round)
+  | PrevoteOP   of (height * round * value)
+  | PrecommitOP of (height * round * value)
+[@@deriving yojson]
+
+let step_of_op = function
+  | ProposalOP _ -> Proposal
+  | PrevoteOP _ -> Prevote
+  | PrecommitOP _ -> Precommit
+
+let string_of_op = function
+  | ProposalOP (height, round, value, vround) ->
+    Printf.sprintf "<PROPOSAL, %Ld, %d, %s, %d>" height round
+      (string_of_value value) vround
+  | PrevoteOP (height, round, value) ->
+    Printf.sprintf "<PREVOTE, %Ld, %d, %s>" height round (string_of_value value)
+  | PrecommitOP (height, round, value) ->
+    Printf.sprintf "<PRECOMMIT, %Ld, %d, %s>" height round
+      (string_of_value value)
+
+let height = function
+  | ProposalOP (h, _, _, _)
+  | PrevoteOP (h, _, _)
+  | PrecommitOP (h, _, _) ->
+    h
+
+let round = function
+  | ProposalOP (_, r, _, _)
+  | PrevoteOP (_, r, _)
+  | PrecommitOP (_, r, _) ->
+    r
+
+let value_of_op = function
+  | ProposalOP (_, _, v, _)
+  | PrevoteOP (_, _, v)
+  | PrecommitOP (_, _, v) ->
+    v
+
+let hash_of_value = function
+  | Nil -> Crypto.BLAKE2B.hash ""
+  | Block b -> b.Block.hash
+
+let hash_of_consensus_op consensus_op sender =
+  let s1 = string_of_op consensus_op in
+  let s2 = Crypto.Key_hash.to_string sender in
+  Crypto.BLAKE2B.hash (s1 ^ s2)
+
+let hash_of_consensus_value consensus_op =
+  let _, _, value =
+    match consensus_op with
+    | ProposalOP (h, r, v, _)
+    | PrevoteOP (h, r, v)
+    | PrecommitOP (h, r, v) ->
+      (h, r, v) in
+  hash_of_value value
+
+type consensus_state = {
+  mutable height : height;
+  mutable round : round;
+  mutable step : consensus_step;
+  mutable locked_value : value;
+  mutable locked_round : round;
+  mutable valid_value : value;
+  mutable valid_round : round;
+}
+
+let fresh_state height =
+  {
+    height;
+    round = 0;
+    step = Proposal;
+    locked_value = nil;
+    locked_round = -1;
+    valid_value = nil;
+    valid_round = -1;
+  }
+
+let short name =
+  let name = Crypto.Key_hash.to_string name in
+  String.sub name (String.length name - 6) 6
+
+let debug state msg =
+  let self = Crypto.Key_hash.to_string state.State.identity.t in
+  let self = String.sub self (String.length self - 6) 6 in
+  prerr_endline ("*** " ^ self ^ "   " ^ msg)
+
+let is_allowed_proposer (global_state : State.t) (height : height)
+    (round : round) (address : Key_hash.t) =
+  let protocol_state = global_state.protocol in
+  let proposer = proposer protocol_state.validators height round in
+  let b = Key_hash.equal address proposer.address in
+  b
+
+let i_am_proposer (global_state : State.t) (height : height) (round : round) =
+  is_allowed_proposer global_state height round global_state.identity.t
+
+let get_weight (global_state : State.t) (address : Key_hash.t) =
+  if Validators.is_validator global_state.protocol.validators address then
+    1
+  else
+    0
+
+let proposal_timeout = 5
+let prevote_timeout = 10
+let precommit_timeout = 15

--- a/src/node/tendermint_internals.mli
+++ b/src/node/tendermint_internals.mli
@@ -1,0 +1,94 @@
+open Crypto
+
+type height = int64 [@@deriving yojson]
+
+type round = int [@@deriving yojson]
+(** At a specific (chain) height, Tendermint's consensus algorithm may run several rounds.*)
+
+(** Tendermint sometimes decides on a `Nil` value. *)
+type value =
+  | Block of Protocol.Block.t
+  | Nil
+[@@deriving yojson]
+
+val repr_of_value : value -> value
+(* TODO: ConsensusStep2 Tendermint uses repr of values instead of values. *)
+
+(* FIXME: ConsensusStep2 this is copied bad design. *)
+val produce_value : (State.t -> value) ref
+
+val is_valid : State.t -> value -> bool
+(** Ensures a value going through Tendermint is valid. TODO: ConsensusStep2 actually verify signatures, logging system. *)
+
+val on_block : nil_default:'a -> (Protocol.Block.t -> 'a) -> value -> 'a
+
+val block : Protocol.Block.t -> value
+
+val nil : value
+
+val update_value : value -> round -> value
+
+type consensus_step =
+  | Proposal
+  | Prevote
+  | Precommit
+      (** Tendermint's consensus goes through 3 steps at each round. Used inside a consensus instance in a node. *)
+
+val string_of_step : consensus_step -> string
+
+(** Tendermint's consensus step-communication with other nodes. Two first fields are height and
+    round of when the operation was sent. *)
+type sidechain_consensus_op =
+  | ProposalOP  of (height * round * value * round)
+  | PrevoteOP   of (height * round * value)
+  | PrecommitOP of (height * round * value)
+[@@deriving yojson]
+
+val step_of_op : sidechain_consensus_op -> consensus_step
+
+val string_of_op : sidechain_consensus_op -> string
+
+val height : sidechain_consensus_op -> height
+
+val round : sidechain_consensus_op -> round
+
+val value_of_op : sidechain_consensus_op -> value
+
+val hash_of_value : value -> BLAKE2B.t
+
+val hash_of_consensus_op : sidechain_consensus_op -> Key_hash.t -> BLAKE2B.t
+(** Hash of a consensus_op (including the step) + sender. *)
+
+val hash_of_consensus_value : sidechain_consensus_op -> BLAKE2B.t
+(** Hash of a value+height+round. If the value is not Nil, returns the state_root_hash of the block.
+    Unlike hash_of_consensus_op, does not discriminate the steps. *)
+
+(* TODO: ConsensusStep2 remove mutable. *)
+type consensus_state = {
+  mutable height : height;
+  mutable round : round;
+  mutable step : consensus_step;
+  mutable locked_value : value;
+  mutable locked_round : round;
+  mutable valid_value : value;
+  mutable valid_round : round;
+}
+
+val fresh_state : height -> consensus_state
+
+val short : Key_hash.t -> string
+
+val debug : State.t -> string -> unit
+
+val is_allowed_proposer : State.t -> height -> round -> Key_hash.t -> bool
+(** Verifies that the Key_hash.t matches the one expected by protocol for this height and round. *)
+
+val i_am_proposer : State.t -> height -> round -> bool
+(** True if the node is the proposer for this (height, round) according to proposer selection. *)
+
+val get_weight : State.t -> Key_hash.t -> int
+(** Implemented as Proof-of-Authority. *)
+
+val proposal_timeout : int
+val prevote_timeout : int
+val precommit_timeout : int

--- a/src/node/tendermint_processes.ml
+++ b/src/node/tendermint_processes.ml
@@ -1,0 +1,367 @@
+(** Tendermint's consensus processes as describded at https://arxiv.org/pdf/1807.04938.pdf *)
+
+open Tendermint_internals
+open Tendermint_data
+
+module type Clock_type = sig
+  type 'a t = {
+    time : int;
+    step : consensus_step;
+    height : height;
+    round : round;
+    on_timeout : consensus_state -> input_log -> OutputLog.t -> State.t -> 'a;
+    started : bool;
+  }
+  val make :
+    int ->
+    consensus_step ->
+    height ->
+    round ->
+    (consensus_state -> input_log -> OutputLog.t -> State.t -> 'a) ->
+    'a t
+end
+
+module Clock : Clock_type = struct
+  type 'a t = {
+    time : int;
+    step : consensus_step;
+    height : height;
+    round : round;
+    on_timeout : consensus_state -> input_log -> OutputLog.t -> State.t -> 'a;
+    started : bool;
+  }
+
+  let make time step height round on_timeout =
+    { time; step; on_timeout; started = false; height; round }
+end
+
+type consensus_action =
+  | Broadcast         of sidechain_consensus_op
+  | Schedule          of consensus_action option Clock.t
+  | RestartTendermint of (height * round)
+  | DoNothing
+
+type process =
+  height ->
+  round ->
+  consensus_state ->
+  input_log ->
+  OutputLog.t ->
+  State.t ->
+  consensus_action option
+
+type clock = consensus_action option Clock.t
+
+let on_timeout_propose (height : height) (round : round)
+    (consensus_state : consensus_state) (msg_log : input_log) _dlog
+    _global_state =
+  let do_something consensus_state =
+    if
+      height = consensus_state.height
+      && round = consensus_state.round
+      && consensus_state.step = Proposal
+    then (
+      consensus_state.step <- Prevote;
+      Broadcast (PrevoteOP (consensus_state.height, consensus_state.round, nil)))
+    else
+      DoNothing in
+  if contains_timeout msg_log height Proposal then
+    Some (do_something consensus_state)
+  else
+    None
+
+let on_timeout_prevote (height : height) (round : round)
+    (consensus_state : consensus_state) (msg_log : input_log) _dlog
+    _global_state =
+  let do_something consensus_state =
+    if
+      height = consensus_state.height
+      && round = consensus_state.round
+      && consensus_state.step = Prevote
+    then (
+      consensus_state.step <- Precommit;
+      Broadcast
+        (PrecommitOP (consensus_state.height, consensus_state.round, nil)))
+    else
+      DoNothing in
+  if contains_timeout msg_log height Prevote then
+    Some (do_something consensus_state)
+  else
+    None
+
+let start_round (height : height) (round : round)
+    (consensus_state : consensus_state) (_msg_log : input_log) _dlog
+    global_state =
+  consensus_state.round <- round;
+  consensus_state.step <- Proposal;
+  (* If we start a round > 0 and already have a valid/locked value, we update their hash
+     with the correct round *)
+  (if consensus_state.valid_value <> nil then
+     let new_value = update_value consensus_state.valid_value round in
+     consensus_state.valid_value <- new_value);
+  (if consensus_state.locked_value <> nil then
+     let new_value = update_value consensus_state.locked_value round in
+     consensus_state.locked_value <- new_value);
+  let return_action =
+    if i_am_proposer global_state height round then
+      if consensus_state.valid_value <> nil then
+        Some
+          (Broadcast
+             (ProposalOP
+                ( consensus_state.height,
+                  consensus_state.round,
+                  consensus_state.valid_value,
+                  consensus_state.valid_round )))
+      else
+        Some
+          (Broadcast
+             (ProposalOP
+                ( consensus_state.height,
+                  consensus_state.round,
+                  (* FIXME: remove depdendency to full global_state *)
+                  !produce_value global_state,
+                  consensus_state.valid_round )))
+    else
+      Some
+        (Schedule
+           (Clock.make proposal_timeout Proposal height round
+              (on_timeout_propose height round))) in
+  return_action
+
+let on_timeout_precommit (height : height) (round : round)
+    (consensus_state : consensus_state) (msg_log : input_log) _dlog
+    _global_state =
+  let do_something consensus_state =
+    if height = consensus_state.height && round = consensus_state.round then
+      RestartTendermint (height, round + 1)
+    else
+      DoNothing in
+  if contains_timeout msg_log height Precommit then
+    Some (do_something consensus_state)
+  else
+    None
+
+let response_to_proposal (height : height) (round : round)
+    (consensus_state : consensus_state) (msg_log : input_log) _dlog global_state
+    =
+  let _height = consensus_state.height in
+  let step = consensus_state.step in
+  let _round = consensus_state.round in
+  let do_something (consensus_state : consensus_state) (found_set : MySet.t) =
+    let value, _ = MySet.choose found_set in
+    consensus_state.step <- Prevote;
+    if
+      is_valid global_state value
+      && (consensus_state.locked_round = -1
+         || consensus_state.locked_value = value)
+    then
+      Broadcast (PrevoteOP (height, round, repr_of_value value))
+    else
+      Broadcast (PrevoteOP (height, round, nil)) in
+  let found_set =
+    select_proposal_process_round_matching_proposer msg_log consensus_state
+      global_state in
+  let extract_valid_set (found_set : MySet.t) =
+    MySet.filter (fun (_, r) -> r = round) found_set in
+  let valid_set = extract_valid_set found_set in
+  if valid_set = MySet.empty || step <> Proposal then
+    None
+  else
+    Some (do_something consensus_state valid_set)
+
+let precommit_failed_previous_round (_height : height) (_round : round)
+    (consensus_state : consensus_state) (msg_log : input_log) _dlog global_state
+    =
+  let height = consensus_state.height in
+  let step = consensus_state.step in
+  let round = consensus_state.round in
+  (* Returns list of (repr_value, round) with filtered round *)
+  let extract_common_set (left_set : MySet.t) (right_set : MySet.t) : MySet.t =
+    let filtered_left_set =
+      MySet.filter (fun (_, r) -> r >= 0 && r < round) left_set in
+    (* (v, r)*)
+    let filtered_right_set =
+      MySet.filter (fun (_, r) -> r >= 0 && r < round) right_set in
+    (* (rv, r)*)
+    MySet.filter
+      (fun (v, r) -> MySet.mem (repr_of_value v, r) filtered_right_set)
+      filtered_left_set in
+  let do_something (consensus_state : consensus_state) (common_set : MySet.t) =
+    let value, valid_round = MySet.choose common_set in
+    consensus_state.step <- Prevote;
+    if
+      is_valid global_state value
+      && (consensus_state.locked_round <= valid_round
+         || consensus_state.locked_value = value)
+    then
+      Broadcast (PrevoteOP (height, round, repr_of_value value))
+    else
+      Broadcast (PrevoteOP (height, round, nil)) in
+  let left_set =
+    select_proposal_valid_round_matching_proposer msg_log consensus_state
+      global_state in
+  let right_set = count_prevotes msg_log consensus_state global_state in
+  let common_set = extract_common_set left_set right_set in
+  if
+    left_set = MySet.empty
+    || right_set = MySet.empty
+    || step <> Proposal
+    || common_set = MySet.empty
+  then
+    None
+  else
+    Some (do_something consensus_state common_set)
+
+let prepare_default_precommit_prevote_phase (height : height) (round : round)
+    (consensus_state : consensus_state) (msg_log : input_log) _dlog global_state
+    =
+  let take_all_prevotes = function
+    | PrevoteContent content when content.process_round = consensus_state.round
+      ->
+      Some ((nil, content.process_round), get_weight global_state content.sender)
+    | PrevoteContent _ -> None
+    | _ -> failwith "This shouldn't happend, it's prevotes" in
+  let found_set : MySet.t =
+    count_prevotes ~prevote_selection:take_all_prevotes msg_log consensus_state
+      global_state in
+  let do_something () =
+    Schedule
+      (Clock.make prevote_timeout Prevote height round
+         (on_timeout_prevote height round)) in
+  if found_set = MySet.empty || consensus_state.step <> Prevote then
+    None
+  else
+    Some (do_something ())
+
+let lock_prevote_phase (_height : height) (_round : round)
+    (consensus_state : consensus_state) (msg_log : input_log) _dlog global_state
+    =
+  let step = consensus_state.step in
+  let left_set : MySet.t =
+    select_proposal_process_round_matching_proposer msg_log consensus_state
+      global_state in
+  let right_set : MySet.t =
+    count_prevotes msg_log consensus_state global_state in
+  let extract_common_set (left_set : MySet.t) (right_set : MySet.t) : MySet.t =
+    let filtered_left_set =
+      MySet.filter (fun (v, _) -> is_valid global_state v) left_set in
+    MySet.filter
+      (fun (v, _) ->
+        MySet.exists (fun (v', _) -> repr_of_value v = v') right_set)
+      filtered_left_set in
+  let do_something (consensus_state : consensus_state) (valid_tuples : MySet.t)
+      =
+    let value, _ = MySet.choose valid_tuples in
+    let round = consensus_state.round in
+    consensus_state.valid_round <- round;
+    consensus_state.valid_value <- value;
+    if consensus_state.step = Prevote then (
+      consensus_state.locked_round <- round;
+      consensus_state.locked_value <- value;
+      consensus_state.step <- Precommit;
+      Broadcast
+        (PrecommitOP
+           (consensus_state.height, consensus_state.round, repr_of_value value)))
+    else
+      DoNothing in
+  let common_set = extract_common_set left_set right_set in
+  if step = Proposal || common_set = MySet.empty then
+    None
+  else
+    Some (do_something consensus_state common_set)
+
+let shortcut_prevote_fails (_height : height) (_round : round)
+    (consensus_state : consensus_state) (msg_log : input_log) _dlog global_state
+    =
+  let found_set = count_prevotes msg_log consensus_state global_state in
+  let find_valid found_set : MySet.t =
+    MySet.filter (fun (v, r) -> v = nil && r = consensus_state.round) found_set
+  in
+  let do_something consensus_state _found_set =
+    consensus_state.step <- Precommit;
+    Broadcast (PrecommitOP (consensus_state.height, consensus_state.round, nil))
+  in
+  let valid_set = find_valid found_set in
+  if valid_set = MySet.empty || consensus_state.step <> Prevote then
+    None
+  else
+    Some (do_something consensus_state valid_set)
+
+let prepare_new_round_precommit_fail (height : height) (round : round)
+    (consensus_state : consensus_state) (msg_log : input_log) _dlog global_state
+    =
+  let found_set =
+    count_precommits msg_log consensus_state global_state
+    |> MySet.filter (fun (_, r) -> r = consensus_state.round) in
+  let do_something () =
+    Schedule
+      (Clock.make precommit_timeout Precommit height round
+         (on_timeout_precommit height round)) in
+  if found_set = MySet.empty then None else Some (do_something ())
+
+let accept_block (_height : height) (process_round : round)
+    (consensus_state : consensus_state) (msg_log : input_log) dlog global_state
+    =
+  let height = consensus_state.height in
+  let extract_common_set (left_set : MySet.t) (right_set : MySet.t) =
+    MySet.filter
+      (fun (v, r) -> MySet.mem (repr_of_value v, r) right_set)
+      left_set in
+  let left_set =
+    select_proposal_matching_several_rounds msg_log consensus_state global_state
+  in
+  let right_set = count_precommits msg_log consensus_state global_state in
+  let valid_set = extract_common_set left_set right_set in
+  let do_something (_consensus_state : consensus_state) (_common_set : MySet.t)
+      =
+    let value, _valid_round = MySet.choose valid_set in
+    if is_valid global_state value then (
+      OutputLog.set dlog height value process_round;
+      (* Removing now irrelevant data from input_log *)
+      prune msg_log height;
+      Some (RestartTendermint (Int64.add height 1L, 0)))
+    else
+      Some DoNothing in
+  let c =
+    (* Should we NOT write in the output log *)
+    match OutputLog.get dlog height with
+    | Some (_, r) -> r >= process_round
+    | None -> false in
+  if valid_set = MySet.empty || c then
+    None
+  else
+    do_something consensus_state valid_set
+
+let handle_node_delay (height : height) (_round : round)
+    (consensus_state : consensus_state) (msg_log : input_log) _dlog global_state
+    =
+  let actions =
+    count_all_actions ~threshold_f:1. msg_log consensus_state global_state in
+  let round = consensus_state.round in
+  let apply_round_condition (actions : MySet.t) : MySet.t =
+    MySet.filter (fun (_, r) -> r > round) actions in
+  let do_something (_consensuus_state : consensus_state) (common_set : MySet.t)
+      =
+    let _, round = MySet.choose common_set in
+    Some (RestartTendermint (height, round)) in
+  let filtered_actions = apply_round_condition actions in
+  if filtered_actions = MySet.empty then
+    None
+  else
+    do_something consensus_state filtered_actions
+
+let all_processes : process list =
+  [
+    start_round;
+    response_to_proposal;
+    precommit_failed_previous_round;
+    lock_prevote_phase;
+    shortcut_prevote_fails;
+    prepare_default_precommit_prevote_phase;
+    prepare_new_round_precommit_fail;
+    accept_block;
+    handle_node_delay;
+    on_timeout_propose;
+    on_timeout_prevote;
+    on_timeout_precommit;
+  ]

--- a/src/node/tendermint_processes.mli
+++ b/src/node/tendermint_processes.mli
@@ -1,0 +1,45 @@
+open Tendermint_internals
+open Tendermint_data
+
+module type Clock_type = sig
+  type 'a t = {
+    time : int;
+    step : consensus_step;
+    height : height;
+    round : round;
+    on_timeout : consensus_state -> input_log -> OutputLog.t -> State.t -> 'a;
+    started : bool;
+  }
+  val make :
+    int ->
+    consensus_step ->
+    height ->
+    round ->
+    (consensus_state -> input_log -> OutputLog.t -> State.t -> 'a) ->
+    'a t
+end
+
+module Clock : Clock_type
+
+(* Values returned by processes, to be interpreted by the node as network
+   s *)
+type consensus_action =
+  | Broadcast         of sidechain_consensus_op
+  | Schedule          of consensus_action option Clock.t
+  | RestartTendermint of (height * round)
+  | DoNothing
+
+type process =
+  height ->
+  round ->
+  consensus_state ->
+  input_log ->
+  OutputLog.t ->
+  State.t ->
+  consensus_action option
+(** Tendermint processes *)
+
+type clock = consensus_action option Clock.t
+(** Clocks scheduled for timeouts, to be used in Tendermint *)
+
+val all_processes : process list

--- a/src/protocol/block.mli
+++ b/src/protocol/block.mli
@@ -8,12 +8,18 @@ type t = private {
   previous_hash : BLAKE2B.t;
   author : Key_hash.t;
   block_height : int64;
+  consensus_round : int;
   operations : Protocol_operation.t list;
 }
 [@@deriving yojson, ord]
 val sign : key:Secret.t -> t -> Protocol_signature.t
 val verify : signature:Protocol_signature.t -> t -> bool
 val genesis : t
+
+val update_round : t -> consensus_round:int -> t
+(** [update_round block round] changes the value of [block.consensus_round] and recomputes the hash
+    *)
+
 val produce :
   state:Protocol_state.t ->
   next_state_root_hash:BLAKE2B.t option ->

--- a/src/protocol/validators.ml
+++ b/src/protocol/validators.ml
@@ -52,3 +52,18 @@ let remove validator t =
   let hash = hash_validators validators in
   { current; validators; length; hash }
 let hash t = t.hash
+
+(** Round-robin proposer as used in Tendermint consensus. *)
+let proposer t height round =
+  let validators = t.validators in
+  let n = List.length validators in
+  (* n should stay small enough *)
+  let i1 = Int64.rem height (Int64.of_int n) in
+  let i1 = Int64.to_int i1 in
+  let i = (i1 + (round mod n)) mod n in
+  List.nth validators i
+
+(** Verifies if someone is a validator as required in Tendermint consensus. *)
+let is_validator t (x : Key_hash.t) =
+  let addresses = List.map (fun v -> v.address) t.validators in
+  List.mem x addresses

--- a/src/protocol/validators.mli
+++ b/src/protocol/validators.mli
@@ -16,3 +16,5 @@ val empty : t
 val add : validator -> t -> t
 val remove : validator -> t -> t
 val hash : t -> BLAKE2B.t
+val proposer : t -> int64 -> int -> validator
+val is_validator : t -> Key_hash.t -> bool

--- a/src/tezos/deku.ml
+++ b/src/tezos/deku.ml
@@ -6,13 +6,13 @@ module Consensus = struct
   let hash_validators validators =
     list (List.map key_hash validators) |> hash_packed_data
   let hash hash = bytes (BLAKE2B.to_raw_string hash |> Bytes.of_string)
-  let hash_block ~block_height ~block_payload_hash ~state_root_hash
-      ~withdrawal_handles_hash ~validators_hash =
+  let hash_block ~block_height ~consensus_round ~block_payload_hash
+      ~state_root_hash ~withdrawal_handles_hash ~validators_hash =
     pair
       (pair
          (pair (int (Z.of_int64 block_height)) (hash block_payload_hash))
-         (pair (hash withdrawal_handles_hash) (hash state_root_hash)))
-      (hash validators_hash)
+         (pair (int (Z.of_int consensus_round)) (hash withdrawal_handles_hash)))
+      (pair (hash state_root_hash) (hash validators_hash))
     |> hash_packed_data
   let hash_withdraw_handle ~id ~owner ~amount ~ticketer ~data =
     pair

--- a/src/tezos/deku.mli
+++ b/src/tezos/deku.mli
@@ -3,6 +3,7 @@ module Consensus : sig
   val hash_validators : Key_hash.t list -> BLAKE2B.t
   val hash_block :
     block_height:int64 ->
+    consensus_round:int ->
     block_payload_hash:BLAKE2B.t ->
     state_root_hash:BLAKE2B.t ->
     withdrawal_handles_hash:BLAKE2B.t ->

--- a/src/tezos_interop/tezos_interop.ml
+++ b/src/tezos_interop/tezos_interop.ml
@@ -190,11 +190,12 @@ end
 module Consensus = struct
   open Michelson.Michelson_v1_primitives
   open Tezos_micheline
-  let commit_state_hash ~context ~block_height ~block_payload_hash ~state_hash
-      ~withdrawal_handles_hash ~validators ~signatures =
+  let commit_state_hash ~context ~block_height ~block_round ~block_payload_hash
+      ~state_hash ~withdrawal_handles_hash ~validators ~signatures =
     let module Payload = struct
       type t = {
         block_height : int64;
+        block_round : int;
         block_payload_hash : BLAKE2B.t;
         signatures : string option list;
         handles_hash : BLAKE2B.t;
@@ -221,6 +222,7 @@ module Consensus = struct
       {
         block_height;
         block_payload_hash;
+        block_round;
         signatures;
         handles_hash = withdrawal_handles_hash;
         state_hash;
@@ -322,8 +324,10 @@ module Consensus = struct
     let micheline_to_validators = function
       | Ok
           (Micheline.Prim
-            (_, D_Pair, [Prim (_, D_Pair, [_; Seq (_, key_hashes)], _); _; _], _))
-        ->
+            ( _,
+              D_Pair,
+              [Prim (_, D_Pair, [_; _; Seq (_, key_hashes)], _); _; _],
+              _ )) ->
         List.fold_left_ok
           (fun acc k ->
             match k with

--- a/src/tezos_interop/tezos_interop.mli
+++ b/src/tezos_interop/tezos_interop.mli
@@ -13,6 +13,7 @@ module Consensus : sig
   val commit_state_hash :
     context:Context.t ->
     block_height:int64 ->
+    block_round:int ->
     block_payload_hash:BLAKE2B.t ->
     state_hash:BLAKE2B.t ->
     withdrawal_handles_hash:BLAKE2B.t ->

--- a/tests/test_tezos_interop.ml
+++ b/tests/test_tezos_interop.ml
@@ -567,7 +567,7 @@ let () =
             "6d6ecacbc858e3a89d87f0d9bd76b0c11b07aa95191129104395d17c6c96d36b");
       test "hash_block" (fun { expect; _ } ->
           let hash =
-            hash_block ~block_height:121L
+            hash_block ~block_height:121L ~consensus_round:0
               ~block_payload_hash:
                 (hash_exn
                    "2d92960a592c56de3046e200969c230a2eda71fc4b775e0cc09a189e5ddc5dbd")
@@ -583,7 +583,7 @@ let () =
           in
           let hash = BLAKE2B.to_string hash in
           (expect.string hash).toEqual
-            "7cb600c19817b899d4c28c521dd9ebf95f688e1444afe7d0e7740bebe848b030");
+            "305db8c9f9100ade89982d6d07e51991679b7128b43f20fa2bcb733743fa6098");
       test "hash_withdraw_handle" (fun { expect; _ } ->
           let hash =
             hash_withdraw_handle ~id:(Z.of_int 0)


### PR DESCRIPTION
(Edited by @aguillon on April 5th)

## Depends

- [ ] #432 
- [ ] #433 

## Problem

This is the crux of the biscuit: execution of Tendermint algorithm and integration into Deku.

## Solution

We keep a separation between calling Tendermint "subprocesses" and maintaining the consensus inner state on one hand, and exchanging messages on the network, accessing Deku node state and committing stuff on Tezos on the other. 

### `Tendermint.t` (`src/node/tendermint.ml`)

```
type t = {
  identity : State.identity;
  clocks : clock list IntSet.t;
  consensus_states : consensus_state IntSet.t;
  mutable procs : (height * process) list;
  node_state : State.t;
  input_log : input_log;
  output_log : output_log;
}
```

- `consensus_states`: memory of previous and current states.
- `clocks` is the list of clocks still ticking
- `procs` is the list of processes that need to be executed for the consensus to work; processes are defined at a given height.


This is performed by recursive function `tendermint_step` (`src/node/tendermint.ml`). Clocks are now started using Lwt timeout functions. Subprocesses are defined for a given height, at which they should match messages (L57); however, other information such as the round are defined in their inner state.

After executing all the processes that may react to the input log, the node may react by sending consensus operations to other nodes. Two hashes need to be signed: the consensus operation itself, and the block (including the round) in case we have to commit those signatures to Tezos. Such signatures prevent person-in-the-middle attacks.

Current implementation of clocks is bad. Sorry.

Finally, note that in some case (Tendermint reached consensus for the current height and wants to start the next height) it is necessary to reexecute the consensus.

### Integration into flows.ml

We first modify server.ml and flows.ml to add yet _another_ global state variable to access the current Tendermint.t instance. This is not ideal.

We also define helpers for Lwt.t, and result Lwt.t effects, that are easier to use together than `let%assert` and `let%await`.

This allows us to write a handler that handles Lwt.t (whereas all the other handlers just use result), which in turn gives us the ability to synchronize with some important subroutines. When we receive a consensus step, we can indeed check that we are at the right height and that we didn't miss any block. If we are late, we call `request_previous_blocks`, which has been changed to be sequential. When we are not late, we can call the consensus with the received operation.

Finally, as we distinguish between Tendermint inner workings and Deku admission of new blocks, we keep the "signature" semantics from the previous consensus: when we receive a Precommit operation for an actual block (not Nil), we treat it as a signature (endorsement) of the block, and commit it to the block pool. When we have enough signatures, the `block_added_to_the_pool` function (that we only slightly changed) finds the signature and, eventually, commits the block.

@d4hines: we restricted the previous Block_pool usage to limit it to blocks that are Precommitted. What's your opinion on this?

I just noticed that these functions are still a bit in WIP state. Sorry about that, I'll edit later.

### Committing on Tezos

In order to periodically commit the state of the consensus on Tezos with the correct round information, some changes were necessary in tezos_interop/ as well.

## Known issues

- Some processes need to be removed from *procs* such as timeouts when the height changed.
- The input_log is not emptied when height increased.

## Reviews

I'm not confident about the stuff in flows.ml, but I think @EduardoRFS and @d4hines should focus on this as this is probably the most sensitive stuff.