### PR TITLE
node: bind to all interfaces

### DIFF
--- a/src/bin/deku_node.ml
+++ b/src/bin/deku_node.ml
@@ -122,7 +122,7 @@ let node folder =
   Node.Server.start ~initial:node;
   Dream.initialize_log ~level:`Warning ();
   let port = Node.Server.get_port () |> Option.get in
-  Dream.run ~port
+  Dream.run ~interface:"0.0.0.0" ~port
   @@ Dream.router
        [
          handle_block_level;


### PR DESCRIPTION
## Problem

On some machines, Dream binds directly to localhost, which is on ipv6, but some software treats localhost as always 127.0.0.1, which makes the connection to fail.

## Solution

Bind on all interfaces using `0.0.0.0`.