### PR TITLE
sandbox(fixDockerCompose): add a dedicated name for each container

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ yarn global add esy
 Alternatively, you can use the `nix` package manager with
 [flakes enabled](https://nixos.wiki/wiki/Flakes#Installing_flakes) to enter an
 environment preloaded with the correct dependencies, including `esy`:
+
 ```
 nix --experimental-features "nix-command flakes" run
 ```
@@ -39,6 +40,7 @@ esy test
 ### Running a sidechain
 
 For convenient local development, we have included two components:
+
 - A `docker-compose.yml` file that setups a local Tezos network
   using [Flextesa](https://tezos.gitlab.io/flextesa/) running in Docker.
   Additionally, the network sets up a [Better Call Dev](https://github.com/baking-bad/bcdhub) instance
@@ -53,9 +55,10 @@ For convenient local development, we have included two components:
 
 The sandbox requires Bash, [Docker](https://docs.docker.com/get-docker/), and docker-compose to be installed,
 in addition to the usual Deku pre-requisites.
+
 #### Setup
 
-Run `docker-compose up -d` to start a Tezos network and the BCD interface. 
+Run `docker-compose up -d` to start a Tezos network and the BCD interface.
 
 Run `./sandbox.sh setup` to start a local Tezos sandbox network, setup three Deku validator node identities, and deploy
 a Deku consensus contract configured for these validators to the local sandbox.
@@ -76,7 +79,7 @@ This starts 3 nodes as background processes.
 
 You may have to stop the session with `killall deku-node` to fully shutdown the cluster.
 
-In either case, if all goes well, you should see the block height displayed in the terminal and increasing every second or so. 
+In either case, if all goes well, you should see the block height displayed in the terminal and increasing every second or so.
 
 ## Contributing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-version: "3.6"
+version: "3.8"
 services:
   elastic:
     container_name: deku_elastic
@@ -119,7 +119,7 @@ services:
       - 20000/tcp
 
   gui:
-    container_name: sandbox-gui
+    container_name: sandbox_gui
     restart: always
     image: bakingbad/bcdhub-gui:4.0
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,19 +2,19 @@
 # Original License:
 #
 # MIT License
-# 
+#
 # Copyright (c) 2020 Baking Bad, Artem Poltorzhitskiy, Roman Serikov, Michael Zaikin
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,6 +26,7 @@
 version: "3.6"
 services:
   elastic:
+    container_name: deku_elastic
     image: ghcr.io/baking-bad/bcdhub-elastic:master
     restart: always
     volumes:
@@ -34,8 +35,9 @@ services:
       - bootstrap.memory_lock=true
       - discovery.type=single-node
       - "ES_JAVA_OPTS=-Xms256m -Xmx256m"
-    
+
   db:
+    container_name: deku_postgres
     image: postgres:12
     shm_size: 1g
     restart: always
@@ -48,6 +50,7 @@ services:
       - db:/var/lib/postgresql/data
 
   api:
+    container_name: deku_api
     restart: always
     image: ghcr.io/baking-bad/bcdhub-api:master
     environment:
@@ -68,6 +71,7 @@ services:
       - "flextesa:sandbox"
 
   indexer:
+    container_name: deku_indexer
     restart: always
     image: ghcr.io/baking-bad/bcdhub-indexer:master
     environment:
@@ -85,6 +89,7 @@ services:
       - bcdshare:/etc/bcd
 
   metrics:
+    container_name: deku_metrics
     restart: always
     image: ghcr.io/baking-bad/bcdhub-metrics:master
     environment:
@@ -102,6 +107,7 @@ services:
       - bcdshare:/etc/bcd
 
   flextesa:
+    container_name: deku_flextesa
     restart: always
     image: tqtezos/flextesa:20211206
     command: hangzbox start

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -18,7 +18,7 @@ sidecli() {
 }
 
 tezos-client() {
-  docker exec -it deku-flextesa-1 tezos-client "$@"
+  docker exec -it deku_flextesa tezos-client "$@"
 }
 
 ligo() {


### PR DESCRIPTION
## Problem

`docker-compose` default naming convention isn't use in `sandbox.sh`
```shell script
$ docker-compose up -d
Creating deku_flextesa_1 ... done
Creating deku_postgres_1 ... done
Creating deku_elastic_1 ... done
Creating deku_api_1      ... done
Creating deku_metrics_1  ... done
Creating sandbox-gui   ... done
Creating deku_indexer_1  ... done
```
See the `_1` suffix for every container

While in `sandbox.sh`:
```shell script
docker exec -it deku-flextesa-1 tezos-client "$@"
```
Hence, this leads to:
```shell script
$ ./sandbox.sh
=========== Configuring Tezos client ===========
Error: No such container: deku-flextesa-1
```

## Solution

Set a `container_name` for every container, with the same naming convention.

## Related

- #422 #428 
 