### PR TITLE
tezos_rpc: add Fetch_block_header

### DIFF
--- a/src/tezos_rpc/fetch_block_header.ml
+++ b/src/tezos_rpc/fetch_block_header.ml
@@ -1,0 +1,23 @@
+open Tezos
+open Http
+
+type response = Block_header.t
+
+let path ~chain ~block_hash =
+  (* TODO: I don't like this Format.sprintf *)
+  Format.sprintf "/chains/%s/blocks/%s/header" chain block_hash
+
+let execute ~node_uri ~chain ~block_hash =
+  let chain =
+    match chain with
+    | Some chain -> Chain_id.to_string chain
+    | None -> "main" in
+
+  let block_hash =
+    match block_hash with
+    | Some block_hash -> Block_hash.to_string block_hash
+    (* TODO: we could also query by height *)
+    | None -> "head" in
+
+  let path = path ~chain ~block_hash in
+  http_get ~node_uri ~path ~of_yojson:Block_header.of_yojson

--- a/src/tezos_rpc/fetch_block_header.mli
+++ b/src/tezos_rpc/fetch_block_header.mli
@@ -1,0 +1,8 @@
+open Tezos
+
+type response = Block_header.t
+val execute :
+  node_uri:Uri.t ->
+  chain:Chain_id.t option ->
+  block_hash:Block_hash.t option ->
+  (response, Error.error) result Lwt.t

--- a/src/tezos_rpc/tezos_rpc.mli
+++ b/src/tezos_rpc/tezos_rpc.mli
@@ -1,6 +1,7 @@
 module Error = Error
 module Inject_operations = Inject_operations
 module Fetch_block_operations = Fetch_block_operations
+module Fetch_block_header = Fetch_block_header
 
 module Block_header = Block_header
 module Listen_to_chain_heads = Listen_to_chain_heads


### PR DESCRIPTION
## Depends

- [x] #447

## Problem

Following #447, in the missiong of moving away from Taquito, sometimes we may not receive a block, because the connection with the Tezos RPC was temporarily broken, so we need to be able to fetch old blocks header.

## Solution

Implements `Tezos_rpc.Fetch_block_header`, this will call Tezos asking for an specific block header.