### PR TITLE
Implement Lambda VM

### DIFF
--- a/src/lambda_vm/ast.mli
+++ b/src/lambda_vm/ast.mli
@@ -1,0 +1,50 @@
+type ident = string
+
+type prim =
+  | Neg
+  | Add
+  | Sub
+  | Mul
+  | Div
+  | Rem
+  | Land
+  | Lor
+  | Lxor
+  | Lsl
+  | Lsr
+  | Asr
+  | Fst
+  | Snd
+
+type expr =
+  (* calculus *)
+  | Var   of ident
+  | Lam   of ident * expr
+  | App   of {
+      funct : expr;
+      arg : expr;
+    }
+  (* prims *)
+  | Const of int64
+  | Prim  of prim
+  (* branching *)
+  | If    of {
+      (* predicate <> 0 ? consequent : alternative *)
+      predicate : expr;
+      consequent : expr;
+      alternative : expr;
+    }
+  (* memory *)
+  | Pair  of {
+      first : expr;
+      second : expr;
+    }
+
+type value =
+  | Int64 of int64
+  | Pair  of value * value
+
+type script = {
+  param : ident;
+  code : expr;
+}

--- a/src/lambda_vm/checks.ml
+++ b/src/lambda_vm/checks.ml
@@ -1,0 +1,23 @@
+exception Out_of_stack
+exception Out_of_gas
+
+(* WHY: This is used to avoid stack overflows.
+
+     In the future if OCaml stack overflow detection becomes reliable then
+   we can remove it and let it overflow, but for now, manual bound checking.
+
+     About this number, OCaml currently only uses the stack for function calls
+   which means each entry is a word and maybe on ARM64 two words,
+   in 64bits systems that is 8-16 bytes. The system that has the smallest stack
+   is macOS and iOS ARM64 where the secondary stack is about 512kb.
+
+     So by assuming the worst case scenario, that allows us up to 32768, minus
+   the stack used by Deku itself. To be conservative as we may have deep
+   primitives in the future, I decided to go with two thirds of this, and
+   rounding down, which means 20k.
+*)
+(* TODO: verify properly all this hypothesis and add references to it *)
+let max_stack_depth = 20000
+
+let check_stack ~stack = if stack <= 0 then raise Out_of_stack
+let check_gas gas = if Gas.is_empty gas then raise Out_of_gas

--- a/src/lambda_vm/checks.mli
+++ b/src/lambda_vm/checks.mli
@@ -1,0 +1,7 @@
+exception Out_of_stack
+exception Out_of_gas
+
+val max_stack_depth : int
+
+val check_stack : stack:int -> unit
+val check_gas : Gas.t -> unit

--- a/src/lambda_vm/compiler.ml
+++ b/src/lambda_vm/compiler.ml
@@ -1,0 +1,129 @@
+open Ast
+open Ir
+open Checks
+
+module String_map = Map.Make (String)
+
+type error = (* user program bugs *)
+  | Undefined_variable
+exception Error of error
+let raise error = raise (Error error)
+
+let compile_prim prim =
+  match prim with
+  | Neg -> P_neg
+  | Add -> P_add
+  | Sub -> P_sub
+  | Mul -> P_mul
+  | Div -> P_div
+  | Rem -> P_rem
+  | Land -> P_land
+  | Lor -> P_lor
+  | Lxor -> P_lxor
+  | Lsl -> P_lsl
+  | Lsr -> P_lsr
+  | Asr -> P_asr
+  | Fst -> P_fst
+  | Snd -> P_snd
+
+module Vars = Map_with_cardinality.Make (String)
+
+let burn_gas gas vars code =
+  (match code with
+  | Var _
+  | Lam _ ->
+    let cardinality = Vars.cardinal vars in
+    Gas.burn_log2 gas ~cardinality
+  | App _
+  | Const _
+  | Prim _
+  | If _
+  | Pair _ ->
+    Gas.burn_constant gas);
+  check_gas gas
+
+let rec compile_expr ~stack gas next_ident vars code =
+  let stack = stack - 1 in
+
+  check_stack ~stack;
+  burn_gas gas vars code;
+
+  let compile_expr vars code = compile_expr ~stack gas next_ident vars code in
+
+  match code with
+  | Var var -> (
+    match Vars.find var vars with
+    | Some ident -> E_var ident
+    | None -> raise Undefined_variable)
+  | Lam (var, body) ->
+    let ident =
+      let ident = !next_ident in
+      next_ident := Ident.next ident;
+      ident in
+    let vars = Vars.add var ident vars in
+    let body = compile_expr vars body in
+    E_lam (ident, body)
+  | App { funct; arg } ->
+    let funct = compile_expr vars funct in
+    let arg = compile_expr vars arg in
+    E_app { funct; arg }
+  (* prims *)
+  | Const value -> E_const value
+  | Prim prim ->
+    let prim = compile_prim prim in
+    E_prim prim
+  (* branching *)
+  | If { predicate; consequent; alternative } ->
+    let predicate = compile_expr vars predicate in
+    let consequent = compile_expr vars consequent in
+    let alternative = compile_expr vars alternative in
+    E_if { predicate; consequent; alternative }
+  (* memory *)
+  | Pair { first; second } ->
+    let first = compile_expr vars first in
+    let second = compile_expr vars second in
+    E_pair { first; second }
+
+let compile_expr gas next_ident vars code =
+  let stack = max_stack_depth in
+  compile_expr ~stack gas next_ident vars code
+
+let compile gas script =
+  let Ast.{ param; code } = script in
+
+  let param_ident, next_ident =
+    let param_ident = Ident.initial in
+    let next_ident = Ident.next param_ident in
+    (param_ident, ref next_ident) in
+  let vars = Vars.add param param_ident Vars.empty in
+
+  let code = compile_expr gas next_ident vars code in
+  { param = param_ident; code }
+
+let compile gas script =
+  try Ok (compile gas script) with
+  | Error error -> Error error
+
+let burn_gas gas =
+  Gas.burn_constant gas;
+  check_gas gas
+
+let rec compile_value ~stack gas value =
+  let compile_value value = compile_value ~stack:(stack - 1) gas value in
+
+  check_stack ~stack;
+  burn_gas gas;
+
+  match value with
+  | Int64 value -> V_int64 value
+  | Pair (first, second) ->
+    let first = compile_value first in
+    let second = compile_value second in
+    V_pair { first; second }
+
+let compile_value gas value =
+  let stack = max_stack_depth in
+  compile_value ~stack gas value
+let compile_value gas value =
+  try Ok (compile_value gas value) with
+  | Error error -> Error error

--- a/src/lambda_vm/compiler.mli
+++ b/src/lambda_vm/compiler.mli
@@ -1,0 +1,6 @@
+type error = (* user program bugs *)
+  | Undefined_variable
+
+(* TODO: compile or translate? *)
+val compile : Gas.t -> Ast.script -> (Ir.script, error) result
+val compile_value : Gas.t -> Ast.value -> (Ir.value, error) result

--- a/src/lambda_vm/dune
+++ b/src/lambda_vm/dune
@@ -1,0 +1,3 @@
+(library
+ (name lambda_vm)
+ (modules_without_implementation ir ast))

--- a/src/lambda_vm/gas.ml
+++ b/src/lambda_vm/gas.ml
@@ -1,0 +1,19 @@
+(* TODO: satured arithmetic *)
+type t = int ref
+
+let constant_burn = 100
+let log2_burn ~cardinality =
+  let log2_cardinality =
+    let open Float in
+    to_int (ceil (log2 (of_int cardinality))) in
+  (* additional burn to prevent free operations when cardinality = 0 *)
+  constant_burn + (constant_burn * log2_cardinality)
+
+let make ~initial_gas = ref initial_gas
+
+let is_empty t = !t <= 0
+
+let burn t amount = t := !t - amount
+
+let burn_constant t = burn t constant_burn
+let burn_log2 t ~cardinality = burn t (log2_burn ~cardinality)

--- a/src/lambda_vm/gas.mli
+++ b/src/lambda_vm/gas.mli
@@ -1,0 +1,8 @@
+type t
+
+val make : initial_gas:int -> t
+
+val is_empty : t -> bool
+
+val burn_constant : t -> unit
+val burn_log2 : t -> cardinality:int -> unit

--- a/src/lambda_vm/ident.ml
+++ b/src/lambda_vm/ident.ml
@@ -1,0 +1,6 @@
+(* TODO: should I care about overflowing this? *)
+type t = int
+
+let compare = Int.compare
+let initial = 0
+let next t = t + 1

--- a/src/lambda_vm/ident.mli
+++ b/src/lambda_vm/ident.mli
@@ -1,0 +1,5 @@
+type t
+
+val compare : t -> t -> int
+val initial : t
+val next : t -> t

--- a/src/lambda_vm/interpreter.ml
+++ b/src/lambda_vm/interpreter.ml
@@ -1,0 +1,186 @@
+open Ir
+open Checks
+
+type error =
+  (* interpreter bugs *)
+  | Undefined_variable
+  | Over_applied_primitives
+  (* user program bugs *)
+  | Value_is_not_pair
+  | Value_is_not_int64
+  | Value_is_not_function
+  | Value_is_not_zero
+
+exception Error of error
+let raise error = raise (Error error)
+
+module Pattern : sig
+  type 'a t
+  type nil = unit
+
+  val script_result : (value * (nil * nil)) t
+  val parse : value -> 'a t -> 'a
+end = struct
+  type nil = unit
+
+  type 'a t =
+    | Any : value t
+    | Pair : 'first t * 'second t -> ('first * 'second) t
+    | Nil : nil t
+
+  let any = Any
+  let pair first second = Pair (first, second)
+  let nil = Nil
+
+  let operations = nil
+  let script_result = pair any (pair operations nil)
+
+  let rec parse : type a. value -> a t -> a =
+   fun value t ->
+    match (t, value) with
+    | Any, value -> value
+    | ( Pair (first_t, second_t),
+        V_pair { first = first_value; second = second_value } ) ->
+      let first = parse first_value first_t in
+      let second = parse second_value second_t in
+      (first, second)
+    | Pair _, (V_int64 _ | V_closure _ | V_primitive _) ->
+      raise Value_is_not_pair
+    | Nil, V_int64 0L -> ()
+    | Nil, (V_int64 _ | V_pair _ | V_closure _ | V_primitive _) ->
+      raise Value_is_not_zero
+end
+
+module Env = Map_with_cardinality.Make (Ident)
+
+let burn_gas gas env code =
+  (match code with
+  | E_var _
+  | E_app _ ->
+    let cardinality = Env.cardinal env in
+    Gas.burn_log2 gas ~cardinality
+  | E_lam _
+  | E_const _
+  | E_prim _
+  | E_if _
+  | E_pair _ ->
+    Gas.burn_constant gas);
+  check_gas gas
+
+let eval_prim prim ~arg ~args =
+  let op1_int64 f =
+    let f value =
+      match value with
+      | V_int64 value -> V_int64 (f value)
+      | V_pair _
+      | V_closure _
+      | V_primitive _ ->
+        raise Value_is_not_int64 in
+    match args with
+    | [] -> f arg
+    | _ -> raise Over_applied_primitives in
+  let op1_pair f =
+    let f value =
+      match value with
+      | V_pair { first; second } -> f first second
+      | V_int64 _
+      | V_closure _
+      | V_primitive _ ->
+        raise Value_is_not_pair in
+    match args with
+    | [] -> f arg
+    | _ -> raise Over_applied_primitives in
+  let op2 f =
+    (* error only happens after both are applied *)
+    let f left right =
+      match (left, right) with
+      | V_int64 left, V_int64 right -> V_int64 (f left right)
+      | ( (V_pair _ | V_int64 _ | V_closure _ | V_primitive _),
+          (V_pair _ | V_int64 _ | V_closure _ | V_primitive _) ) ->
+        raise Value_is_not_int64 in
+    match args with
+    | [] -> V_primitive { args = [arg]; prim }
+    | [left] -> f left arg
+    | _ -> raise Over_applied_primitives in
+
+  let op2_shift f =
+    let f left right = f left (Int64.to_int right) in
+    op2 f in
+  match prim with
+  | P_neg -> op1_int64 Int64.neg
+  | P_add -> op2 Int64.add
+  | P_sub -> op2 Int64.sub
+  | P_mul -> op2 Int64.mul
+  | P_div -> op2 Int64.div
+  | P_rem -> op2 Int64.rem
+  | P_land -> op2 Int64.logand
+  | P_lor -> op2 Int64.logor
+  | P_lxor -> op2 Int64.logxor
+  | P_lsl -> op2_shift Int64.shift_left
+  | P_lsr -> op2_shift Int64.shift_right_logical
+  | P_asr -> op2_shift Int64.shift_right
+  | P_fst -> op1_pair (fun fst _snd -> fst)
+  | P_snd -> op1_pair (fun _fst snd -> snd)
+
+(* TODO: gas must be ref *)
+let rec eval ~stack gas env code =
+  let eval_call env code = eval ~stack:(stack - 1) gas env code in
+  let eval_jump env code = eval ~stack gas env code in
+
+  check_stack ~stack;
+  burn_gas gas env code;
+
+  match code with
+  | E_var var -> (
+    (* TODO: gas cost for this *)
+    (* TODO: should this be a hashtbl? Or an array? *)
+    match Env.find var env with
+    | Some value -> value
+    | None ->
+      (* TODO: could we eliminate this using GADTs? *) raise Undefined_variable)
+  | E_lam (param, body) -> V_closure { env; param; body }
+  | E_app { funct; arg } -> (
+    let funct = eval_call env funct in
+    let arg = eval_call env arg in
+    match funct with
+    | V_pair _
+    | V_int64 _ ->
+      raise Value_is_not_function
+    | V_closure { env; param; body } ->
+      let env = Env.add param arg env in
+      eval_jump env body
+    | V_primitive { args; prim } -> eval_prim prim ~arg ~args)
+  | E_const value -> V_int64 value
+  | E_prim prim -> V_primitive { args = []; prim }
+  | E_if { predicate; consequent; alternative } -> (
+    let predicate = eval_call env predicate in
+    match predicate with
+    | V_int64 0L -> eval_jump env alternative
+    | V_int64 _ -> eval_jump env consequent
+    | V_pair _
+    | V_closure _
+    | V_primitive _ ->
+      raise Value_is_not_int64)
+  | E_pair { first; second } ->
+    let first = eval_call env first in
+    let second = eval_call env second in
+    V_pair { first; second }
+let eval gas env code =
+  let stack = max_stack_depth in
+  eval ~stack gas env code
+
+type script_result = {
+  storage : Ir.value;
+  operations : unit;
+}
+
+let execute gas ~arg script =
+  let { param; code } = script in
+  let env = Env.add param arg Env.empty in
+  let output = eval gas env code in
+  let storage, (operations, ()) = Pattern.(parse output script_result) in
+  { storage; operations }
+
+let execute gas ~arg script =
+  try Ok (execute gas ~arg script) with
+  | Error error -> Error error

--- a/src/lambda_vm/interpreter.mli
+++ b/src/lambda_vm/interpreter.mli
@@ -1,0 +1,16 @@
+type error =
+  (* interpreter bugs *)
+  | Undefined_variable
+  | Over_applied_primitives
+  (* user program bugs *)
+  | Value_is_not_pair
+  | Value_is_not_int64
+  | Value_is_not_function
+  | Value_is_not_zero
+
+type script_result = {
+  storage : Ir.value;
+  operations : unit;
+}
+val execute :
+  Gas.t -> arg:Ir.value -> Ir.script -> (script_result, error) result

--- a/src/lambda_vm/ir.mli
+++ b/src/lambda_vm/ir.mli
@@ -1,0 +1,63 @@
+type ident = Ident.t
+
+type prim =
+  | P_neg
+  | P_add
+  | P_sub
+  | P_mul
+  | P_div
+  | P_rem
+  | P_land
+  | P_lor
+  | P_lxor
+  | P_lsl
+  | P_lsr
+  | P_asr
+  | P_fst
+  | P_snd
+
+type expr =
+  (* calculus *)
+  | E_var   of ident
+  | E_lam   of ident * expr
+  | E_app   of {
+      funct : expr;
+      arg : expr;
+    }
+  (* prims *)
+  | E_const of int64
+  | E_prim  of prim
+  (* branching *)
+  | E_if    of {
+      (* predicate <> 0 ? consequent : alternative *)
+      predicate : expr;
+      consequent : expr;
+      alternative : expr;
+    }
+  (* memory *)
+  | E_pair  of {
+      first : expr;
+      second : expr;
+    }
+
+type value =
+  | V_int64     of int64
+  | V_pair      of {
+      first : value;
+      second : value;
+    }
+  | V_closure   of {
+      env : env;
+      param : Ident.t;
+      body : expr;
+    }
+  | V_primitive of {
+      args : value list;
+      prim : prim;
+    }
+and env = value Map_with_cardinality.Make(Ident).t
+
+type script = {
+  param : Ident.t;
+  code : expr;
+}

--- a/src/lambda_vm/lambda_vm.ml
+++ b/src/lambda_vm/lambda_vm.ml
@@ -1,0 +1,23 @@
+module Ast = Ast
+module Gas = Gas
+
+type script = Ir.script
+type value = Ir.value
+
+type compile_error = Compiler.error =
+  (* user program bugs *)
+  | Undefined_variable
+
+include Compiler
+
+type execution_error = Interpreter.error =
+  (* interpreter bugs *)
+  | Undefined_variable
+  | Over_applied_primitives
+  (* user program bugs *)
+  | Value_is_not_pair
+  | Value_is_not_int64
+  | Value_is_not_function
+  | Value_is_not_zero
+
+include Interpreter

--- a/src/lambda_vm/lambda_vm.mli
+++ b/src/lambda_vm/lambda_vm.mli
@@ -1,0 +1,31 @@
+module Ast = Ast
+module Gas : module type of Gas
+
+(* ir *)
+type script
+type value
+
+(* compiler *)
+type compile_error = (* user program bugs *)
+  | Undefined_variable
+
+val compile : Gas.t -> Ast.script -> (script, compile_error) result
+val compile_value : Gas.t -> Ast.value -> (value, compile_error) result
+
+(* interpreter *)
+type execution_error =
+  (* interpreter bugs *)
+  | Undefined_variable
+  | Over_applied_primitives
+  (* user program bugs *)
+  | Value_is_not_pair
+  | Value_is_not_int64
+  | Value_is_not_function
+  | Value_is_not_zero
+
+type script_result = {
+  storage : value;
+  operations : unit;
+}
+val execute :
+  Gas.t -> arg:value -> script -> (script_result, execution_error) result

--- a/src/lambda_vm/map_with_cardinality.ml
+++ b/src/lambda_vm/map_with_cardinality.ml
@@ -1,0 +1,43 @@
+module type S = sig
+  type key
+
+  type 'a t
+
+  val empty : 'a t
+
+  (* O(log n) *)
+  val add : key -> 'a -> 'a t -> 'a t
+
+  (* O(1) *)
+  val cardinal : 'a t -> int
+
+  (* O(log n) *)
+  val find : key -> 'a t -> 'a option
+end
+
+(* Map.S + O(1) cardinal*)
+module Make (K : Map.OrderedType) : S with type key = K.t = struct
+  type key = K.t
+
+  module Map = Map.Make (K)
+  type 'a t = {
+    cardinality : int;
+    values : 'a Map.t;
+  }
+
+  let empty = { cardinality = 0; values = Map.empty }
+
+  let add key value t =
+    let { cardinality; values } = t in
+    let cardinality =
+      (* TODO: this could be fused with Ident.Map.add by using Ident.Map.update *)
+      if Map.mem key values then
+        cardinality
+      else
+        cardinality + 1 in
+    let values = Map.add key value values in
+    { cardinality; values }
+
+  let cardinal t = t.cardinality
+  let find key t = Map.find_opt key t.values
+end

--- a/src/lambda_vm/map_with_cardinality.mli
+++ b/src/lambda_vm/map_with_cardinality.mli
@@ -1,0 +1,18 @@
+module type S = sig
+  type key
+
+  type 'a t
+
+  val empty : 'a t
+
+  (* O(log n) *)
+  val add : key -> 'a -> 'a t -> 'a t
+
+  (* O(1) *)
+  val cardinal : 'a t -> int
+
+  (* O(log n) *)
+  val find : key -> 'a t -> 'a option
+end
+
+module Make (K : Map.OrderedType) : S with type key = K.t


### PR DESCRIPTION
## Problem

As discussed in the past, Deku needs a VM to execute Ligo smart contracts.

## Solution

As we're short time on time, unlike what have been discussed in the past, I decided to go with an untyped Lambda VM that can be used to compile both Ligo and OCaml easily. The goal is that in the future this machine could be compiled to a lower level VM.

It provides an strict lambda calculus supporting tail call optimization, combined with int64 primitives, branching using an if C-like and pairs. This allows to describe primitive recursion without stack overflow, pattern matching and complex structures such as tuples, records, natural numbers and etc...

One very important property of this machine is that all the behavior should be defined, including the failure modes, so that in the future when compiling it to assembly all contracts will exhibit the same behavior, that likely will incur in some performance loss in those early contracts when optimized, but we end up having a clear migration path.

## Related

- #163
 