### PR TITLE
chore: use stderr for logs

### DIFF
--- a/src/node/snapshots.ml
+++ b/src/node/snapshots.ml
@@ -35,7 +35,7 @@ let append_block ~pool (block, signatures) t =
       additional_blocks = blocks @ [t.last_block] @ t.additional_blocks;
     }
 let add_snapshot ~new_snapshot ~block_height t =
-  Format.printf "\027[36m New protocol snapshot hash: %s\027[m\n%!"
+  Format.eprintf "\027[36mNew protocol snapshot hash: %s\027[m\n%!"
     (new_snapshot.hash |> BLAKE2B.to_string);
   {
     next_snapshots = t.next_snapshots @ [(block_height, new_snapshot)];

--- a/src/protocol/protocol.ml
+++ b/src/protocol/protocol.ml
@@ -78,7 +78,7 @@ let apply_operation (state, receipts) operation =
     let state = apply_consensus_operation state consensus_operation in
     (state, receipts)
 let apply_block state block =
-  Printf.printf "%Ld\n%!" block.Block.block_height;
+  Format.eprintf "\027[32mblock: %Ld\027[m\n%!" block.Block.block_height;
   let state, receipts =
     List.fold_left apply_operation (state, []) block.operations in
   let state =

--- a/src/tezos_interop/tezos_interop.ml
+++ b/src/tezos_interop/tezos_interop.ml
@@ -70,7 +70,7 @@ module Run_contract = struct
         (Yojson.Safe.to_string (input_to_yojson input)) in
     match Yojson.Safe.from_string output |> output_of_yojson with
     | Ok data ->
-      Format.printf "Commit operation result: %s\n%!" output;
+      Format.eprintf "Commit operation result: %s\n%!" output;
       await data
     | Error error -> await (Error error)
 end


### PR DESCRIPTION
## Depends

- [x] #458

## Problem

If you stop the chain when it's time for a new protocol hash, `sidecli produce-block` will print an additional message on stdout, which breaks `./start.sh`.

## Solution

For now this PR makes so that we use stderr for logs, in the future we should have a proper logging solution.

This PR also improves the messages a bit.