### PR TITLE
tezos_interop: fix consensus.mligo integration

### DIFF
--- a/src/tezos_interop/tezos_interop.ml
+++ b/src/tezos_interop/tezos_interop.ml
@@ -209,7 +209,7 @@ module Consensus = struct
         block_height : int64;
         block_payload_hash : BLAKE2B.t;
         signatures : string option list;
-        withdrawal_handles_hash : BLAKE2B.t;
+        handles_hash : BLAKE2B.t;
         state_hash : BLAKE2B.t;
         validators : string list;
         current_validator_keys : string option list;
@@ -234,7 +234,7 @@ module Consensus = struct
         block_height;
         block_payload_hash;
         signatures;
-        withdrawal_handles_hash;
+        handles_hash = withdrawal_handles_hash;
         state_hash;
         validators;
         current_validator_keys;


### PR DESCRIPTION
## Depends

- [x] #457

## Problem

As of #431 Deku main is broken when talking to Tezos due to a JSON change.

## Solution

This is the conservative solution, instead of changing it also on the consensus.mligo contract we just revert the change for this specific JOSN field.

In the future we should use ocaml-to-ligo to prevents mistakes as this.