### PR TITLE
tezos: fix Operation.forge with default + Unit

### DIFF
--- a/src/tezos/michelson.ml
+++ b/src/tezos/michelson.ml
@@ -7,3 +7,10 @@ type t = Michelson_v1_primitives.prim Tezos_micheline.Micheline.canonical
 let expr_encoding =
   Micheline_encoding.canonical_encoding ~variant:"michelson_v1"
     Michelson_v1_primitives.prim_encoding
+
+let unit =
+  Micheline.strip_locations (Prim (-1, Michelson_v1_primitives.D_Unit, [], []))
+let is_unit value =
+  match Micheline.root value with
+  | Prim (_, Michelson_v1_primitives.D_Unit, [], []) -> true
+  | _ -> false

--- a/src/tezos/michelson.ml
+++ b/src/tezos/michelson.ml
@@ -7,4 +7,3 @@ type t = Michelson_v1_primitives.prim Tezos_micheline.Micheline.canonical
 let expr_encoding =
   Micheline_encoding.canonical_encoding ~variant:"michelson_v1"
     Michelson_v1_primitives.prim_encoding
-let lazy_expr_encoding = Data_encoding.lazy_encoding expr_encoding

--- a/src/tezos/michelson.mli
+++ b/src/tezos/michelson.mli
@@ -3,3 +3,6 @@ module Michelson_v1_primitives = Michelson_v1_primitives
 type t = Michelson_v1_primitives.prim Tezos_micheline.Micheline.canonical
 
 val expr_encoding : t Data_encoding.t
+
+val unit : t
+val is_unit : t -> bool

--- a/src/tezos/michelson.mli
+++ b/src/tezos/michelson.mli
@@ -3,4 +3,3 @@ module Michelson_v1_primitives = Michelson_v1_primitives
 type t = Michelson_v1_primitives.prim Tezos_micheline.Micheline.canonical
 
 val expr_encoding : t Data_encoding.t
-val lazy_expr_encoding : t Data_encoding.lazy_t Data_encoding.t

--- a/src/tezos/operation.ml
+++ b/src/tezos/operation.ml
@@ -5,9 +5,7 @@ let () = Printexc.record_backtrace true
 
 type parameters = {
   entrypoint : string;
-  value :
-    Michelson_v1_primitives.prim Tezos_micheline.Micheline.canonical
-    Data_encoding.lazy_t;
+  value : Michelson.t;
 }
 type transaction = {
   amount : Tez.t;
@@ -74,7 +72,7 @@ let encoding =
         (opt "parameters"
            (obj2
               (req "entrypoint" entrypoint_encoding)
-              (req "value" Michelson.lazy_expr_encoding)))
+              (req "value" Michelson.expr_encoding)))
 
     let encoding =
       conv

--- a/src/tezos/operation.mli
+++ b/src/tezos/operation.mli
@@ -2,15 +2,12 @@ open Crypto
 
 (* TODO: operation here means Manager_operation *)
 
-type parameters = {
-  entrypoint : string;
-  (* WARNING: not lazy, only use with trusted communication *)
-  value : Michelson.t;
-}
 type transaction = {
   amount : Tez.t;
   destination : Address.t;
-  parameters : parameters option;
+  entrypoint : string;
+  (* WARNING: not lazy, only use with trusted communication *)
+  value : Michelson.t;
 }
 
 type content = Transaction of transaction

--- a/src/tezos/operation.mli
+++ b/src/tezos/operation.mli
@@ -4,7 +4,8 @@ open Crypto
 
 type parameters = {
   entrypoint : string;
-  value : Michelson.t Data_encoding.lazy_t;
+  (* WARNING: not lazy, only use with trusted communication *)
+  value : Michelson.t;
 }
 type transaction = {
   amount : Tez.t;


### PR DESCRIPTION
## Problem

On Tezos there is no distinction between parameters being empty, and a parameter that has entrypoint of `default` and value of `unit`, this is currently not the case on Deku.

This can be verified at [operation_repr.ml](https://gitlab.com/tezos/tezos/-/blob/40c795e414f9a799bf0af3312e0efd264a1231d9/src/proto_alpha/lib_protocol/operation_repr.ml#L440)

## Solution

Changing the API to represent this and also handling the checking on the encodings like how Tezos is doing. I also added another test extracted from Taquito calling a contract.