### PR TITLE
Simple end-to-end smoke test

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -1,0 +1,30 @@
+name: Deku E2E Tests
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  test:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          
+      # Running flextesa first because we need some time to bootstrap
+      - name: Run flextesa
+        run: docker-compose up -d flextesa
+
+      - name: Install esy
+        run: npm install -g @esy-nightly/esy
+
+      - uses: esy/github-action@master
+        with:
+          cache-key: e2e-${{ hashFiles('esy.lock/index.json') }}
+
+      - name: Run sandbox setup
+        run: ./sandbox.sh setup
+
+      - name: Run smoke test
+        run: ./sandbox.sh smoke-test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
   flextesa:
     container_name: deku_flextesa
     restart: always
-    image: tqtezos/flextesa:20211206
+    image: oxheadalpha/flextesa:20220127
     command: hangzbox start
     environment:
       - block_time=4

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -19,6 +19,7 @@ pkgs.mkShell {
       shellcheck
       tilt
       docker-compose # This is needed by tilt
+      jq
 
       # formatters
       nixfmt

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -289,6 +289,10 @@ start)
   wait_for_servers
   ;;
 smoke-test)
+  if ! command -v jq; then
+    echo "Command jq not found, but it is required to verify the result of the test."
+    exit 1
+  fi
   start_deku_cluster
   seconds=35
   sleep $seconds

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+# shellcheck disable=SC2155
 
 set -e
 
@@ -235,22 +236,41 @@ wait_for_servers() {
   done
 }
 
+deku_storage() {
+  local contract=$(< "$data_directory/0/tezos.json" jq '.consensus_contract' | xargs)
+  local storage=$(curl --silent "$RPC_NODE/chains/main/blocks/head/context/contracts/$contract/storage")
+  echo "$storage"
+}
+
+deku_state_hash() {
+  local storage=$(deku_storage)
+  local state_hash=$(echo "$storage" | jq '.args[0].args[0].args[2].bytes' | xargs)
+  echo "$state_hash"
+}
+
+deku_height() {
+  local storage=$(deku_storage)
+  local block_height=$(echo "$storage" | jq '.args[0].args[0].args[0].args[1].int' | xargs)
+  echo "$block_height"
+}
+
 assert_deku_state() {
-  contract=$(< "$data_directory/0/tezos.json" jq '.consensus_contract' | xargs)
-  storage=$(curl --silent "$RPC_NODE/chains/main/blocks/head/context/contracts/$contract/storage")
-  current_state_hash=$(echo "$storage" | jq '.args[0].args[0].args[2].bytes' | xargs)
-  current_block_height=$(echo "$storage" | jq '.args[0].args[0].args[0].args[1].int' | xargs)
+  local current_state_hash=$(deku_state_hash)
+  local current_block_height=$(deku_height)
+  local starting_height=$1
+  local seconds=$2
+  local minimum_expected_height=$((starting_height + $2))
 
   echo "The current block height is" "$current_block_height"
 
-  # Check that a state root hash was published recently
-  if [ "$current_block_height" -lt 20 ]; then
-    echo "Error: no recent state root hash update found. Exiting."
+  # Check that a current height has progressed past the starting height sufficiently
+  if [ $((current_block_height - starting_height)) -lt 20 ]; then
+    echo "Error: less than 20 blocks were produced in $2 seconds."
     exit 1
   fi
 
   for i in "${VALIDATORS[@]}"; do
-    asserter "$data_directory/$i" "$current_state_hash" "$@"
+    asserter "$data_directory/$i" "$current_state_hash" "$minimum_expected_height"
   done
 }
 
@@ -289,11 +309,12 @@ start)
   wait_for_servers
   ;;
 smoke-test)
+  starting_height=$(deku_height)
   start_deku_cluster
   seconds=35
   sleep $seconds
   killall deku-node
-  assert_deku_state $seconds
+  assert_deku_state "$starting_height" $seconds
   ;;
 tear-down)
   tear-down

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -192,8 +192,8 @@ start_tezos_node() {
   tezos-client --endpoint $RPC_NODE import secret key myWallet "unencrypted:$SECRET_KEY" --force
 }
 
+SERVERS=()
 start_deku_cluster() {
-  SERVERS=()
   echo "Starting nodes."
   for i in "${VALIDATORS[@]}"; do
     if [ "$mode" = "local" ]
@@ -227,6 +227,9 @@ start_deku_cluster() {
     fi
   done
 
+}
+
+wait_for_servers() {
   for PID in "${SERVERS[@]}"; do
     wait "$PID"
   done
@@ -262,6 +265,7 @@ setup)
   ;;
 start)
   start_deku_cluster
+  wait_for_servers
   ;;
 tear-down)
   tear-down

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -237,7 +237,7 @@ wait_for_servers() {
 
 assert_deku_state() {
   contract=$(< "$data_directory/0/tezos.json" jq '.consensus_contract' | xargs)
-  storage=$(curl "$RPC_NODE/chains/main/blocks/head/context/contracts/$contract/storage")
+  storage=$(curl --silent "$RPC_NODE/chains/main/blocks/head/context/contracts/$contract/storage")
   current_state_hash=$(echo "$storage" | jq '.args[0].args[0].args[2].bytes' | xargs)
   current_block_height=$(echo "$storage" | jq '.args[0].args[0].args[0].args[1].int' | xargs)
 
@@ -289,10 +289,6 @@ start)
   wait_for_servers
   ;;
 smoke-test)
-  if ! command -v jq; then
-    echo "Command jq not found, but it is required to verify the result of the test."
-    exit 1
-  fi
   start_deku_cluster
   seconds=35
   sleep $seconds

--- a/tests/e2e/asserter.ml
+++ b/tests/e2e/asserter.ml
@@ -1,0 +1,44 @@
+open Cmdliner
+open Bin_common
+open Crypto
+
+let assert_state_correct data_folder expected_state_root_hash
+    expected_block_height =
+  print_endline @@ "Checking state at path: " ^ data_folder;
+  let file = data_folder ^ "/state.bin" in
+  let protocol_state = Lwt_main.run @@ Files.State_bin.read ~file in
+  Format.printf "Minimum expected block height: %Ld. Actual height: %Ld\n%!"
+    expected_block_height protocol_state.block_height;
+  assert (protocol_state.block_height >= expected_block_height);
+  let actual_state_root_hash =
+    protocol_state.state_root_hash |> BLAKE2B.to_string in
+  Format.printf "Expected state root hash: %s. Actual state root hash: %s\n%!"
+    expected_state_root_hash actual_state_root_hash;
+  assert (actual_state_root_hash = expected_state_root_hash);
+  print_endline "State looks good 👍"
+(* TODO: add more assertions *)
+
+let args =
+  let folder_node =
+    let docv = "folder_node" in
+    let doc = "Path to the folder containing the node configuration data." in
+    let open Arg in
+    required & pos 0 (some string) None & info [] ~doc ~docv in
+  let expected_state_root_hash =
+    let docv = "expected_state_root_hash" in
+    let doc = "The expected state root hash of the node" in
+    let open Arg in
+    required & pos 1 (some string) None & info [] ~doc ~docv in
+  let expected_block_height =
+    let docv = "exepcted_block_height" in
+    let doc = "The expected block height of the node" in
+    let open Arg in
+    required & pos 2 (some int64) None & info [] ~doc ~docv in
+
+  let open Term in
+  const assert_state_correct
+  $ folder_node
+  $ expected_state_root_hash
+  $ expected_block_height
+
+let () = Term.exit @@ Term.eval (args, Term.info "asserter")

--- a/tests/e2e/dune
+++ b/tests/e2e/dune
@@ -1,0 +1,4 @@
+(executable
+ (name asserter)
+ (public_name asserter)
+ (libraries bin_common lwt cmdliner))


### PR DESCRIPTION
## Depends

- [x] #486 

## Problem

Deku's tezos integration is easy to break and not notice.

## Solution

This PR adds a simple e2e smoke test. It does the following:
- runs a deku cluster of 3 nodes for 30 seconds, then kills them.
- checks that a state root hash was published with a block height greater than 20
Control is then passed to a small OCaml program that uses the protocol library to unmarshal each node's `state.bin` and check the following:
- each node's block height is exactly 30 (yes, this is abuses internal knowledge about the block production rate)
- each node's current state root hash is the one posted to Tezos.

These checks are trivial and won't catch any subtle errors in logic, but they're a decent smoke test.

 Currently the test needs to be run manually with `./sandbox.sh smoke-test`. I'm talking to infra now about how to have this as a github action.

Code is duplicated between start.sh and e2e_smoke_test.sh. Not sure the best way to handle that - we could refactor the scripts to share code, but I get sad when I need to start creating bash libraries for my project.

## Related
- #207 