### PR TITLE
exclude docker folder from docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 _esy
 node_modules
 .github
+docker
 
 # files
 *.install


### PR DESCRIPTION
## Problem

On every change to the dockerfile, the change is sent to the buid context, triggering deku to be built from scratch every time.

## Solution

Ignore ./docker in .dockerignore

 