### PR TITLE
Fetch validators from discovery.mligo instead of validators.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@taquito/rpc": "^11.0.1",
-        "@taquito/signer": "^11.0.1",
-        "@taquito/taquito": "^11.0.1",
+        "@taquito/rpc": "^12.1.0",
+        "@taquito/signer": "^12.1.0",
+        "@taquito/taquito": "^12.1.0",
         "webpack": "^5.47.1",
         "webpack-cli": "^4.7.1"
       },
@@ -20,9 +20,9 @@
       }
     },
     "node_modules/@discoveryjs/json-ext": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
-      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz",
+      "integrity": "sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -45,6 +45,16 @@
         "@stablelib/wipe": "^1.0.1"
       }
     },
+    "node_modules/@stablelib/bytes": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/bytes/-/bytes-1.0.1.tgz",
+      "integrity": "sha512-Kre4Y4kdwuqL8BR2E9hV/R5sOrUj6NanZaZis0V6lX5yzqC3hBuVSDXUIBqQv/sCpmuWRiHLwqiT1pqqjuBXoQ=="
+    },
+    "node_modules/@stablelib/constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.1.tgz",
+      "integrity": "sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg=="
+    },
     "node_modules/@stablelib/ed25519": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.2.tgz",
@@ -65,12 +75,51 @@
       "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
       "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w=="
     },
+    "node_modules/@stablelib/keyagreement": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/keyagreement/-/keyagreement-1.0.1.tgz",
+      "integrity": "sha512-VKL6xBwgJnI6l1jKrBAfn265cspaWBPAPEc62VBQrWHLqVgNRE09gQ/AnOEyKUWrrqfD+xSQ3u42gJjLDdMDQg==",
+      "dependencies": {
+        "@stablelib/bytes": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/nacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@stablelib/nacl/-/nacl-1.0.3.tgz",
+      "integrity": "sha512-ZdDGRo4s6ke2rdhwwna5SAikU48AQRNqPPbJ29ZSC781SMUMPpkixKpyZG+NfYhMkFSJ0ZRlFdKW+/ksmpVHWA==",
+      "dependencies": {
+        "@stablelib/poly1305": "^1.0.1",
+        "@stablelib/random": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1",
+        "@stablelib/x25519": "^1.0.2",
+        "@stablelib/xsalsa20": "^1.0.2"
+      }
+    },
+    "node_modules/@stablelib/poly1305": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/poly1305/-/poly1305-1.0.1.tgz",
+      "integrity": "sha512-1HlG3oTSuQDOhSnLwJRKeTRSAdFNVB/1djy2ZbS35rBSJ/PFqx9cf9qatinWghC2UbfOYD8AcrtbUQl8WoxabA==",
+      "dependencies": {
+        "@stablelib/constant-time": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
     "node_modules/@stablelib/random": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.1.tgz",
       "integrity": "sha512-zOh+JHX3XG9MSfIB0LZl/YwPP9w3o6WBiJkZvjPoKKu5LKFW4OLV71vMxWp9qG5T43NaWyn0QQTWgqCdO+yOBQ==",
       "dependencies": {
         "@stablelib/binary": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/salsa20": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stablelib/salsa20/-/salsa20-1.0.2.tgz",
+      "integrity": "sha512-nfjKzw0KTKrrKBasEP+j7UP4I8Xudom8lVZIBCp0kQNARXq72IlSic0oabg2FC1NU68L4RdHrNJDd8bFwrphYA==",
+      "dependencies": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/constant-time": "^1.0.1",
         "@stablelib/wipe": "^1.0.1"
       }
     },
@@ -89,32 +138,64 @@
       "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
       "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
     },
-    "node_modules/@taquito/http-utils": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-11.2.0.tgz",
-      "integrity": "sha512-9s9l4z70ah8/pjmc5ARxdwy6GCnsqwYxMITqCqKBT4DKVgI8m8kXkdxaVg+Ob5ZGvRQoVDSgTeSeNg8TUMtc+w==",
+    "node_modules/@stablelib/x25519": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.2.tgz",
+      "integrity": "sha512-wTR0t0Bp1HABLFRbYaE3vFLuco2QbAg6QvxBnzi5j9qjhYezWHW7OiCZyaWbt25UkSaoolUUT4Il0nS/2vcbSw==",
       "dependencies": {
-        "xhr2-cookies": "^1.1.0"
+        "@stablelib/keyagreement": "^1.0.1",
+        "@stablelib/random": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/xsalsa20": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stablelib/xsalsa20/-/xsalsa20-1.0.2.tgz",
+      "integrity": "sha512-7XdBGbcNgBShmuhDXv1G1WPVCkjZdkb1oPMzSidO7Fve0MHntH6TjFkj5bfLI+aRE+61weO076vYpP/jmaAYog==",
+      "dependencies": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/salsa20": "^1.0.2",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@taquito/http-utils": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-12.1.0.tgz",
+      "integrity": "sha512-/sD6+fWk25pBPA99pzkdbVwB+MmhouRV83QooUr3qCU2x+/QyxVDCvjKZCPQn5i/JBzQkc9KCBbg1rcCxqdZJQ==",
+      "dependencies": {
+        "axios": "^0.26.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@taquito/local-forging": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-12.1.0.tgz",
+      "integrity": "sha512-gOl//ewOGhosykxsQvwfRsdAJQ3OxjzEM2ZPsMfsoRXT7WabeP+8recrda5jgPv1SSN6kIS4YObLn8sdekK6jg==",
+      "dependencies": {
+        "@taquito/utils": "^12.1.0",
+        "bignumber.js": "^9.0.2"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@taquito/michel-codec": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-11.2.0.tgz",
-      "integrity": "sha512-ZWu1eyRl9RqOpyHP5h3JKfSPylUMN/91GTWjlJ26GhaMP9YA6mVjJ7pWDrZHFn1QXiS8JgQ7xwsmU+dBqZznSw==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-12.1.0.tgz",
+      "integrity": "sha512-003+8p+S/vLIgvwmbgYi71FzVN2m8ivO43pOovhJ+SKMeYJr+08YuyZhJf37P4XsqWdkeievLFGadKc7sSxRMQ==",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@taquito/michelson-encoder": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-11.2.0.tgz",
-      "integrity": "sha512-ifU3PSrJiQDovY7MT3RjrBTVToW82vGBwXeTIKIMnnoAjCnZdL/XjxFfzTrxT90jaz++ou3xcrgIabSvJrfJjg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-12.1.0.tgz",
+      "integrity": "sha512-olRt1h0F+/f2dKpYbTJU8M5z7gtptwkeT4f6Om3rhqm+nNioq/+PLiSoJ0TWEy/hYZpLUmhPGS1f1/jBTOO2Yg==",
       "dependencies": {
-        "@taquito/rpc": "^11.2.0",
-        "@taquito/utils": "^11.2.0",
+        "@taquito/rpc": "^12.1.0",
+        "@taquito/utils": "^12.1.0",
         "bignumber.js": "^9.0.2",
         "fast-json-stable-stringify": "^2.1.0"
       },
@@ -123,12 +204,12 @@
       }
     },
     "node_modules/@taquito/rpc": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-11.2.0.tgz",
-      "integrity": "sha512-Hb5KIi1swUIGHg6h6cPJ+6G+6Nfi6Npat4RogOFvULpbn+WQIo+CTUecEW7aWEBuXahs7W0JBcL4a6GbqE3YGg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-12.1.0.tgz",
+      "integrity": "sha512-q4uMSPU2Ibbs2ZPW1TWHYz2oVXXP7ZVKKR+Yqu3Y0mm49yb/vpH847IKyyz8F+NZdHkyIHVR/dpQcEtk2x1hXA==",
       "dependencies": {
-        "@taquito/http-utils": "^11.2.0",
-        "@taquito/utils": "^11.2.0",
+        "@taquito/http-utils": "^12.1.0",
+        "@taquito/utils": "^12.1.0",
         "bignumber.js": "^9.0.2"
       },
       "engines": {
@@ -136,14 +217,16 @@
       }
     },
     "node_modules/@taquito/signer": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-11.2.0.tgz",
-      "integrity": "sha512-OthNW7gN2hJNph8VMy9LRbZcn7bIBaKdrfC+hAy5N6yzG8EW/t6IEMAgESmNcthMhPUhuOWS37khuwMsuL1GUg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-12.1.0.tgz",
+      "integrity": "sha512-liU0ePyTIGivcA/+X6cQ4pQMIxD6TFZOHYPStxdJBphLsbYAVn5sH6nuQimY5DNmynK3kQOAVfZmV553xjesoA==",
       "dependencies": {
-        "@taquito/taquito": "^11.2.0",
-        "@taquito/utils": "^11.2.0",
+        "@stablelib/blake2b": "^1.0.1",
+        "@stablelib/ed25519": "^1.0.2",
+        "@stablelib/nacl": "^1.0.3",
+        "@taquito/taquito": "^12.1.0",
+        "@taquito/utils": "^12.1.0",
         "elliptic": "^6.5.4",
-        "libsodium-wrappers": "0.7.8",
         "pbkdf2": "^3.1.2",
         "typedarray-to-buffer": "^4.0.0"
       },
@@ -152,16 +235,17 @@
       }
     },
     "node_modules/@taquito/taquito": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-11.2.0.tgz",
-      "integrity": "sha512-OJJYPqQiF7IoxWsBavdKDuxi2oeWHHvRph2nqeCyqVx6H+7uQLpZCf0OP5iQ4F6AxoYPyD7DzEsSFH5tOdgqNQ==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-12.1.0.tgz",
+      "integrity": "sha512-mCWZIFR6a6M/vggj8eGtU10e1CSlyF7boYxPd2eBYQpH8k2Sz1FsRKBEZhNGS6CKCb3gBYmNYH/USqv5d3pRWw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@taquito/http-utils": "^11.2.0",
-        "@taquito/michel-codec": "^11.2.0",
-        "@taquito/michelson-encoder": "^11.2.0",
-        "@taquito/rpc": "^11.2.0",
-        "@taquito/utils": "^11.2.0",
+        "@taquito/http-utils": "^12.1.0",
+        "@taquito/local-forging": "^12.1.0",
+        "@taquito/michel-codec": "^12.1.0",
+        "@taquito/michelson-encoder": "^12.1.0",
+        "@taquito/rpc": "^12.1.0",
+        "@taquito/utils": "^12.1.0",
         "bignumber.js": "^9.0.2",
         "rxjs": "^6.6.3"
       },
@@ -170,9 +254,9 @@
       }
     },
     "node_modules/@taquito/utils": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-I5LoD5fG9S2Yo4CNpW4u3vF9lUJG1PxkGLi6ntvvH49SBXwo9HJ/n/v04aoE9V7ncA0a7LUm6ucnROagIc2QQQ==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-12.1.0.tgz",
+      "integrity": "sha512-XXO5m6Zfn/JuxOsWDny970sPI7qX+3rWQuEpu1lHDhGCaKbkwCNfhroeUU2TZnC6YGyMLLNLUorarmKpS7aMPA==",
       "dependencies": {
         "@stablelib/blake2b": "^1.0.1",
         "@stablelib/ed25519": "^1.0.2",
@@ -196,9 +280,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.2.tgz",
-      "integrity": "sha512-Z1nseZON+GEnFjJc04sv4NSALGjhFwy6K0HXt7qsn5ArfAKtb63dXNJHf+1YW6IpOIYRBGUbu3GwJdj8DGnCjA==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
+      "integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -219,14 +303,14 @@
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
     },
     "node_modules/@types/node": {
-      "version": "17.0.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
-      "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q=="
+      "version": "17.0.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
+      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ=="
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -403,9 +487,9 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
     "node_modules/acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -442,6 +526,14 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "peerDependencies": {
         "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/base-x": {
@@ -495,24 +587,14 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "node_modules/browserslist": {
-      "version": "4.20.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
-      "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        }
-      ],
+      "version": "4.19.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.3.tgz",
+      "integrity": "sha512-XK3X4xtKJ+Txj8G5c30B4gsm71s69lqXlkYui4s6EkKxuv49qjYlY6oVd+IFJ73d4YymtM3+djvvt/R/iJwwDg==",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001332",
-        "electron-to-chromium": "^1.4.118",
+        "caniuse-lite": "^1.0.30001312",
+        "electron-to-chromium": "^1.4.71",
         "escalade": "^3.1.1",
-        "node-releases": "^2.0.3",
+        "node-releases": "^2.0.2",
         "picocolors": "^1.0.0"
       },
       "bin": {
@@ -520,6 +602,10 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
       }
     },
     "node_modules/bs58": {
@@ -569,19 +655,13 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001335",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001335.tgz",
-      "integrity": "sha512-ddP1Tgm7z2iIxu6QTtbZUv6HJxSaV/PZeSrWFZtbY4JZ69tOeNhBCl3HyRQgeNZKE5AOn1kpV7fhljigy0Ty3w==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        }
-      ]
+      "version": "1.0.30001312",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
+      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
@@ -623,11 +703,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
-    "node_modules/cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
-    },
     "node_modules/create-hash": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -667,9 +742,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.132",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.132.tgz",
-      "integrity": "sha512-JYdZUw/1068NWN+SwXQ7w6Ue0bWYGihvSUNNQwurvcDV/SM7vSiGZ3NuFvFgoEiCs4kB8xs3cX2an3wB7d4TBw=="
+      "version": "1.4.73",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.73.tgz",
+      "integrity": "sha512-RlCffXkE/LliqfA5m29+dVDPB2r72y2D2egMMfIy3Le8ODrxjuZNVo4NIC2yPL01N4xb4nZQLwzi6Z5tGIGLnA=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -686,9 +761,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz",
-      "integrity": "sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.1.tgz",
+      "integrity": "sha512-jdyZMwCQ5Oj4c5+BTnkxPgDZO/BJzh/ADDmKebayyzNwjVX1AFCeGkOfxNx0mHi2+8BKC5VxUYiw3TIvoT7vhw==",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -817,6 +892,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -839,9 +933,9 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -953,9 +1047,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -1029,23 +1123,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/libsodium": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.8.tgz",
-      "integrity": "sha512-/Qc+APf0jbeWSaeEruH0L1/tbbT+sbf884ZL0/zV/0JXaDPBzYkKbyb/wmxMHgAHzm3t6gqe7bOOXAVwfqVikQ=="
-    },
-    "node_modules/libsodium-wrappers": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.8.tgz",
-      "integrity": "sha512-PDhPWXBqd/SaqAFUBgH2Ux7b3VEEJgyD6BQB+VdNFJb9PbExGr/T/myc/MBoSvl8qLzfm0W0IVByOQS5L1MrCg==",
-      "dependencies": {
-        "libsodium": "0.7.8"
-      }
-    },
     "node_modules/loader-runner": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
+      "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
       "engines": {
         "node": ">=6.11.5"
       }
@@ -1060,11 +1141,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "node_modules/md5.js": {
       "version": "1.3.5",
@@ -1082,19 +1158,19 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "version": "2.1.34",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
       "dependencies": {
-        "mime-db": "1.52.0"
+        "mime-db": "1.51.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -1124,9 +1200,9 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/node-releases": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
-      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
+      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg=="
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
@@ -1239,18 +1315,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
         "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode": {
@@ -1506,13 +1579,13 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.13.1.tgz",
-      "integrity": "sha512-hn4WKOfwnwbYfe48NgrQjqNOH9jzLqRcIfbYytOXCOv46LBfWr9bDS17MQqOi+BWGD0sJK3Sj5NC/gJjiojaoA==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.11.0.tgz",
+      "integrity": "sha512-uCA9DLanzzWSsN1UirKwylhhRz3aKPInlfmpGfw8VN6jHsAtu8HJtIpeeHHK23rxnE/cDc+yvmq5wqkIC6Kn0A==",
       "dependencies": {
         "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.8.0-beta.0",
+        "source-map": "~0.7.2",
         "source-map-support": "~0.5.20"
       },
       "bin": {
@@ -1556,22 +1629,11 @@
       }
     },
     "node_modules/terser/node_modules/source-map": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-      "dependencies": {
-        "whatwg-url": "^7.0.0"
-      },
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dependencies": {
-        "punycode": "^2.1.0"
       }
     },
     "node_modules/tslib": {
@@ -1623,15 +1685,10 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
-    },
     "node_modules/webpack": {
-      "version": "5.72.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.0.tgz",
-      "integrity": "sha512-qmSmbspI0Qo5ld49htys8GY9XhS9CGqFoHTsOVAnjBdg0Zn79y135R+k4IR4rKK6+eKaabMhJwiVB7xw0SJu5w==",
+      "version": "5.69.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.69.1.tgz",
+      "integrity": "sha512-+VyvOSJXZMT2V5vLzOnDuMz5GxEqLk7hKWQ56YxPW/PQRUuKimPqmEIJOx8jHYeyo65pKbapbW464mvsKbaj4A==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -1642,7 +1699,7 @@
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.9.2",
+        "enhanced-resolve": "^5.8.3",
         "es-module-lexer": "^0.9.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -1744,16 +1801,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-      "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -1772,14 +1819,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw=="
-    },
-    "node_modules/xhr2-cookies": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
-      "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
-      "dependencies": {
-        "cookiejar": "^2.1.1"
-      }
     }
   },
   "dependencies": {
@@ -1806,6 +1845,16 @@
         "@stablelib/wipe": "^1.0.1"
       }
     },
+    "@stablelib/bytes": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/bytes/-/bytes-1.0.1.tgz",
+      "integrity": "sha512-Kre4Y4kdwuqL8BR2E9hV/R5sOrUj6NanZaZis0V6lX5yzqC3hBuVSDXUIBqQv/sCpmuWRiHLwqiT1pqqjuBXoQ=="
+    },
+    "@stablelib/constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.1.tgz",
+      "integrity": "sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg=="
+    },
     "@stablelib/ed25519": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.2.tgz",
@@ -1826,12 +1875,51 @@
       "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
       "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w=="
     },
+    "@stablelib/keyagreement": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/keyagreement/-/keyagreement-1.0.1.tgz",
+      "integrity": "sha512-VKL6xBwgJnI6l1jKrBAfn265cspaWBPAPEc62VBQrWHLqVgNRE09gQ/AnOEyKUWrrqfD+xSQ3u42gJjLDdMDQg==",
+      "requires": {
+        "@stablelib/bytes": "^1.0.1"
+      }
+    },
+    "@stablelib/nacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@stablelib/nacl/-/nacl-1.0.3.tgz",
+      "integrity": "sha512-ZdDGRo4s6ke2rdhwwna5SAikU48AQRNqPPbJ29ZSC781SMUMPpkixKpyZG+NfYhMkFSJ0ZRlFdKW+/ksmpVHWA==",
+      "requires": {
+        "@stablelib/poly1305": "^1.0.1",
+        "@stablelib/random": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1",
+        "@stablelib/x25519": "^1.0.2",
+        "@stablelib/xsalsa20": "^1.0.2"
+      }
+    },
+    "@stablelib/poly1305": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/poly1305/-/poly1305-1.0.1.tgz",
+      "integrity": "sha512-1HlG3oTSuQDOhSnLwJRKeTRSAdFNVB/1djy2ZbS35rBSJ/PFqx9cf9qatinWghC2UbfOYD8AcrtbUQl8WoxabA==",
+      "requires": {
+        "@stablelib/constant-time": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
     "@stablelib/random": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.1.tgz",
       "integrity": "sha512-zOh+JHX3XG9MSfIB0LZl/YwPP9w3o6WBiJkZvjPoKKu5LKFW4OLV71vMxWp9qG5T43NaWyn0QQTWgqCdO+yOBQ==",
       "requires": {
         "@stablelib/binary": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "@stablelib/salsa20": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stablelib/salsa20/-/salsa20-1.0.2.tgz",
+      "integrity": "sha512-nfjKzw0KTKrrKBasEP+j7UP4I8Xudom8lVZIBCp0kQNARXq72IlSic0oabg2FC1NU68L4RdHrNJDd8bFwrphYA==",
+      "requires": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/constant-time": "^1.0.1",
         "@stablelib/wipe": "^1.0.1"
       }
     },
@@ -1850,71 +1938,103 @@
       "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
       "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
     },
-    "@taquito/http-utils": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-11.2.0.tgz",
-      "integrity": "sha512-9s9l4z70ah8/pjmc5ARxdwy6GCnsqwYxMITqCqKBT4DKVgI8m8kXkdxaVg+Ob5ZGvRQoVDSgTeSeNg8TUMtc+w==",
+    "@stablelib/x25519": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.2.tgz",
+      "integrity": "sha512-wTR0t0Bp1HABLFRbYaE3vFLuco2QbAg6QvxBnzi5j9qjhYezWHW7OiCZyaWbt25UkSaoolUUT4Il0nS/2vcbSw==",
       "requires": {
-        "xhr2-cookies": "^1.1.0"
+        "@stablelib/keyagreement": "^1.0.1",
+        "@stablelib/random": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "@stablelib/xsalsa20": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stablelib/xsalsa20/-/xsalsa20-1.0.2.tgz",
+      "integrity": "sha512-7XdBGbcNgBShmuhDXv1G1WPVCkjZdkb1oPMzSidO7Fve0MHntH6TjFkj5bfLI+aRE+61weO076vYpP/jmaAYog==",
+      "requires": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/salsa20": "^1.0.2",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "@taquito/http-utils": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-12.1.0.tgz",
+      "integrity": "sha512-/sD6+fWk25pBPA99pzkdbVwB+MmhouRV83QooUr3qCU2x+/QyxVDCvjKZCPQn5i/JBzQkc9KCBbg1rcCxqdZJQ==",
+      "requires": {
+        "axios": "^0.26.0"
+      }
+    },
+    "@taquito/local-forging": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-12.1.0.tgz",
+      "integrity": "sha512-gOl//ewOGhosykxsQvwfRsdAJQ3OxjzEM2ZPsMfsoRXT7WabeP+8recrda5jgPv1SSN6kIS4YObLn8sdekK6jg==",
+      "requires": {
+        "@taquito/utils": "^12.1.0",
+        "bignumber.js": "^9.0.2"
       }
     },
     "@taquito/michel-codec": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-11.2.0.tgz",
-      "integrity": "sha512-ZWu1eyRl9RqOpyHP5h3JKfSPylUMN/91GTWjlJ26GhaMP9YA6mVjJ7pWDrZHFn1QXiS8JgQ7xwsmU+dBqZznSw=="
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-12.1.0.tgz",
+      "integrity": "sha512-003+8p+S/vLIgvwmbgYi71FzVN2m8ivO43pOovhJ+SKMeYJr+08YuyZhJf37P4XsqWdkeievLFGadKc7sSxRMQ=="
     },
     "@taquito/michelson-encoder": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-11.2.0.tgz",
-      "integrity": "sha512-ifU3PSrJiQDovY7MT3RjrBTVToW82vGBwXeTIKIMnnoAjCnZdL/XjxFfzTrxT90jaz++ou3xcrgIabSvJrfJjg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-12.1.0.tgz",
+      "integrity": "sha512-olRt1h0F+/f2dKpYbTJU8M5z7gtptwkeT4f6Om3rhqm+nNioq/+PLiSoJ0TWEy/hYZpLUmhPGS1f1/jBTOO2Yg==",
       "requires": {
-        "@taquito/rpc": "^11.2.0",
-        "@taquito/utils": "^11.2.0",
+        "@taquito/rpc": "^12.1.0",
+        "@taquito/utils": "^12.1.0",
         "bignumber.js": "^9.0.2",
         "fast-json-stable-stringify": "^2.1.0"
       }
     },
     "@taquito/rpc": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-11.2.0.tgz",
-      "integrity": "sha512-Hb5KIi1swUIGHg6h6cPJ+6G+6Nfi6Npat4RogOFvULpbn+WQIo+CTUecEW7aWEBuXahs7W0JBcL4a6GbqE3YGg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-12.1.0.tgz",
+      "integrity": "sha512-q4uMSPU2Ibbs2ZPW1TWHYz2oVXXP7ZVKKR+Yqu3Y0mm49yb/vpH847IKyyz8F+NZdHkyIHVR/dpQcEtk2x1hXA==",
       "requires": {
-        "@taquito/http-utils": "^11.2.0",
-        "@taquito/utils": "^11.2.0",
+        "@taquito/http-utils": "^12.1.0",
+        "@taquito/utils": "^12.1.0",
         "bignumber.js": "^9.0.2"
       }
     },
     "@taquito/signer": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-11.2.0.tgz",
-      "integrity": "sha512-OthNW7gN2hJNph8VMy9LRbZcn7bIBaKdrfC+hAy5N6yzG8EW/t6IEMAgESmNcthMhPUhuOWS37khuwMsuL1GUg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-12.1.0.tgz",
+      "integrity": "sha512-liU0ePyTIGivcA/+X6cQ4pQMIxD6TFZOHYPStxdJBphLsbYAVn5sH6nuQimY5DNmynK3kQOAVfZmV553xjesoA==",
       "requires": {
-        "@taquito/taquito": "^11.2.0",
-        "@taquito/utils": "^11.2.0",
+        "@stablelib/blake2b": "^1.0.1",
+        "@stablelib/ed25519": "^1.0.2",
+        "@stablelib/nacl": "^1.0.3",
+        "@taquito/taquito": "^12.1.0",
+        "@taquito/utils": "^12.1.0",
         "elliptic": "^6.5.4",
-        "libsodium-wrappers": "0.7.8",
         "pbkdf2": "^3.1.2",
         "typedarray-to-buffer": "^4.0.0"
       }
     },
     "@taquito/taquito": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-11.2.0.tgz",
-      "integrity": "sha512-OJJYPqQiF7IoxWsBavdKDuxi2oeWHHvRph2nqeCyqVx6H+7uQLpZCf0OP5iQ4F6AxoYPyD7DzEsSFH5tOdgqNQ==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-12.1.0.tgz",
+      "integrity": "sha512-mCWZIFR6a6M/vggj8eGtU10e1CSlyF7boYxPd2eBYQpH8k2Sz1FsRKBEZhNGS6CKCb3gBYmNYH/USqv5d3pRWw==",
       "requires": {
-        "@taquito/http-utils": "^11.2.0",
-        "@taquito/michel-codec": "^11.2.0",
-        "@taquito/michelson-encoder": "^11.2.0",
-        "@taquito/rpc": "^11.2.0",
-        "@taquito/utils": "^11.2.0",
+        "@taquito/http-utils": "^12.1.0",
+        "@taquito/local-forging": "^12.1.0",
+        "@taquito/michel-codec": "^12.1.0",
+        "@taquito/michelson-encoder": "^12.1.0",
+        "@taquito/rpc": "^12.1.0",
+        "@taquito/utils": "^12.1.0",
         "bignumber.js": "^9.0.2",
         "rxjs": "^6.6.3"
       }
     },
     "@taquito/utils": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-I5LoD5fG9S2Yo4CNpW4u3vF9lUJG1PxkGLi6ntvvH49SBXwo9HJ/n/v04aoE9V7ncA0a7LUm6ucnROagIc2QQQ==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-12.1.0.tgz",
+      "integrity": "sha512-XXO5m6Zfn/JuxOsWDny970sPI7qX+3rWQuEpu1lHDhGCaKbkwCNfhroeUU2TZnC6YGyMLLNLUorarmKpS7aMPA==",
       "requires": {
         "@stablelib/blake2b": "^1.0.1",
         "@stablelib/ed25519": "^1.0.2",
@@ -2156,6 +2276,14 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "requires": {}
     },
+    "axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "base-x": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
@@ -2271,11 +2399,6 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
-    "cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
     },
     "create-hash": {
       "version": "1.2.0",
@@ -2429,6 +2552,11 @@
         "path-exists": "^4.0.0"
       }
     },
+    "follow-redirects": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -2575,19 +2703,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-    },
-    "libsodium": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.8.tgz",
-      "integrity": "sha512-/Qc+APf0jbeWSaeEruH0L1/tbbT+sbf884ZL0/zV/0JXaDPBzYkKbyb/wmxMHgAHzm3t6gqe7bOOXAVwfqVikQ=="
-    },
-    "libsodium-wrappers": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.8.tgz",
-      "integrity": "sha512-PDhPWXBqd/SaqAFUBgH2Ux7b3VEEJgyD6BQB+VdNFJb9PbExGr/T/myc/MBoSvl8qLzfm0W0IVByOQS5L1MrCg==",
-      "requires": {
-        "libsodium": "0.7.8"
-      }
     },
     "loader-runner": {
       "version": "4.3.0",
@@ -3088,14 +3203,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw=="
-    },
-    "xhr2-cookies": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
-      "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
-      "requires": {
-        "cookiejar": "^2.1.1"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.0",
   "license": "MIT",
   "dependencies": {
-    "@taquito/taquito": "^11.0.1",
-    "@taquito/signer": "^11.0.1",
-    "@taquito/rpc": "^11.0.1",
+    "@taquito/taquito": "^12.1.0",
+    "@taquito/signer": "^12.1.0",
+    "@taquito/rpc": "^12.1.0",
     "webpack": "^5.47.1",
     "webpack-cli": "^4.7.1"
   },

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -55,25 +55,16 @@ message() {
   echo -e "\e[35m\e[1m**************************    $*    ********************************\e[0m"
 }
 
-validators_json() {
+discovery_storage() {
   ## most of the noise in this function is because of indentation
-  echo "["
+  echo "Big_map.literal ["
   for VALIDATOR in "${VALIDATORS[@]}"; do
-    i=$(echo "$VALIDATOR" | awk -F';' '{ print $1 }')
     ADDRESS=$(echo "$VALIDATOR" | awk -F';' '{ print $4 }')
     URI=$(echo "$VALIDATOR" | awk -F';' '{ print $3 }')
-    if [ "$i" != 0 ]; then
-      printf ",
-"
-    fi
     cat <<EOF
-  {
-    "address": "$ADDRESS",
-    "uri": "$URI"
+  (("$ADDRESS" : key_hash), (0, "$URI"));
 EOF
-    printf "  }"
   done
-  echo ""
   echo "]"
 }
 
@@ -97,6 +88,21 @@ EOF
   echo "]"
 }
 
+deploy_contract () {
+  message "Deploying new $1 contract"
+  storage=$(ligo compile storage "$2" "$3")
+  contract=$(ligo compile contract "$2")
+  
+  echo "Originating $1 contract"
+  sleep 2
+  tezos-client --endpoint $RPC_NODE originate contract "$1" \
+    transferring 0 from myWallet \
+    running "$contract" \
+    --init "$storage" \
+    --burn-cap 2 \
+    --force
+}
+
 create_new_deku_environment() {
   message "Creating validator identities"
   for i in "${VALIDATORS[@]}"; do
@@ -114,12 +120,11 @@ create_new_deku_environment() {
     VALIDATORS[$i]="$i;$KEY;$URI;$ADDRESS"
   done
 
-  message "Deploying new consensus contract"
 
   # To register the validators, run consensus.mligo with the list of
   # validators. To do this quickly, open the LIGO IDE with the url
   # provided and paste the following storage as inputs to the contract.
-  storage=$(
+  consensus_storage=$(
     cat <<EOF
 {
   root_hash = {
@@ -147,27 +152,19 @@ EOF
   )
 
   consensus="./src/tezos_interop/consensus.mligo"
-  storage=$(ligo compile storage "$consensus" "$storage")
-  contract=$(ligo compile contract $consensus)
-
-  message "Originating contract"
-  sleep 2
-  tezos-client --endpoint $RPC_NODE originate contract "consensus" \
-    transferring 0 from myWallet \
-    running "$contract" \
-    --init "$storage" \
-    --burn-cap 2 \
-    --force
+  discovery="./src/tezos_interop/discovery.mligo"
+  deploy_contract "consensus" "$consensus" "$consensus_storage"
+  deploy_contract "discovery" "$discovery" "$(discovery_storage)"
 
   for VALIDATOR in "${VALIDATORS[@]}"; do
     i=$(echo "$VALIDATOR" | awk -F';' '{ print $1 }')
     FOLDER="$DATA_DIRECTORY/$i"
-    validators_json >"$FOLDER/validators.json"
     trusted_validator_membership_change_json >"$FOLDER/trusted-validator-membership-change.json"
   done
 
   message "Getting contract address"
   TEZOS_CONSENSUS_ADDRESS="$(tezos-client --endpoint $RPC_NODE show known contract consensus | grep KT1 | tr -d '\r')"
+  TEZOS_DISCOVERY_ADDRESS="$(tezos-client --endpoint $RPC_NODE show known contract discovery | grep KT1 | tr -d '\r')"
 
   message "Configuring Deku nodes"
   for VALIDATOR in "${VALIDATORS[@]}"; do
@@ -176,6 +173,7 @@ EOF
 
     deku-cli setup-tezos "$FOLDER" \
       --tezos_consensus_contract="$TEZOS_CONSENSUS_ADDRESS" \
+      --tezos_discovery_contract="$TEZOS_DISCOVERY_ADDRESS" \
       --tezos_rpc_node=$RPC_NODE \
       --tezos_secret="$SECRET_KEY" \
       --unsafe_tezos_required_confirmations 1

--- a/src/bin/files.ml
+++ b/src/bin/files.ml
@@ -24,22 +24,6 @@ module Wallet = struct
   let read = read_json of_yojson
   let write = write_json to_yojson
 end
-module Validators = struct
-  type t = {
-    address : Crypto.Key_hash.t;
-    uri : Uri.t;
-  }
-  [@@deriving yojson]
-  let read =
-    read_json (fun json ->
-        let%ok validators = [%of_yojson: t list] json in
-        Ok (List.map (fun { address; uri } -> (address, uri)) validators))
-  let write =
-    write_json (fun validators ->
-        validators
-        |> List.map (fun (address, uri) -> { address; uri })
-        |> [%to_yojson: t list])
-end
 module Interop_context = struct
   module Secret = struct
     include Crypto.Secret
@@ -53,6 +37,7 @@ module Interop_context = struct
     rpc_node : Uri.t;
     secret : Secret.t;
     consensus_contract : Tezos.Address.t;
+    discovery_contract : Tezos.Address.t;
     required_confirmations : int;
   }
   [@@deriving yojson]

--- a/src/bin/files.mli
+++ b/src/bin/files.mli
@@ -13,15 +13,12 @@ module Wallet : sig
   val read : file:string -> t Lwt.t
   val write : t -> file:string -> unit Lwt.t
 end
-module Validators : sig
-  val read : file:string -> (Crypto.Key_hash.t * Uri.t) list Lwt.t
-  val write : (Crypto.Key_hash.t * Uri.t) list -> file:string -> unit Lwt.t
-end
 module Interop_context : sig
   type t = {
     rpc_node : Uri.t;
     secret : Crypto.Secret.t;
     consensus_contract : Tezos.Address.t;
+    discovery_contract : Tezos.Address.t;
     required_confirmations : int;
   }
   val read : file:string -> t Lwt.t

--- a/src/helpers/list_ext.ml
+++ b/src/helpers/list_ext.ml
@@ -28,3 +28,9 @@ let rec fold_left_ok f state = function
   match f state head with
   | Ok state -> fold_left_ok f state tl
   | Error error -> Error error
+let somes l = List.filter_map (fun x -> x) l
+let fold_right_ok f l state =
+  let rec go = function
+    | [] -> Ok state
+    | head :: tl -> Result.bind (go tl) (fun tl -> f head tl) in
+  go l

--- a/src/helpers/list_ext.ml
+++ b/src/helpers/list_ext.ml
@@ -36,6 +36,6 @@ let rec kmap_ok k f l =
   | [] -> Ok (k [])
   | el :: tl ->
   match f el with
-  | Ok el -> kmap_ok (fun tl -> el :: tl) f tl
+  | Ok el -> kmap_ok (fun tl -> k (el :: tl)) f tl
   | Error error -> Error error
 let map_ok f l = kmap_ok (fun x -> x) f l

--- a/src/helpers/list_ext.ml
+++ b/src/helpers/list_ext.ml
@@ -29,8 +29,13 @@ let rec fold_left_ok f state = function
   | Ok state -> fold_left_ok f state tl
   | Error error -> Error error
 let somes l = List.filter_map (fun x -> x) l
-let fold_right_ok f l state =
-  let rec go = function
-    | [] -> Ok state
-    | head :: tl -> Result.bind (go tl) (fun tl -> f head tl) in
-  go l
+
+(* NOT TCO *)
+let rec kmap_ok k f l =
+  match l with
+  | [] -> Ok (k [])
+  | el :: tl ->
+  match f el with
+  | Ok el -> kmap_ok (fun tl -> el :: tl) f tl
+  | Error error -> Error error
+let map_ok f l = kmap_ok (fun x -> x) f l

--- a/src/helpers/list_ext.mli
+++ b/src/helpers/list_ext.mli
@@ -4,5 +4,4 @@ val in_order_uniq : ('a -> 'a -> int) -> 'a t -> 'a t
 val fold_left_ok :
   ('a -> 'b -> ('a, 'c) result) -> 'a -> 'b list -> ('a, 'c) result
 val somes : 'a option list -> 'a list
-val fold_right_ok :
-  ('a -> 'b -> ('b, 'c) result) -> 'a list -> 'b -> ('b, 'c) result
+val map_ok : ('a -> ('b, 'c) result) -> 'a t -> ('b t, 'c) result

--- a/src/helpers/list_ext.mli
+++ b/src/helpers/list_ext.mli
@@ -3,3 +3,6 @@ val find_index : ('a -> bool) -> 'a t -> int option
 val in_order_uniq : ('a -> 'a -> int) -> 'a t -> 'a t
 val fold_left_ok :
   ('a -> 'b -> ('a, 'c) result) -> 'a -> 'b list -> ('a, 'c) result
+val somes : 'a option list -> 'a list
+val fold_right_ok :
+  ('a -> 'b -> ('b, 'c) result) -> 'a list -> 'b -> ('b, 'c) result

--- a/src/tezos/michelson.ml
+++ b/src/tezos/michelson.ml
@@ -14,3 +14,5 @@ let is_unit value =
   match Micheline.root value with
   | Prim (_, Michelson_v1_primitives.D_Unit, [], []) -> true
   | _ -> false
+
+type big_map_key = Key_hash of Crypto.Key_hash.t

--- a/src/tezos/michelson.mli
+++ b/src/tezos/michelson.mli
@@ -6,3 +6,6 @@ val expr_encoding : t Data_encoding.t
 
 val unit : t
 val is_unit : t -> bool
+
+(* TODO: this seems like it should be in a tezos library somewhere already *)
+type big_map_key = Key_hash of Crypto.Key_hash.t

--- a/src/tezos_interop/discovery.mligo
+++ b/src/tezos_interop/discovery.mligo
@@ -1,8 +1,7 @@
-(* TODO: probably string *)
-type uri = bytes
+type uri = string
 (* TODO: maybe nat *)
 type nonce = int
-type storage = (key, (nonce * uri)) big_map
+type storage = (key_hash, (nonce * uri)) big_map
 type uri_update = {
   key: key;
   uri: uri;
@@ -10,8 +9,8 @@ type uri_update = {
   signature: signature;
 }
 
-let check_nonce (storage: storage) (key: key) (nonce: nonce) =
-  match Big_map.find_opt key storage with
+let check_nonce (storage: storage) (key_hash: key_hash) (nonce: nonce) =
+  match Big_map.find_opt key_hash storage with
   | Some (old_nonce, _) -> 
     if not (nonce > old_nonce) then
       failwith "old nonce"
@@ -28,12 +27,13 @@ let check_signature
 
 let main (uri_update, storage : uri_update * storage) =
   let key = uri_update.key in
+  let key_hash = Crypto.hash_key key in
   let uri = uri_update.uri in
   let nonce = uri_update.nonce in
   let signature = uri_update.signature in
 
-  let () = check_nonce storage key nonce in
+  let () = check_nonce storage key_hash nonce in
   let () = check_signature key uri nonce signature in
   
-  let storage = Big_map.add key (nonce, uri) storage in
+  let storage = Big_map.add key_hash (nonce, uri) storage in
   (([] : operation list), storage)

--- a/src/tezos_interop/tezos_bridge.mli
+++ b/src/tezos_interop/tezos_bridge.mli
@@ -52,3 +52,11 @@ val storage :
   required_confirmations:int ->
   destination:Address.t ->
   (Michelson.t, string) result Lwt.t
+
+val big_map_keys :
+  t ->
+  rpc_node:Uri.t ->
+  required_confirmations:int ->
+  destination:Address.t ->
+  keys:Michelson.big_map_key list ->
+  (Yojson.Safe.t option list, string) result Lwt.t

--- a/src/tezos_interop/tezos_interop.ml
+++ b/src/tezos_interop/tezos_interop.ml
@@ -236,7 +236,13 @@ module Consensus = struct
               Ok (Some key_hash))
           micheline_uris in
       let key_hash_uri_pairs =
-        Result.map (List.combine validator_key_hashes) uris in
+        Result.map
+          (fun uris ->
+            Format.eprintf "%d : %d\n%!"
+              (List.length validator_key_hashes)
+              (List.length uris);
+            List.combine validator_key_hashes uris)
+          uris in
       Lwt.return key_hash_uri_pairs
 
   let fetch_validators t =

--- a/src/tezos_interop/tezos_interop.mli
+++ b/src/tezos_interop/tezos_interop.mli
@@ -7,6 +7,7 @@ val make :
   rpc_node:Uri.t ->
   secret:Secret.t ->
   consensus_contract:Address.t ->
+  discovery_contract:Address.t ->
   required_confirmations:int ->
   t
 
@@ -34,7 +35,8 @@ module Consensus : sig
     transactions : transaction list;
   }
   val listen_operations : t -> on_operation:(operation -> unit) -> unit
-  val fetch_validators : t -> (Key_hash.t list, string) result Lwt.t
+  val fetch_validators :
+    t -> ((Key_hash.t * Uri.t option) list, string) result Lwt.t
 end
 module Discovery : sig
   val sign : Secret.t -> nonce:int64 -> Uri.t -> Signature.t

--- a/src/tezos_interop/tezos_js_bridge.js
+++ b/src/tezos_interop/tezos_js_bridge.js
@@ -214,7 +214,15 @@ const onBigMapMultipleKeyRequest = async (id, content) => {
   const storage = await contract.storage();
   const valuesMap = await storage.getMultipleValues(keys);
 
-  const values = keys.map(key => valuesMap.get(key) ?? null);
+  
+  const values = keys.map(key => {
+    const value = valuesMap.get(key);
+    if (value === undefined) {
+      return null;
+    } else {
+      return value[1];
+    }
+  });
 
   /* To make sure the storage state is finalized, we query the last
      block and any one of it's operation, and wait till it receives

--- a/src/tezos_interop/tezos_js_bridge.js
+++ b/src/tezos_interop/tezos_js_bridge.js
@@ -210,22 +210,11 @@ const onBigMapMultipleKeyRequest = async (id, content) => {
 
   const block = await client.getBlock(); // fetches the head
 
-  let contract = await Tezos.contract.at(destination);
-  let storage = await contract.storage();
-  let big_map_abstraction = await storage.getMultipleValues(keys);
-  let values = new Array(keys.length);
-  // Need to convert the `big_map_abstraction` to an array of values,
-  // where the order of the values matches the order of the keys.
-  // Also big_map_abstraction will give us the value `undefined` if a key is not present,
-  // but deriving_yojson's option deserializer expects `null`.
-  await big_map_abstraction.forEach((value, key) => {
-    let index = keys.indexOf(key);
-    if (value !== undefined) {
-      values[index] = value[1];
-    } else {
-      values[index] = null;
-    }
-  });
+  const contract = await Tezos.contract.at(destination);
+  const storage = await contract.storage();
+  const valuesMap = await storage.getMultipleValues(keys);
+
+  const values = keys.map(key => valuesMap.get(key) ?? null);
 
   /* To make sure the storage state is finalized, we query the last
      block and any one of it's operation, and wait till it receives

--- a/src/tezos_interop/tezos_js_bridge.js
+++ b/src/tezos_interop/tezos_js_bridge.js
@@ -214,8 +214,7 @@ const onBigMapMultipleKeyRequest = async (id, content) => {
   const storage = await contract.storage();
   const valuesMap = await storage.getMultipleValues(keys);
 
-  
-  const values = keys.map(key => {
+  const values = keys.map((key) => {
     const value = valuesMap.get(key);
     if (value === undefined) {
       return null;


### PR DESCRIPTION
## Depends

- [x] #501

## Problem

Currently, the node assumes there will be a `validators.json` file that provides a mapping from validator keys_hashes to URIs. But when new nodes join the network, or when existing nodes want to change their URI, we need some foolproof way to communicate the new URIs to all the nodes. 

## Solution

The discovery.mligo contract was written for this purpose, but before this PR it was unused. Its storage is a map from key_hashes to URIs. Anyone can add or update a key_hash and its associated URI (provided they prove they control the key). After the node fetches the list of validator key_hashes from consensus.mligo, it only has to look up those keys in the map maintained by the discovery.mligo contract.

## Related

- closes  #160
 