### PR TITLE
tezos_rpc: library and /inject-operations

### DIFF
--- a/src/tezos_rpc/dune
+++ b/src/tezos_rpc/dune
@@ -1,0 +1,6 @@
+(library
+ (name tezos_rpc)
+ (libraries helpers piaf crypto tezos uri)
+ (modules_without_implementation error tezos_rpc)
+ (preprocess
+  (pps ppx_deriving_yojson ppx_deriving.eq ppx_let_binding)))

--- a/src/tezos_rpc/error.mli
+++ b/src/tezos_rpc/error.mli
@@ -1,0 +1,5 @@
+type error =
+  | Json_error         of string
+  | Piaf_body          of Piaf.Error.t
+  | Piaf_request       of Piaf.Error.t
+  | Response_of_yojson of string

--- a/src/tezos_rpc/http.ml
+++ b/src/tezos_rpc/http.ml
@@ -1,0 +1,41 @@
+open Helpers
+open Error
+
+type 'a method_ =
+  | GET : unit method_
+  | POST : string method_
+let http_request (type a) ~uri ~(method_ : a method_) (data : a) =
+  let open Piaf in
+  let%await response =
+    match method_ with
+    | GET -> Client.Oneshot.get uri
+    | POST ->
+      let body = Body.of_string data in
+      Client.Oneshot.post ~body uri in
+  match response with
+  | Ok response -> (
+    let%await body = Piaf.Body.to_string response.body in
+    match body with
+    | Ok body -> await (Ok body)
+    | Error err -> await (Error (Piaf_body err)))
+  | Error err -> await (Error (Piaf_request err))
+
+let http_request ~node_uri ~path ~method_ response_of_yojson data =
+  let uri = Uri.with_path node_uri path in
+  let%await body = http_request ~uri ~method_ data in
+  match body with
+  | Ok body -> (
+    try
+      let json = Yojson.Safe.from_string body in
+      match response_of_yojson json with
+      | Ok response -> await (Ok response)
+      | Error err -> await (Error (Response_of_yojson err))
+    with
+    | Yojson.Json_error err -> await (Error (Json_error err)))
+  | Error err -> await (Error err)
+
+let http_get ~node_uri ~path ~of_yojson =
+  http_request ~node_uri ~path ~method_:GET of_yojson ()
+let http_post ~node_uri ~path ~of_yojson ~data =
+  let data = Yojson.Safe.to_string data in
+  http_request ~node_uri ~path ~method_:POST of_yojson data

--- a/src/tezos_rpc/http.mli
+++ b/src/tezos_rpc/http.mli
@@ -1,0 +1,11 @@
+val http_get :
+  node_uri:Uri.t ->
+  path:string ->
+  of_yojson:(Yojson.Safe.t -> ('a, string) result) ->
+  ('a, Error.error) result Lwt.t
+val http_post :
+  node_uri:Uri.t ->
+  path:string ->
+  of_yojson:(Yojson.Safe.t -> ('a, string) result) ->
+  data:Yojson.Safe.t ->
+  ('a, Error.error) result Lwt.t

--- a/src/tezos_rpc/inject_operations.ml
+++ b/src/tezos_rpc/inject_operations.ml
@@ -1,0 +1,12 @@
+open Tezos
+open Http
+
+type response = Operation_hash.t [@@deriving yojson]
+
+(* TODO: should I use ?async *)
+let path = "/injection/operation"
+
+let execute ~node_uri ~secret ~branch ~operations =
+  let signed_forged_operation = Operation.forge ~secret ~branch ~operations in
+  http_post ~node_uri ~path ~of_yojson:response_of_yojson
+    ~data:(`String signed_forged_operation)

--- a/src/tezos_rpc/inject_operations.mli
+++ b/src/tezos_rpc/inject_operations.mli
@@ -1,0 +1,10 @@
+open Crypto
+open Tezos
+
+type response = Operation_hash.t
+val execute :
+  node_uri:Uri.t ->
+  secret:Secret.t ->
+  branch:Block_hash.t ->
+  operations:Operation.t list ->
+  (response, Error.error) result Lwt.t

--- a/src/tezos_rpc/tezos_rpc.mli
+++ b/src/tezos_rpc/tezos_rpc.mli
@@ -1,0 +1,2 @@
+module Error = Error
+module Inject_operations = Inject_operations


### PR DESCRIPTION
## Depends

- [x] #445

## Problem

As mentioned at #429 ideally we should move away from Taquito, for this one of the requirements is that we need to be able to inject operations on Tezos.

## Solution

This PR exposes `Tezos_rpc.Inject_operations.execute` to actually inject the operations on the chain, under the hood it uses #429 work to make the HTTP requests to a Tezos node.

This also defines the `tezos_rpc` library to be extended in the future.