### PR TITLE
tezos_rpc: add Fetch_constants

### DIFF
--- a/src/helpers/dune
+++ b/src/helpers/dune
@@ -1,5 +1,5 @@
 (library
  (name helpers)
- (libraries lwt uri zarith hex digestif)
+ (libraries lwt uri zarith hex digestif data-encoding)
  (preprocess
   (pps ppx_deriving_yojson ppx_let_binding)))

--- a/src/helpers/yojson_ext.ml
+++ b/src/helpers/yojson_ext.ml
@@ -5,3 +5,53 @@ let with_yojson_string name to_string of_string =
     let%ok string = [%of_yojson: string] json in
     of_string string |> Option.to_result ~none:("invalid " ^ name) in
   (to_yojson, of_yojson)
+
+let rec of_data_encoding_json (json : Data_encoding.json) : Yojson.Safe.t =
+  match json with
+  | `O properties ->
+    let properties =
+      List.map
+        (fun (key, value) -> (key, of_data_encoding_json value))
+        properties in
+    `Assoc properties
+  | `A elements ->
+    let elements = List.map of_data_encoding_json elements in
+    `List elements
+  | `Bool bool -> `Bool bool
+  | `Float float -> `Float float
+  | `Null -> `Null
+  | `String string -> `String string
+
+let rec to_data_encoding_json (json : Yojson.Basic.t) : Data_encoding.Json.t =
+  match json with
+  | `Assoc properties ->
+    let properties =
+      List.map
+        (fun (key, value) -> (key, to_data_encoding_json value))
+        properties in
+    `O properties
+  | `List elements ->
+    let elements = List.map to_data_encoding_json elements in
+    `A elements
+  | `Bool bool -> `Bool bool
+  | `Float float -> `Float float
+  | `Null -> `Null
+  | `String string -> `String string
+  | `Int int -> `Float (float_of_int int)
+let to_data_encoding_json json =
+  json |> Yojson.Safe.to_basic |> to_data_encoding_json
+
+let with_data_encoding encoder =
+  let to_yojson t =
+    let json = Data_encoding.Json.construct encoder t in
+    of_data_encoding_json json in
+  let of_yojson json =
+    let json = to_data_encoding_json json in
+    try Ok (Data_encoding.Json.destruct encoder json) with
+    | exn ->
+      let print_unknown _fmt exn = raise exn in
+      let err =
+        Format.asprintf "%a" (Data_encoding.Json.print_error ~print_unknown) exn
+      in
+      Error err in
+  (to_yojson, of_yojson)

--- a/src/helpers/yojson_ext.mli
+++ b/src/helpers/yojson_ext.mli
@@ -3,3 +3,7 @@ val with_yojson_string :
   ('a -> string) ->
   (string -> 'a option) ->
   ('a -> Yojson.Safe.t) * (Yojson.Safe.t -> ('a, string) result)
+
+val with_data_encoding :
+  'a Data_encoding.t ->
+  ('a -> Yojson.Safe.t) * (Yojson.Safe.t -> ('a, string) result)

--- a/src/tezos/gas.ml
+++ b/src/tezos/gas.ml
@@ -5,4 +5,6 @@ type integral = Z.t
 
 let n_integral_encoding = Data_encoding.n
 
+let z_integral_encoding = Data_encoding.z
+
 let of_int t = if t >= 0 then Some (Z.of_int t) else None

--- a/src/tezos/gas.mli
+++ b/src/tezos/gas.mli
@@ -2,4 +2,6 @@ type integral
 
 val n_integral_encoding : integral Data_encoding.t
 
+val z_integral_encoding : integral Data_encoding.t
+
 val of_int : int -> integral option

--- a/src/tezos/tez.ml
+++ b/src/tezos/tez.ml
@@ -1,9 +1,13 @@
-type t = int64 [@@deriving eq, ord, yojson]
+open Helpers
+
+type t = int64 [@@deriving eq, ord]
 
 let encoding =
   let open Data_encoding in
   let name = "mutez" in
   def name (check_size 10 (conv Z.of_int64 (Json.wrap_error Z.to_int64) n))
+
+let to_yojson, of_yojson = Yojson_ext.with_data_encoding encoding
 
 let zero = 0L
 let one_mutez = 1L

--- a/src/tezos_rpc/fetch_constants.ml
+++ b/src/tezos_rpc/fetch_constants.ml
@@ -1,0 +1,34 @@
+open Helpers
+open Tezos
+open Http
+
+let _z_integral_to_yojson, z_integral_of_yojson =
+  Yojson_ext.with_data_encoding Gas.z_integral_encoding
+type gas_z_integral = Gas.integral
+let gas_z_integral_of_yojson = z_integral_of_yojson
+
+type response = {
+  hard_gas_limit_per_operation : gas_z_integral;
+  hard_gas_limit_per_block : gas_z_integral;
+  hard_storage_limit_per_operation : Z.t;
+  cost_per_byte : Tez.t;
+}
+[@@deriving of_yojson { strict = false }]
+
+let path ~chain ~block_hash =
+  Format.sprintf "/chains/%s/blocks/%s/context/constants" chain block_hash
+
+let execute ~node_uri ~chain ~block_hash =
+  let chain =
+    match chain with
+    | Some chain -> Chain_id.to_string chain
+    | None -> "main" in
+
+  let block_hash =
+    match block_hash with
+    | Some block_hash -> Block_hash.to_string block_hash
+    (* TODO: we could also query by height *)
+    | None -> "head" in
+
+  let path = path ~chain ~block_hash in
+  http_get ~node_uri ~path ~of_yojson:response_of_yojson

--- a/src/tezos_rpc/tezos_rpc.mli
+++ b/src/tezos_rpc/tezos_rpc.mli
@@ -3,6 +3,7 @@ module Preapply_operations = Preapply_operations
 module Inject_operations = Inject_operations
 module Fetch_block_operations = Fetch_block_operations
 module Fetch_block_header = Fetch_block_header
+module Fetch_constants = Fetch_constants
 
 module Block_header = Block_header
 module Listen_to_chain_heads = Listen_to_chain_heads

--- a/tests/test_tezos_rpc.ml
+++ b/tests/test_tezos_rpc.ml
@@ -74,11 +74,22 @@ let fetch_block_header ~block_hash () =
   | Error err -> failwith_err err);
   Lwt.return_unit
 
+let fetch_constants ~block_hash () =
+  let open Tezos_rpc.Fetch_constants in
+  let%await result = execute ~node_uri ~chain:None ~block_hash in
+  (match result with
+  | Ok constants ->
+    Format.printf "hard_storage_limit_per_operation: %a\n%!" Z.pp_print
+      constants.hard_storage_limit_per_operation
+  | Error err -> failwith_err err);
+  Lwt.return_unit
+
 (* to run a test, just uncomment it *)
 let tests =
   [ (* fetch_block_operations ~block_hash:None; *)
     (* listen_to_chain_heads; *)
     (* listen_to_blocks; *)
-    (* fetch_block_header ~block_hash:None; *) ]
+    (* fetch_block_header ~block_hash:None; *)
+    (* fetch_constants ~block_hash:None; *) ]
 
 let () = Lwt_list.iter_s (fun test -> test ()) tests |> Lwt_main.run


### PR DESCRIPTION
## Problem

To dispatch operations to Tezos, deku need's to estimate a reasonable fee, a requirement to make a good estimate is knowing the constants in Tezos.

## Solution

This PR implements `Tezos_rpc.Fetch_constants`, allowing us to query all the required data. This is likely the last endpoint required to move away from Taquito.
