### PR TITLE
Don't use double semicolon

### DIFF
--- a/src/bin/deku_cli.ml
+++ b/src/bin/deku_cli.ml
@@ -5,9 +5,9 @@ open State
 open Protocol
 open Cmdliner
 open Core
-open Bin_common;;
+open Bin_common
 
-Printexc.record_backtrace true
+let () = Printexc.record_backtrace true
 let read_validators ~node_folder =
   Files.Validators.read ~file:(node_folder ^ "/validators.json")
 let read_identity ~node_folder =

--- a/src/crypto/random.ml
+++ b/src/crypto/random.ml
@@ -1,5 +1,5 @@
-Stdlib.Random.self_init ();;
-Mirage_crypto_rng_unix.initialize ()
+Stdlib.Random.self_init ()
+let () = Mirage_crypto_rng_unix.initialize ()
 open Mirage_crypto_rng
 let generate bits = generate bits
 let int32 = Stdlib.Random.int32

--- a/src/node/flows.ml
+++ b/src/node/flows.ml
@@ -125,11 +125,12 @@ let rec request_protocol_snapshot tries =
     (fun _exn ->
       Printexc.print_backtrace stdout;
       request_protocol_snapshot (tries + 1))
-;;
-Lwt.async_exception_hook :=
-  fun exn ->
-    Printexc.to_string exn |> Format.eprintf "global_exception: %s\n%!";
-    Printexc.print_backtrace stderr
+
+let () =
+  Lwt.async_exception_hook :=
+    fun exn ->
+      Printexc.to_string exn |> Format.eprintf "global_exception: %s\n%!";
+      Printexc.print_backtrace stderr
 let pending = ref false
 let load_snapshot snapshot_data =
   let open Networking.Protocol_snapshot in
@@ -265,8 +266,7 @@ and block_added_to_the_pool state update_state block =
     | None ->
       request_previous_blocks state block;
       Ok ()
-;;
-block_added_to_the_pool' := block_added_to_the_pool
+let () = block_added_to_the_pool' := block_added_to_the_pool
 let received_block state update_state block =
   let%ok () =
     is_valid_block state block

--- a/src/node/server.ml
+++ b/src/node/server.ml
@@ -29,7 +29,6 @@ let rec reset_timeout server =
      | Error `Not_current_block_producer -> ());
      reset_timeout server;
      Lwt.return_unit)
-;;
-Flows.reset_timeout := fun () -> reset_timeout (get ());;
-Flows.get_state := get_state;;
-Flows.set_state := set_state
+let () = Flows.reset_timeout := fun () -> reset_timeout (get ())
+let () = Flows.get_state := get_state
+let () = Flows.set_state := set_state

--- a/tests/test_incremental_patricia.ml
+++ b/tests/test_incremental_patricia.ml
@@ -10,35 +10,36 @@ module M = struct
   let make key = { key; hash = BLAKE2B.hash (string_of_int key) }
 end
 open M
-open Incremental_patricia.Make (M);;
-describe "incremental Patricia" (fun { test; _ } ->
-    test "add and find" (fun { expect; _ } ->
-        let add_and_test tree () =
-          let tree, value = add make tree in
-          let _, stored_value = find value.key tree |> Option.get in
-          expect.equal value stored_value;
-          tree in
-        let size = 1 in
-        let tree =
-          List.init size (fun _ -> ()) |> List.fold_left add_and_test empty
-        in
-        let _ =
-          List.init size (fun n -> (expect.option (find n tree)).toBeSome ())
-        in
-        ());
-    test "hash" (fun { expect; _ } ->
-        let tree = empty in
-        let tree, a = add make tree in
-        expect.equal (hash tree) a.hash;
-        let tree, b = add make tree in
-        expect.equal (hash tree) (BLAKE2B.both a.hash b.hash);
-        let tree, c = add make tree in
-        expect.equal (hash tree)
-          (BLAKE2B.both
-             (BLAKE2B.both a.hash b.hash)
-             (BLAKE2B.both c.hash (hash empty)));
-        let tree, d = add make tree in
-        expect.equal (hash tree)
-          (BLAKE2B.both
-             (BLAKE2B.both a.hash b.hash)
-             (BLAKE2B.both c.hash d.hash))))
+open Incremental_patricia.Make (M)
+let () =
+  describe "incremental Patricia" (fun { test; _ } ->
+      test "add and find" (fun { expect; _ } ->
+          let add_and_test tree () =
+            let tree, value = add make tree in
+            let _, stored_value = find value.key tree |> Option.get in
+            expect.equal value stored_value;
+            tree in
+          let size = 1 in
+          let tree =
+            List.init size (fun _ -> ()) |> List.fold_left add_and_test empty
+          in
+          let _ =
+            List.init size (fun n -> (expect.option (find n tree)).toBeSome ())
+          in
+          ());
+      test "hash" (fun { expect; _ } ->
+          let tree = empty in
+          let tree, a = add make tree in
+          expect.equal (hash tree) a.hash;
+          let tree, b = add make tree in
+          expect.equal (hash tree) (BLAKE2B.both a.hash b.hash);
+          let tree, c = add make tree in
+          expect.equal (hash tree)
+            (BLAKE2B.both
+               (BLAKE2B.both a.hash b.hash)
+               (BLAKE2B.both c.hash (hash empty)));
+          let tree, d = add make tree in
+          expect.equal (hash tree)
+            (BLAKE2B.both
+               (BLAKE2B.both a.hash b.hash)
+               (BLAKE2B.both c.hash d.hash))))

--- a/tests/test_ledger.ml
+++ b/tests/test_ledger.ml
@@ -2,182 +2,185 @@ open Setup
 open Helpers
 open Crypto
 open Core
-open Ledger;;
-describe "ledger" (fun { test; _ } ->
-    let make_ticket ?ticketer ?data () =
-      let open Tezos in
-      let ticketer =
-        match ticketer with
-        | Some ticketer -> ticketer
-        | None ->
-          let random_hash =
-            Random.generate 20
-            |> Cstruct.to_string
-            |> BLAKE2B_20.of_raw_string
-            |> Option.get in
-          Address.Originated { contract = random_hash; entrypoint = None } in
-      let data =
-        match data with
-        | Some data -> data
-        | None -> Random.generate 256 |> Cstruct.to_bytes in
-      let open Ticket_id in
-      { ticketer; data } in
-    let make_address () =
-      let _secret, _key, key_hash = Key_hash.make_ed25519 () in
-      key_hash in
-    let make_tezos_address () =
-      let open Crypto in
-      let open Tezos in
-      let _key, address = Ed25519.generate () in
-      let hash = Ed25519.Key_hash.of_key address in
-      Address.Implicit (Ed25519 hash) in
-    let setup_two () =
-      let t1 = make_ticket () in
-      let t2 = make_ticket () in
-      let a = make_address () in
-      let b = make_address () in
-      let t =
-        empty
-        |> deposit a (Amount.of_int 100) t1
-        |> deposit a (Amount.of_int 300) t2
-        |> deposit b (Amount.of_int 200) t1
-        |> deposit b (Amount.of_int 400) t2 in
-      (t, (t1, t2), (a, b)) in
-    let test name f =
-      test name (fun { expect; _ } ->
-          let expect_balance address ticket expected t =
-            expect.equal (Amount.of_int expected) (balance address ticket t)
-          in
-          f expect expect_balance) in
-    test "amount" (fun expect _ ->
-        expect.equal
-          (let open Amount in
-          of_int 0 + of_int 5)
-          (Amount.of_int 5);
-        (expect.fn (fun () -> Amount.of_int (-1))).toThrowException
-          (Invalid_argument "Negative amount"));
-    test "balance" (fun _ expect_balance ->
-        let t, (t1, t2), (a, b) = setup_two () in
-        expect_balance a t1 100 t;
-        expect_balance a t2 300 t;
-        expect_balance b t1 200 t;
-        expect_balance b t2 400 t;
-        expect_balance (make_address ()) t1 0 t;
-        expect_balance (make_address ()) t2 0 t;
-        expect_balance a (make_ticket ()) 0 t;
-        expect_balance b (make_ticket ()) 0 t);
-    test "transfer" (fun expect expect_balance ->
-        let t, (t1, t2), (a, b) = setup_two () in
-        let c = make_address () in
-        let t = transfer ~sender:a ~destination:b (Amount.of_int 1) t1 t in
-        (expect.result t).toBeOk ();
-        let t = Result.get_ok t in
-        expect_balance a t1 99 t;
-        expect_balance a t2 300 t;
-        expect_balance b t1 201 t;
-        expect_balance b t2 400 t;
-        expect_balance c t1 0 t;
-        expect_balance c t2 0 t;
-        let t = transfer ~sender:b ~destination:a (Amount.of_int 3) t2 t in
-        (expect.result t).toBeOk ();
-        let t = Result.get_ok t in
-        expect_balance a t1 99 t;
-        expect_balance a t2 303 t;
-        expect_balance b t1 201 t;
-        expect_balance b t2 397 t;
-        expect_balance c t1 0 t;
-        expect_balance c t2 0 t;
-        let t = transfer ~sender:b ~destination:c (Amount.of_int 5) t2 t in
-        (expect.result t).toBeOk ();
-        let t = Result.get_ok t in
-        expect_balance a t1 99 t;
-        expect_balance a t2 303 t;
-        expect_balance b t1 201 t;
-        expect_balance b t2 392 t;
-        expect_balance c t1 0 t;
-        expect_balance c t2 5 t;
-        let t = transfer ~sender:a ~destination:c (Amount.of_int 99) t1 t in
-        (expect.result t).toBeOk ();
-        let t = Result.get_ok t in
-        expect_balance a t1 0 t;
-        expect_balance a t2 303 t;
-        expect_balance b t1 201 t;
-        expect_balance b t2 392 t;
-        expect_balance c t1 99 t;
-        expect_balance c t2 5 t;
-        (let t = transfer ~sender:b ~destination:c (Amount.of_int 202) t1 t in
-         (expect.result t).toBeError ();
-         expect.equal (Result.get_error t) `Not_enough_funds);
-        (let d = make_address () in
-         let t = transfer ~sender:d ~destination:c (Amount.of_int 1) t2 t in
-         (expect.result t).toBeError ();
-         expect.equal (Result.get_error t) `Not_enough_funds);
-        (let t3 = make_ticket () in
-         let t = transfer ~sender:a ~destination:b (Amount.of_int 1) t3 t in
-         (expect.result t).toBeError ();
-         expect.equal (Result.get_error t) `Not_enough_funds);
-        ());
-    test "deposit" (fun _ expect_balance ->
-        let t, (t1, t2), (a, b) = setup_two () in
-        let t = deposit a (Amount.of_int 123) t1 t in
-        expect_balance a t1 223 t;
-        expect_balance a t2 300 t;
-        expect_balance b t1 200 t;
-        expect_balance b t2 400 t;
-        let t = deposit b (Amount.of_int 456) t2 t in
-        expect_balance a t1 223 t;
-        expect_balance a t2 300 t;
-        expect_balance b t1 200 t;
-        expect_balance b t2 856 t);
-    test "withdraw" (fun expect expect_balance ->
-        let t, (t1, t2), (a, b) = setup_two () in
-        let destination = make_tezos_address () in
-        let t = withdraw ~sender:a ~destination (Amount.of_int 10) t1 t in
-        (expect.result t).toBeOk ();
-        let t, handle = Result.get_ok t in
-        expect_balance a t1 90 t;
-        expect_balance a t2 300 t;
-        expect_balance b t1 200 t;
-        expect_balance b t2 400 t;
-        expect.equal handle.id 0;
-        expect.equal handle.owner destination;
-        expect.equal handle.amount (Amount.of_int 10);
-        let t = withdraw ~sender:b ~destination (Amount.of_int 9) t2 t in
-        (expect.result t).toBeOk ();
-        let t, handle = Result.get_ok t in
-        expect_balance a t1 90 t;
-        expect_balance a t2 300 t;
-        expect_balance b t1 200 t;
-        expect_balance b t2 391 t;
-        expect.equal handle.id 1;
-        expect.equal handle.owner destination;
-        expect.equal handle.amount (Amount.of_int 9);
-        let t = withdraw ~sender:a ~destination (Amount.of_int 8) t2 t in
-        (expect.result t).toBeOk ();
-        let t, handle = Result.get_ok t in
-        expect_balance a t1 90 t;
-        expect_balance a t2 292 t;
-        expect_balance b t1 200 t;
-        expect_balance b t2 391 t;
-        expect.equal handle.id 2;
-        expect.equal handle.owner destination;
-        expect.equal handle.amount (Amount.of_int 8);
-        (let t = withdraw ~sender:a ~destination (Amount.of_int 91) t1 t in
-         (expect.result t).toBeError ());
-        (let t = withdraw ~sender:b ~destination (Amount.of_int 203) t1 t in
-         (expect.result t).toBeError ());
-        (let c = make_address () in
-         let t = withdraw ~sender:c ~destination (Amount.of_int 1) t1 t in
-         (expect.result t).toBeError ());
-        ());
-    test "compare" (fun expect _ ->
-        let t, (t1, _), (a, b) = setup_two () in
-        (let t1' = make_ticket ~data:t1.data () in
-         let t = transfer ~sender:a ~destination:b (Amount.of_int 1) t1' t in
-         (expect.result t).toBeError ();
-         expect.equal (Result.get_error t) `Not_enough_funds);
-        (let t1' = make_ticket ~ticketer:t1.ticketer () in
-         let t = transfer ~sender:a ~destination:b (Amount.of_int 1) t1' t in
-         (expect.result t).toBeError ();
-         expect.equal (Result.get_error t) `Not_enough_funds);
-        ()))
+open Ledger
+
+let () =
+  describe "ledger" (fun { test; _ } ->
+      let make_ticket ?ticketer ?data () =
+        let open Tezos in
+        let ticketer =
+          match ticketer with
+          | Some ticketer -> ticketer
+          | None ->
+            let random_hash =
+              Random.generate 20
+              |> Cstruct.to_string
+              |> BLAKE2B_20.of_raw_string
+              |> Option.get in
+            Address.Originated { contract = random_hash; entrypoint = None }
+        in
+        let data =
+          match data with
+          | Some data -> data
+          | None -> Random.generate 256 |> Cstruct.to_bytes in
+        let open Ticket_id in
+        { ticketer; data } in
+      let make_address () =
+        let _secret, _key, key_hash = Key_hash.make_ed25519 () in
+        key_hash in
+      let make_tezos_address () =
+        let open Crypto in
+        let open Tezos in
+        let _key, address = Ed25519.generate () in
+        let hash = Ed25519.Key_hash.of_key address in
+        Address.Implicit (Ed25519 hash) in
+      let setup_two () =
+        let t1 = make_ticket () in
+        let t2 = make_ticket () in
+        let a = make_address () in
+        let b = make_address () in
+        let t =
+          empty
+          |> deposit a (Amount.of_int 100) t1
+          |> deposit a (Amount.of_int 300) t2
+          |> deposit b (Amount.of_int 200) t1
+          |> deposit b (Amount.of_int 400) t2 in
+        (t, (t1, t2), (a, b)) in
+      let test name f =
+        test name (fun { expect; _ } ->
+            let expect_balance address ticket expected t =
+              expect.equal (Amount.of_int expected) (balance address ticket t)
+            in
+            f expect expect_balance) in
+      test "amount" (fun expect _ ->
+          expect.equal
+            (let open Amount in
+            of_int 0 + of_int 5)
+            (Amount.of_int 5);
+          (expect.fn (fun () -> Amount.of_int (-1))).toThrowException
+            (Invalid_argument "Negative amount"));
+      test "balance" (fun _ expect_balance ->
+          let t, (t1, t2), (a, b) = setup_two () in
+          expect_balance a t1 100 t;
+          expect_balance a t2 300 t;
+          expect_balance b t1 200 t;
+          expect_balance b t2 400 t;
+          expect_balance (make_address ()) t1 0 t;
+          expect_balance (make_address ()) t2 0 t;
+          expect_balance a (make_ticket ()) 0 t;
+          expect_balance b (make_ticket ()) 0 t);
+      test "transfer" (fun expect expect_balance ->
+          let t, (t1, t2), (a, b) = setup_two () in
+          let c = make_address () in
+          let t = transfer ~sender:a ~destination:b (Amount.of_int 1) t1 t in
+          (expect.result t).toBeOk ();
+          let t = Result.get_ok t in
+          expect_balance a t1 99 t;
+          expect_balance a t2 300 t;
+          expect_balance b t1 201 t;
+          expect_balance b t2 400 t;
+          expect_balance c t1 0 t;
+          expect_balance c t2 0 t;
+          let t = transfer ~sender:b ~destination:a (Amount.of_int 3) t2 t in
+          (expect.result t).toBeOk ();
+          let t = Result.get_ok t in
+          expect_balance a t1 99 t;
+          expect_balance a t2 303 t;
+          expect_balance b t1 201 t;
+          expect_balance b t2 397 t;
+          expect_balance c t1 0 t;
+          expect_balance c t2 0 t;
+          let t = transfer ~sender:b ~destination:c (Amount.of_int 5) t2 t in
+          (expect.result t).toBeOk ();
+          let t = Result.get_ok t in
+          expect_balance a t1 99 t;
+          expect_balance a t2 303 t;
+          expect_balance b t1 201 t;
+          expect_balance b t2 392 t;
+          expect_balance c t1 0 t;
+          expect_balance c t2 5 t;
+          let t = transfer ~sender:a ~destination:c (Amount.of_int 99) t1 t in
+          (expect.result t).toBeOk ();
+          let t = Result.get_ok t in
+          expect_balance a t1 0 t;
+          expect_balance a t2 303 t;
+          expect_balance b t1 201 t;
+          expect_balance b t2 392 t;
+          expect_balance c t1 99 t;
+          expect_balance c t2 5 t;
+          (let t = transfer ~sender:b ~destination:c (Amount.of_int 202) t1 t in
+           (expect.result t).toBeError ();
+           expect.equal (Result.get_error t) `Not_enough_funds);
+          (let d = make_address () in
+           let t = transfer ~sender:d ~destination:c (Amount.of_int 1) t2 t in
+           (expect.result t).toBeError ();
+           expect.equal (Result.get_error t) `Not_enough_funds);
+          (let t3 = make_ticket () in
+           let t = transfer ~sender:a ~destination:b (Amount.of_int 1) t3 t in
+           (expect.result t).toBeError ();
+           expect.equal (Result.get_error t) `Not_enough_funds);
+          ());
+      test "deposit" (fun _ expect_balance ->
+          let t, (t1, t2), (a, b) = setup_two () in
+          let t = deposit a (Amount.of_int 123) t1 t in
+          expect_balance a t1 223 t;
+          expect_balance a t2 300 t;
+          expect_balance b t1 200 t;
+          expect_balance b t2 400 t;
+          let t = deposit b (Amount.of_int 456) t2 t in
+          expect_balance a t1 223 t;
+          expect_balance a t2 300 t;
+          expect_balance b t1 200 t;
+          expect_balance b t2 856 t);
+      test "withdraw" (fun expect expect_balance ->
+          let t, (t1, t2), (a, b) = setup_two () in
+          let destination = make_tezos_address () in
+          let t = withdraw ~sender:a ~destination (Amount.of_int 10) t1 t in
+          (expect.result t).toBeOk ();
+          let t, handle = Result.get_ok t in
+          expect_balance a t1 90 t;
+          expect_balance a t2 300 t;
+          expect_balance b t1 200 t;
+          expect_balance b t2 400 t;
+          expect.equal handle.id 0;
+          expect.equal handle.owner destination;
+          expect.equal handle.amount (Amount.of_int 10);
+          let t = withdraw ~sender:b ~destination (Amount.of_int 9) t2 t in
+          (expect.result t).toBeOk ();
+          let t, handle = Result.get_ok t in
+          expect_balance a t1 90 t;
+          expect_balance a t2 300 t;
+          expect_balance b t1 200 t;
+          expect_balance b t2 391 t;
+          expect.equal handle.id 1;
+          expect.equal handle.owner destination;
+          expect.equal handle.amount (Amount.of_int 9);
+          let t = withdraw ~sender:a ~destination (Amount.of_int 8) t2 t in
+          (expect.result t).toBeOk ();
+          let t, handle = Result.get_ok t in
+          expect_balance a t1 90 t;
+          expect_balance a t2 292 t;
+          expect_balance b t1 200 t;
+          expect_balance b t2 391 t;
+          expect.equal handle.id 2;
+          expect.equal handle.owner destination;
+          expect.equal handle.amount (Amount.of_int 8);
+          (let t = withdraw ~sender:a ~destination (Amount.of_int 91) t1 t in
+           (expect.result t).toBeError ());
+          (let t = withdraw ~sender:b ~destination (Amount.of_int 203) t1 t in
+           (expect.result t).toBeError ());
+          (let c = make_address () in
+           let t = withdraw ~sender:c ~destination (Amount.of_int 1) t1 t in
+           (expect.result t).toBeError ());
+          ());
+      test "compare" (fun expect _ ->
+          let t, (t1, _), (a, b) = setup_two () in
+          (let t1' = make_ticket ~data:t1.data () in
+           let t = transfer ~sender:a ~destination:b (Amount.of_int 1) t1' t in
+           (expect.result t).toBeError ();
+           expect.equal (Result.get_error t) `Not_enough_funds);
+          (let t1' = make_ticket ~ticketer:t1.ticketer () in
+           let t = transfer ~sender:a ~destination:b (Amount.of_int 1) t1' t in
+           (expect.result t).toBeError ();
+           expect.equal (Result.get_error t) `Not_enough_funds);
+          ()))

--- a/tests/test_runner.ml
+++ b/tests/test_runner.ml
@@ -1,2 +1,2 @@
-Printexc.record_backtrace true;;
-Protocol_test_lib.Setup.cli ()
+Printexc.record_backtrace true
+let () = Protocol_test_lib.Setup.cli ()

--- a/tests/test_tezos_interop.ml
+++ b/tests/test_tezos_interop.ml
@@ -22,576 +22,584 @@ module TZ3_ex = struct
 end
 let some_contract_hash =
   Contract_hash.of_string "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc" |> Option.get
-;;
-describe "key" (fun { test; _ } ->
-    let open Key in
-    let edpk = genesis_wallet in
-    test "to_string" (fun { expect; _ } ->
-        (expect.string (to_string edpk)).toEqual
-          "edpkvDqjL7aXdsXSiK5ChCMAfqaqmCFWCv7DaT3dK1egJt136WBiT6";
-        (expect.string (to_string TZ2_ex.pk)).toEqual
-          "sppk7aCim2kYBWGoEQGezcg8LbHi99XxrAE5dh6DDUru26pT93V2c5U";
-        (expect.string (to_string TZ3_ex.pk)).toEqual
-          "p2pk67mCLEZ2iFivprKpjugLakXfahdq9VUqmiTho1fhtv9P3AeJoc7");
-    test "of_string" (fun { expect; _ } ->
-        (expect.option
-           (of_string "edpkvDqjL7aXdsXSiK5ChCMAfqaqmCFWCv7DaT3dK1egJt136WBiT6"))
-          .toBe
-          ~equals:Key.equal (Some edpk);
-        (expect.option
-           (of_string "sppk7aCim2kYBWGoEQGezcg8LbHi99XxrAE5dh6DDUru26pT93V2c5U"))
-          .toBe
-          ~equals:Key.equal (Some TZ2_ex.pk);
-        (expect.option
-           (of_string "p2pk67mCLEZ2iFivprKpjugLakXfahdq9VUqmiTho1fhtv9P3AeJoc7"))
-          .toBe
-          ~equals:Key.equal (Some TZ3_ex.pk));
-    test "invalid prefix" (fun { expect; _ } ->
-        (expect.option
-           (of_string "edpuvDqjL7aXdsXSiK5ChCMAfqaqmCFWCv7DaT3dK1egJt136WBiT6"))
-          .toBeNone
-          ();
-        (expect.option
-           (of_string "sddk7aCim2kYBWGoEQGezcg8LbHi99XxrAE5dh6DDUru26pT93V2c5U"))
-          .toBeNone
-          ();
-        (expect.option
-           (of_string "p3pk67mCLEZ2iFivprKpjugLakXfahdq9VUqmiTho1fhtv9P3AeJoc7"))
-          .toBeNone
-          ());
-    test "invalid checksum" (fun { expect; _ } ->
-        (expect.option
-           (of_string "edpkvDqjL7aXdsXSiK5ChCMAfqaqmCFWCv7DaT3dK1egJt136WBiT5"))
-          .toBeNone
-          ();
-        (expect.option
-           (of_string "sppk7dCim2kYBWGoEQGezcg8LbHi99XxrAE5dh6DDUru26pT93V2c5U"))
-          .toBeNone
-          ();
-        (expect.option
-           (of_string "p2pk67mCLEz2iFivprKpjugLakXfahdq9VUqmiTho1fhtv9P3AeJoc7"))
-          .toBeNone
-          ());
-    test "invalid size" (fun { expect; _ } ->
-        (expect.option
-           (of_string "edpkvDqjL7aXdsXSiK5ChCMAfqaqmCFWCv7DaT3dK1egJt136WBiT"))
-          .toBeNone
-          ();
-        (expect.option
-           (of_string "sppk7Cim2kYBWGoEQGezcg8LbHi99XxrAE5dh6DDUru26pT93V2c5U"))
-          .toBeNone
-          ();
-        (expect.option
-           (of_string "p2pk67mCLE2iFivprKpjugLakXfahdq9VUqmiTho1fhtv9P3AeJoc7"))
-          .toBeNone
-          ()))
-;;
-describe "key_hash" (fun { test; _ } ->
-    let open Key_hash in
-    let tz1 = of_key genesis_wallet in
-    let tz2 = of_key TZ2_ex.pk in
-    let tz3 = of_key TZ3_ex.pk in
-    test "to_string" (fun { expect; _ } ->
-        (expect.string (to_string tz1)).toEqual
-          "tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC";
-        (expect.string (to_string tz2)).toEqual
-          "tz2LcShRoD1PHxUYHq2DyEUjayG1kfqeqLVD";
-        (expect.string (to_string tz3)).toEqual
-          "tz3b8hJcRfJzz5ZNCTepE9kU1QnTrL8Acy3y");
-    test "of_string" (fun { expect; _ } ->
-        (expect.option (of_string "tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC")).toBe
-          ~equals:Key_hash.equal (Some tz1);
-        (expect.option (of_string "tz2LcShRoD1PHxUYHq2DyEUjayG1kfqeqLVD")).toBe
-          ~equals:Key_hash.equal (Some tz2);
-        (expect.option (of_string "tz3b8hJcRfJzz5ZNCTepE9kU1QnTrL8Acy3y")).toBe
-          ~equals:Key_hash.equal (Some tz3));
-    test "invalid prefix" (fun { expect; _ } ->
-        (expect.option (of_string "tzaLzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC"))
-          .toBeNone ();
-        (expect.option (of_string "tz4LcShRoD1PHxUYHq2DyEUjayG1kfqeqLVD"))
-          .toBeNone ();
-        (expect.option (of_string "tzdb8hJcRfJzz5ZNCTepE9kU1QnTrL8Acy3y"))
-          .toBeNone ());
-    test "invalid checksum" (fun { expect; _ } ->
-        (expect.option (of_string "tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLA"))
-          .toBeNone ();
-        (expect.option (of_string "tz2LcrhRoD1PHxUYHq2DyEUjayG1kfqeqLVD"))
-          .toBeNone ();
-        (expect.option (of_string "tz3d8hJcRfJzz5ZNCTepE9kU1QnTrL8Acy3y"))
-          .toBeNone ());
-    test "invalid size" (fun { expect; _ } ->
-        (expect.option (of_string "tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCL"))
-          .toBeNone ();
-        (expect.option (of_string "tz2LcShRD1PHxUYHq2DyEUjayG1kfqeqLVD"))
-          .toBeNone ();
-        (expect.option (of_string "tz38hJcRfJzz5ZNCTepE9kU1QnTrL8Acy3y"))
-          .toBeNone ()))
-;;
-describe "secret" (fun { test; _ } ->
-    let open Secret in
-    let edsk = genesis_key in
-    let spsk = TZ2_ex.sk in
-    let p2sk = TZ3_ex.sk in
-    test "to_string" (fun { expect; _ } ->
-        (expect.string (to_string edsk)).toEqual
-          "edsk4bfbFdb4s2BdkW3ipfB23i9u82fgji6KT3oj2SCWTeHUthbSVd";
-        (expect.string (to_string spsk)).toEqual
-          "spsk3LfH15rYByf7whY9YNAxS5ghpjzCr96jZ16Jt4pv2mnshf8Tcy";
-        (expect.string (to_string p2sk)).toEqual
-          "p2sk2s8WFJdvL6J9JxY7R3tWwMnaqJotbcTFgXg3pSVNPvrxKL1AkQ");
-    test "of_string" (fun { expect; _ } ->
-        (expect.option
-           (of_string "edsk4bfbFdb4s2BdkW3ipfB23i9u82fgji6KT3oj2SCWTeHUthbSVd"))
-          .toBe
-          ~equals:Secret.equal (Some edsk);
-        (expect.option
-           (of_string "spsk3LfH15rYByf7whY9YNAxS5ghpjzCr96jZ16Jt4pv2mnshf8Tcy"))
-          .toBe
-          ~equals:Secret.equal (Some spsk);
-        (expect.option
-           (of_string "p2sk2s8WFJdvL6J9JxY7R3tWwMnaqJotbcTFgXg3pSVNPvrxKL1AkQ"))
-          .toBe
-          ~equals:Secret.equal (Some p2sk));
-    test "invalid prefix" (fun { expect; _ } ->
-        (expect.option
-           (of_string "edsa4bfbFdb4s2BdkW3ipfB23i9u82fgji6KT3oj2SCWTeHUthbSVd"))
-          .toBeNone
-          ();
-        (expect.option
-           (of_string "spdk3LfH15rYByf7whY9YNAxS5ghpjzCr96jZ16Jt4pv2mnshf8Tcy"))
-          .toBeNone
-          ();
-        (expect.option
-           (of_string "p3sk2s8WFJdvL6J9JxY7R3tWwMnaqJotbcTFgXg3pSVNPvrxKL1AkQ"))
-          .toBeNone
-          ());
-    test "invalid checksum" (fun { expect; _ } ->
-        (expect.option
-           (of_string "edsk4bfbFdb4s2BdkW3ipfB23i9u82fgji6KT3oj2SCWTeHUthbSVb"))
-          .toBeNone
-          ();
-        (expect.option
-           (of_string "spsk3LfH15dYByf7whY9YNAxS5ghpjzCr96jZ16Jt4pv2mnshf8Tcy"))
-          .toBeNone
-          ();
-        (expect.option
-           (of_string "p2sk3s8WFJdvL6J9JxY7R3tWwMnaqJotbcTFgXg3pSVNPvrxKL1AkQ"))
-          .toBeNone
-          ());
-    test "invalid size" (fun { expect; _ } ->
-        (expect.option
-           (of_string "edsk4bfbFdb4s2BdkW3ipfB23i9u82fgji6KT3oj2SCWTeHUthbSV"))
-          .toBeNone
-          ();
-        (expect.option
-           (of_string "spsk3LfH15YByf7whY9YNAxS5ghpjzCr96jZ16Jt4pv2mnshf8Tcy"))
-          .toBeNone
-          ();
-        (expect.option
-           (of_string "p2sk2s8wFJdvL6J9JxY7R3tWwMnaqJotbcTFgXg3pSVNPvrxKL1AkQ"))
-          .toBeNone
-          ()))
-;;
-describe "signature" (fun { test; _ } ->
-    let open BLAKE2B in
-    let open Signature in
-    let edpk = genesis_wallet in
-    let edsk = genesis_key in
-    let tuturu = hash "tuturu" in
-    let tuturu2 = hash "tuturu2" in
-    let edsig = sign edsk tuturu in
-    let sppk = TZ2_ex.pk in
-    let spsk = TZ2_ex.sk in
-    let spsig = sign spsk tuturu in
-    let p2pk = TZ3_ex.pk in
-    let p2sk = TZ3_ex.sk in
-    let p2sig = sign p2sk tuturu in
-    test "check" (fun { expect; _ } ->
-        (expect.bool (verify edpk edsig tuturu)).toBeTrue ();
-        (expect.bool (verify sppk spsig tuturu)).toBeTrue ();
-        (expect.bool (verify p2pk p2sig tuturu)).toBeTrue ());
-    test "invalid message" (fun { expect; _ } ->
-        (expect.bool (verify edpk edsig tuturu2)).toBeFalse ();
-        (expect.bool (verify sppk spsig tuturu2)).toBeFalse ();
-        (expect.bool (verify p2pk p2sig tuturu2)).toBeFalse ());
-    test "invalid key" (fun { expect; _ } ->
-        let secret, key =
-          let secret, key = Ed25519.generate () in
-          (Secret.Ed25519 secret, Key.Ed25519 key) in
-        let edsig_from_key = sign secret tuturu in
-        (expect.bool (verify key edsig_from_key tuturu)).toBeTrue ();
-        (expect.bool (verify edpk edsig_from_key tuturu)).toBeFalse ();
-        let secret, key =
-          let secret, key = Crypto.Secp256k1.generate () in
-          (Secret.Secp256k1 secret, Key.Secp256k1 key) in
-        let pksig_from_key = sign secret tuturu in
-        (expect.bool (verify key pksig_from_key tuturu)).toBeTrue ();
-        (expect.bool (verify sppk pksig_from_key tuturu)).toBeFalse ();
-        let secret, key =
-          let secret, key = Crypto.P256.generate () in
-          (Secret.P256 secret, Key.P256 key) in
-        let p2sig_from_key = sign secret tuturu in
-        (expect.bool (verify key p2sig_from_key tuturu)).toBeTrue ();
-        (expect.bool (verify p2pk p2sig_from_key tuturu)).toBeFalse ());
-    test "to_string" (fun { expect; _ } ->
-        (expect.string (to_string edsig)).toEqual
-          "edsigtp1tNe8hVhfn9QPoGaLyxqksCbRxk6w3wTjbMDyu4QckAyhMDwUQc3yDCjfSqFXeccLkRjE1c1Lbm71i7uhGZqx7V8nSq4";
-        (expect.string (to_string spsig)).toEqual
-          "spsig1ao4VRH1rAXpfUDT6B7y2ScbbM5RSP9ZRqtkKuKbE4Eo1QGAKqMVKieYtvFcUDUeqSpGWcqVMedfsfKr45yuQqWpz7Wgqh";
-        (expect.string (to_string p2sig)).toEqual
-          "p2sigt13usEEBey8JkpRCarwHnMUZ744xeAQFv65ZT5UZeNgoGaFDdFfw27MEGpGSSAdxpSyBdfBhkrtUf7cwHx6NQnCpjWbpo");
-    test "of_string" (fun { expect; _ } ->
-        (expect.option
-           (of_string
-              "edsigtp1tNe8hVhfn9QPoGaLyxqksCbRxk6w3wTjbMDyu4QckAyhMDwUQc3yDCjfSqFXeccLkRjE1c1Lbm71i7uhGZqx7V8nSq4"))
-          .toBe
-          ~equals:Signature.equal (Some edsig);
-        (expect.option
-           (of_string
-              "spsig1ao4VRH1rAXpfUDT6B7y2ScbbM5RSP9ZRqtkKuKbE4Eo1QGAKqMVKieYtvFcUDUeqSpGWcqVMedfsfKr45yuQqWpz7Wgqh"))
-          .toBe
-          ~equals:Signature.equal (Some spsig);
-        (expect.option
-           (of_string
-              "p2sigt13usEEBey8JkpRCarwHnMUZ744xeAQFv65ZT5UZeNgoGaFDdFfw27MEGpGSSAdxpSyBdfBhkrtUf7cwHx6NQnCpjWbpo"))
-          .toBe
-          ~equals:Signature.equal (Some p2sig));
-    test "invalid prefix" (fun { expect; _ } ->
-        (expect.option
-           (of_string
-              "edsiatp1tNe8hVhfn9QPoGaLyxqksCbRxk6w3wTjbMDyu4QckAyhMDwUQc3yDCjfSqFXeccLkRjE1c1Lbm71i7uhGZqx7V8nSq4"))
-          .toBeNone
-          ();
-        (expect.option
-           (of_string
-              "spsdg1ao4VRH1rAXpfUDT6B7y2ScbbM5RSP9ZRqtkKuKbE4Eo1QGAKqMVKieYtvFcUDUeqSpGWcqVMedfsfKr45yuQqWpz7Wgqh"))
-          .toBeNone
-          ();
-        (expect.option
-           (of_string
-              "p3sigt13usEEBey8JkpRCarwHnMUZ744xeAQFv65ZT5UZeNgoGaFDdFfw27MEGpGSSAdxpSyBdfBhkrtUf7cwHx6NQnCpjWbpo"))
-          .toBeNone
-          ());
-    test "invalid checksum" (fun { expect; _ } ->
-        (expect.option
-           (of_string
-              "edsigtp1tNe8hVhfn9QPoGaLyxqksCbRxk6w3wTjbMDyu4QckAyhMDwUQc3yDCjfSqFXeccLkRjE1c1Lbm71i7uhGZqx7V8nSq3"))
-          .toBeNone
-          ();
-        (expect.option
-           (of_string
-              "spsig1ao4VRH1rAXpaUDT6B7y2ScbbM5RSP9ZRqtkKuKbE4Eo1QGAKqMVKieYtvFcUDUeqSpGWcqVMedfsfKr45yuQqWpz7Wgqh"))
-          .toBeNone
-          ();
-        (expect.option
-           (of_string
-              "p2sigt13useEBey8JkpRCarwHnMUZ744xeAQFv65ZT5UZeNgoGaFDdFfw27MEGpGSSAdxpSyBdfBhkrtUf7cwHx6NQnCpjWbpo"))
-          .toBeNone
-          ());
-    test "invalid size" (fun { expect; _ } ->
-        (expect.option
-           (of_string
-              "edsigtp1tNe8hVhfn9QPoGaLyxqksCbRxk6w3wTjbMDyu4QckAyhMDwUQc3yDCjfSqFXeccLkRjE1c1Lbm71i7uhGZqx7V8nSq"))
-          .toBeNone
-          ();
-        (expect.option
-           (of_string
-              "spsig1ao4VRH1rAXpfUDT67y2ScbbM5RSP9ZRqtkKuKbE4Eo1QGAKqMVKieYtvFcUDUeqSpGWcqVMedfsfKr45yuQqWpz7Wgqh"))
-          .toBeNone
-          ();
-        (expect.option
-           (of_string
-              "p2sigt13usEEBeyJkpRCarwHnMUZ744xeAQFv65ZT5UZeNgoGaFDdFfw27MEGpGSSAdxpSyBdfBhkrtUf7cwHx6NQnCpjWbpo"))
-          .toBeNone
-          ()))
-;;
-describe "contract_hash" (fun { test; _ } ->
-    let open Contract_hash in
-    let kt1 = some_contract_hash in
-    test "to_string" (fun { expect; _ } ->
-        (expect.string (to_string kt1)).toEqual
-          "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc");
-    test "of_string" (fun { expect; _ } ->
-        (expect.option (of_string "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc")).toBe
-          ~equals:Contract_hash.equal (Some kt1));
-    test "invalid prefix" (fun { expect; _ } ->
-        (expect.option (of_string "KT2Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc"))
-          .toBeNone ());
-    test "invalid checksum" (fun { expect; _ } ->
-        (expect.option (of_string "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTd"))
-          .toBeNone ());
-    test "invalid size" (fun { expect; _ } ->
-        (expect.option (of_string "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABT"))
-          .toBeNone ()))
-;;
-describe "address" (fun { test; _ } ->
-    let open Address in
-    let tz1 = Implicit (Key_hash.of_key genesis_wallet) in
-    let tz2 = Implicit (Key_hash.of_key TZ2_ex.pk) in
-    let tz3 = Implicit (Key_hash.of_key TZ3_ex.pk) in
-    let kt1 = Originated { contract = some_contract_hash; entrypoint = None } in
-    let kt1_tuturu =
-      Originated { contract = some_contract_hash; entrypoint = Some "tuturu" }
-    in
-    test "to_string" (fun { expect; _ } ->
-        (expect.string (to_string tz1)).toEqual
-          "tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC";
-        (expect.string (to_string tz2)).toEqual
-          "tz2LcShRoD1PHxUYHq2DyEUjayG1kfqeqLVD";
-        (expect.string (to_string tz3)).toEqual
-          "tz3b8hJcRfJzz5ZNCTepE9kU1QnTrL8Acy3y";
-        (expect.string (to_string kt1)).toEqual
-          "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc";
-        (expect.string (to_string kt1_tuturu)).toEqual
-          "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc%tuturu");
-    test "of_string" (fun { expect; _ } ->
-        (expect.option (of_string "tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC")).toBe
-          ~equals:Address.equal (Some tz1);
-        (expect.option (of_string "tz2LcShRoD1PHxUYHq2DyEUjayG1kfqeqLVD")).toBe
-          ~equals:Address.equal (Some tz2);
-        (expect.option (of_string "tz3b8hJcRfJzz5ZNCTepE9kU1QnTrL8Acy3y")).toBe
-          ~equals:Address.equal (Some tz3);
-        (expect.option (of_string "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc")).toBe
-          ~equals:Address.equal (Some kt1);
-        (expect.option
-           (of_string "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc%tuturu"))
-          .toBe ~equals:Address.equal (Some kt1_tuturu);
-        (expect.option
-           (of_string "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc%default"))
-          .toBeNone ());
-    test "invalid prefix" (fun { expect; _ } ->
-        (expect.option (of_string "tz4LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC"))
-          .toBeNone ();
-        (expect.option (of_string "td2LcShRoD1PHxUYHq2DyEUjayG1kfqeqLVD"))
-          .toBeNone ();
-        (expect.option (of_string "tzab8hJcRfJzz5ZNCTepE9kU1QnTrL8Acy3y"))
-          .toBeNone ());
-    test "invalid checksum" (fun { expect; _ } ->
-        (expect.option (of_string "tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLd"))
-          .toBeNone ();
-        (expect.option (of_string "tz2LcShaoD1PHxUYHq2DyEUjayG1kfqeqLVD"))
-          .toBeNone ();
-        (expect.option (of_string "tz3b8hdcRfJzz5ZNCTepE9kU1QnTrL8Acy3y"))
-          .toBeNone ());
-    test "invalid size" (fun { expect; _ } ->
-        (expect.option (of_string "tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCL"))
-          .toBeNone ();
-        (expect.option (of_string "tz2LcShRoDPHxUYHq2DyEUjayG1kfqeqLVD"))
-          .toBeNone ();
-        (expect.option (of_string "tz3b8hJRfJzz5ZNCTepE9kU1QnTrL8Acy3y"))
-          .toBeNone ()))
-;;
-describe "ticket" (fun { test; _ } ->
-    let open Ticket_id in
-    let kt1 =
-      Address.Originated { contract = some_contract_hash; entrypoint = None }
-    in
-    let ticket = { ticketer = kt1; data = Bytes.of_string "a" } in
-    test "to_string" (fun { expect; _ } ->
-        (expect.string (to_string ticket)).toEqual
-          {|(Pair "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc" 0x61)|});
-    test "of_string" (fun { expect; _ } ->
-        (expect.option
-           (of_string {|(Pair "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc" 0x61)|}))
-          .toBe
-          ~equals:equal (Some ticket));
-    test "invalid address" (fun { expect; _ } ->
-        (expect.option
-           (of_string {|(Pair "BT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc" 0x61)|}))
-          .toBeNone
-          ());
-    test "invalid bytes" (fun { expect; _ } ->
-        (expect.option
-           (of_string {|(Pair "BT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc" 0x6Z)|}))
-          .toBeNone
-          ()))
-;;
-describe "operation_hash" (fun { test; _ } ->
-    let open Operation_hash in
-    let op =
-      of_string "opCAkifFMh1Ya2J4WhRHskaXc297ELtx32wnc2WzeNtdQHp7DW4"
-      |> Option.get in
-    test "to_string" (fun { expect; _ } ->
-        (expect.string (to_string op)).toEqual
-          "opCAkifFMh1Ya2J4WhRHskaXc297ELtx32wnc2WzeNtdQHp7DW4");
-    test "of_string" (fun { expect; _ } ->
-        (expect.option
-           (of_string {|opCAkifFMh1Ya2J4WhRHskaXc297ELtx32wnc2WzeNtdQHp7DW4|}))
-          .toBe
-          ~equals:Operation_hash.equal (Some op));
-    test "invalid prefix" (fun { expect; _ } ->
-        (expect.option
-           (of_string "obCAkifFMh1Ya2J4WhRHskaXc297ELtx32wnc2WzeNtdQHp7DW4"))
-          .toBeNone
-          ());
-    test "invalid checksum" (fun { expect; _ } ->
-        (expect.option
-           (of_string "opCAkifFMh1Ya2J4WhRHskaXc297ELtx32wnc2WzeNtdQHp7DW5"))
-          .toBeNone
-          ());
-    test "invalid size" (fun { expect; _ } ->
-        (expect.option
-           (of_string "opCAkifFMh1Ya2J4WhRHskaXc297ELtx32wnc2WzeNtdQHp7DW"))
-          .toBeNone
-          ()))
-;;
-describe "operation forging" (fun { test; _ } ->
-    let open Tezos in
-    let open Operation in
-    let forge_transaction ~branch ~fee ~gas_limit ~storage_limit ~amount
-        ~destination ~source ~counter ~secret ~entrypoint ~value =
-      let branch = Block_hash.of_string branch |> Option.get in
-      let fee = Tez.of_mutez fee |> Option.get in
-      let gas_limit = Gas.of_int gas_limit |> Option.get in
-      let storage_limit = Z.of_int storage_limit in
-      let amount = Tez.of_mutez amount |> Option.get in
-      let destination = Address.of_string destination |> Option.get in
-      let source = Key_hash.of_string source |> Option.get in
-      let counter = Z.of_int counter in
-      let secret = Secret.of_string secret |> Option.get in
-      let operation =
-        {
-          source;
-          fee;
-          counter;
-          content = Transaction { amount; destination; entrypoint; value };
-          gas_limit;
-          storage_limit;
-        } in
-      Tezos.Operation.forge ~secret ~branch ~operations:[operation] in
-    test "same result as taquito" (fun { expect; _ } ->
-        let forged_bytes =
-          forge_transaction
-            ~branch:"BLBQQXyZ1qTwxZiT5FkJwvKj4YnCmx6xhqnhgaZg1Z13aQDJiCk"
-            ~fee:443L ~gas_limit:1520 ~storage_limit:0 ~amount:2000000L
-            ~destination:"tz1ULf5uGJXefx8c8iLfHfuW1doMPpVicg7u"
-            ~source:"tz1M6iKVFN8RhHjVSL3oF75nF2FJ1yMkrk5t" ~counter:3305389
-            ~secret:"edsk4RbgwutwsEdVNuJsE5JDsxeJ6qFcG8F5rKFGnj5finT6FV46sd"
-            ~entrypoint:"default" ~value:Michelson.unit in
-        let taquito_forged_bytes =
-          "3d95683f0d29a6deb044f4ecd86efd9cbae6b373b7b9d7c2db16456783e664566c001004051072b588b39e25b9f4dbf4673abcd63147bb03addfc901f00b0080897a00005f70062003e798791cb04f51bcec1d3358ac64a600468a797b657cff8b585c18cb599443d7c0982220cfa9231270138c7a3e0996d8ea42a2912d51c44681877b2d3a3e8051ebd1498305f8f73cf68967f60349fc00"
-        in
-        (expect.string forged_bytes).toEqual taquito_forged_bytes);
-    test "parameter unit and entrypoint default" (fun { expect; _ } ->
-        let forged_bytes =
-          forge_transaction
-            ~branch:"BMb1r7vPdSkTb8ACDpuk4vKXPqEm6knqKjEzqpNj8Prxb2KWMP3"
-            ~fee:420L ~gas_limit:1303 ~storage_limit:0 ~amount:0L
-            ~destination:"KT1GAr6WWLeavRVHgxEJq1F7tNLzavCLu9YB"
-            ~source:"tz1M6iKVFN8RhHjVSL3oF75nF2FJ1yMkrk5t" ~counter:3305396
-            ~secret:"edsk4RbgwutwsEdVNuJsE5JDsxeJ6qFcG8F5rKFGnj5finT6FV46sd"
-            ~entrypoint:"default" ~value:Michelson.unit in
-        let taquito_forged_bytes =
-          "f6e43992b2f45aedbfdc7f5f6a21aa68c99973afffa0ddbe8b98e33672dec6396c001004051072b588b39e25b9f4dbf4673abcd63147a403b4dfc901970a000001533ace00d71497d23fdac2a8809bb1e9df14c579000048a432efc5ef0e700c2f696957996e90194787995d43826b18ade1823d05857f35787f4e7a223d3ea226f22b1809ee56a9046bd313f547e3746fb46bc8ed3803"
-        in
-        (expect.string forged_bytes).toEqual taquito_forged_bytes))
-;;
-describe "pack" (fun { test; _ } ->
-    let open Pack in
-    let test name input output =
-      test name (fun { expect; _ } ->
-          let (`Hex result) = to_bytes input |> Hex.of_bytes in
-          (expect.string result).toEqual output) in
-    let int n = int (Z.of_int n) in
-    let bytes s = bytes (Bytes.of_string (Hex.to_string (`Hex s))) in
-    test "int(1)" (int 1) "050001";
-    test "int(-1)" (int (-1)) "050041";
-    test "bytes(0x)" (bytes "") "050a00000000";
-    test "bytes(0x050001)" (bytes "050001") "050a00000003050001";
-    test "pair(1, 0x)" (pair (int 1) (bytes "")) "05070700010a00000000";
-    test "pair(1, (0xAA, -1))"
-      (pair (int 1) (pair (bytes "AA") (int (-1))))
-      "050707000107070a00000001aa0041";
-    test "list([])" (list []) "050200000000";
-    test "list([1])" (list [int 1]) "0502000000020001";
-    test "list([(1, (0x, -1))])"
-      (list [pair (int 1) (pair (bytes "") (int (-1)))])
-      "05020000000d0707000107070a000000000041";
-    test "key(\"edpkvDqjL7aXdsXSiK5ChCMAfqaqmCFWCv7DaT3dK1egJt136WBiT6\")"
-      (key genesis_wallet)
-      "050a0000002100d00725159de904a28aaed9adb2320f95bd2117959e41c1c2377ac11045d18bd7";
-    test "key(\"sppk7aCim2kYBWGoEQGezcg8LbHi99XxrAE5dh6DDUru26pT93V2c5U\")"
-      (key TZ2_ex.pk)
-      "050a0000002201027643ad744d2e26125b38726114eadf9f5f75af61838e7dee1bb7dda9df1984fd";
-    test "key(\"p2pk67mCLEZ2iFivprKpjugLakXfahdq9VUqmiTho1fhtv9P3AeJoc7\")"
-      (key TZ3_ex.pk)
-      "050a000000220203a4242cde26340f1eb943956bf1209c5247c76ff4ddf51eb8cf050a70312c9c19";
-    test "key_hash(\"tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC\")"
-      (key_hash (Key_hash.of_key genesis_wallet))
-      "050a00000015000ec89608700c0414159d93552ef9361cea96da13";
-    test "key_hash(\"tz2LcShRoD1PHxUYHq2DyEUjayG1kfqeqLVD\")"
-      (key_hash (Key_hash.of_key TZ2_ex.pk))
-      "050a000000150186e2a0c1f9a83eb066b54c8a594b3af88445b395";
-    test "key_hash(\"tz3b8hJcRfJzz5ZNCTepE9kU1QnTrL8Acy3y\")"
-      (key_hash (Key_hash.of_key TZ3_ex.pk))
-      "050a0000001502a2645b31bbb34a3a070378905f2b03a823b63227";
-    test "address(\"tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC\")"
-      (address (Implicit (Key_hash.of_key genesis_wallet)))
-      "050a0000001600000ec89608700c0414159d93552ef9361cea96da13";
-    test "address(\"tz2LcShRoD1PHxUYHq2DyEUjayG1kfqeqLVD\")"
-      (address (Implicit (Key_hash.of_key TZ2_ex.pk)))
-      "050a00000016000186e2a0c1f9a83eb066b54c8a594b3af88445b395";
-    test "address(\"tz3b8hJcRfJzz5ZNCTepE9kU1QnTrL8Acy3y\")"
-      (address (Implicit (Key_hash.of_key TZ3_ex.pk)))
-      "050a000000160002a2645b31bbb34a3a070378905f2b03a823b63227";
-    test "address(\"KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc\")"
-      (address
-         (Originated { contract = some_contract_hash; entrypoint = None }))
-      "050a0000001601370027c6c8f3fbafda4f9bfd08b14f45e6a29ce300")
-;;
-describe "consensus" (fun { test; _ } ->
-    let open Helpers in
-    let open Deku.Consensus in
-    let hash_exn s = BLAKE2B.of_string s |> Option.get in
-    let key_hash_exn s = Key_hash.of_string s |> Option.get in
-    let address_exn s = Address.of_string s |> Option.get in
-    test "hash_validators" (fun { expect; _ } ->
-        let hash =
-          [
-            key_hash_exn "tz1XoDYhrUJT4HtskbEUrJusHtFHx6ZXcemd";
-            key_hash_exn "tz1R1XF4NnYkiCxcVphdLTYokQiyL38rtSQF";
-            key_hash_exn "tz1d6QHk2oFzrYYasZWof8BU26D7jXAXeajv";
-            key_hash_exn "tz1da6gqyddChGTwzW5aUA3Bia7DaAXmtqAE";
-          ]
-          |> hash_validators in
-        let hash = BLAKE2B.to_string hash in
-        (expect.string hash).toEqual
-          "6d6ecacbc858e3a89d87f0d9bd76b0c11b07aa95191129104395d17c6c96d36b");
-    test "hash_block" (fun { expect; _ } ->
-        let hash =
-          hash_block ~block_height:121L
-            ~block_payload_hash:
-              (hash_exn
-                 "2d92960a592c56de3046e200969c230a2eda71fc4b775e0cc09a189e5ddc5dbd")
-            ~state_root_hash:
-              (hash_exn
-                 "bdd051ddb07925a0d88dc27583e38ae560aa1b4429cc93b9ec35dacdbd74ffb2")
-            ~withdrawal_handles_hash:
-              (hash_exn
-                 "0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8")
-            ~validators_hash:
-              (hash_exn
-                 "546d2bb2375cc919efc81a103a7ad3bd1227546b320f275e357bd9a5d5eef946")
-        in
-        let hash = BLAKE2B.to_string hash in
-        (expect.string hash).toEqual
-          "7cb600c19817b899d4c28c521dd9ebf95f688e1444afe7d0e7740bebe848b030");
-    test "hash_withdraw_handle" (fun { expect; _ } ->
-        let hash =
-          hash_withdraw_handle ~id:(Z.of_int 0)
-            ~owner:(address_exn "tz1YywYq77UAMbVgoYndnZLkRawjUhX3nVh4")
-            ~amount:(Z.of_int 10)
-            ~ticketer:(address_exn "KT1AS9rCk1wpybsvZ5Tnd4yRxDvtN39uxMoq")
-            ~data:(Bytes.of_string "") in
-        let hash = BLAKE2B.to_string hash in
-        (expect.string hash).toEqual
-          "63dfd90ec7be98a9c23bf374692de4d36f41fe03c4c768fc0c650641d3ed4f86"))
-;;
-describe "discovery" (fun { test; _ } ->
-    let open Discovery in
-    let secret = genesis_key in
-    test "sign" (fun { expect; _ } ->
-        let signature =
-          sign secret ~nonce:1L (Uri.of_string "http://localhost") in
-        (expect.string (Signature.to_string signature)).toEqual
-          "edsigtpGEA7XKPKMFkFiEA6SfJaaha4Ai2XbteJG5FYvuMtMRyPnXRuZNi54P7BWvV6GaWTijf8EBjGb8MZZvdTrWCGFCVCXL7r"))
+
+let () =
+  describe "key" (fun { test; _ } ->
+      let open Key in
+      let edpk = genesis_wallet in
+      test "to_string" (fun { expect; _ } ->
+          (expect.string (to_string edpk)).toEqual
+            "edpkvDqjL7aXdsXSiK5ChCMAfqaqmCFWCv7DaT3dK1egJt136WBiT6";
+          (expect.string (to_string TZ2_ex.pk)).toEqual
+            "sppk7aCim2kYBWGoEQGezcg8LbHi99XxrAE5dh6DDUru26pT93V2c5U";
+          (expect.string (to_string TZ3_ex.pk)).toEqual
+            "p2pk67mCLEZ2iFivprKpjugLakXfahdq9VUqmiTho1fhtv9P3AeJoc7");
+      test "of_string" (fun { expect; _ } ->
+          (expect.option
+             (of_string "edpkvDqjL7aXdsXSiK5ChCMAfqaqmCFWCv7DaT3dK1egJt136WBiT6"))
+            .toBe
+            ~equals:Key.equal (Some edpk);
+          (expect.option
+             (of_string
+                "sppk7aCim2kYBWGoEQGezcg8LbHi99XxrAE5dh6DDUru26pT93V2c5U"))
+            .toBe
+            ~equals:Key.equal (Some TZ2_ex.pk);
+          (expect.option
+             (of_string
+                "p2pk67mCLEZ2iFivprKpjugLakXfahdq9VUqmiTho1fhtv9P3AeJoc7"))
+            .toBe
+            ~equals:Key.equal (Some TZ3_ex.pk));
+      test "invalid prefix" (fun { expect; _ } ->
+          (expect.option
+             (of_string "edpuvDqjL7aXdsXSiK5ChCMAfqaqmCFWCv7DaT3dK1egJt136WBiT6"))
+            .toBeNone
+            ();
+          (expect.option
+             (of_string
+                "sddk7aCim2kYBWGoEQGezcg8LbHi99XxrAE5dh6DDUru26pT93V2c5U"))
+            .toBeNone
+            ();
+          (expect.option
+             (of_string
+                "p3pk67mCLEZ2iFivprKpjugLakXfahdq9VUqmiTho1fhtv9P3AeJoc7"))
+            .toBeNone
+            ());
+      test "invalid checksum" (fun { expect; _ } ->
+          (expect.option
+             (of_string "edpkvDqjL7aXdsXSiK5ChCMAfqaqmCFWCv7DaT3dK1egJt136WBiT5"))
+            .toBeNone
+            ();
+          (expect.option
+             (of_string
+                "sppk7dCim2kYBWGoEQGezcg8LbHi99XxrAE5dh6DDUru26pT93V2c5U"))
+            .toBeNone
+            ();
+          (expect.option
+             (of_string
+                "p2pk67mCLEz2iFivprKpjugLakXfahdq9VUqmiTho1fhtv9P3AeJoc7"))
+            .toBeNone
+            ());
+      test "invalid size" (fun { expect; _ } ->
+          (expect.option
+             (of_string "edpkvDqjL7aXdsXSiK5ChCMAfqaqmCFWCv7DaT3dK1egJt136WBiT"))
+            .toBeNone
+            ();
+          (expect.option
+             (of_string "sppk7Cim2kYBWGoEQGezcg8LbHi99XxrAE5dh6DDUru26pT93V2c5U"))
+            .toBeNone
+            ();
+          (expect.option
+             (of_string "p2pk67mCLE2iFivprKpjugLakXfahdq9VUqmiTho1fhtv9P3AeJoc7"))
+            .toBeNone
+            ()))
+let () =
+  describe "key_hash" (fun { test; _ } ->
+      let open Key_hash in
+      let tz1 = of_key genesis_wallet in
+      let tz2 = of_key TZ2_ex.pk in
+      let tz3 = of_key TZ3_ex.pk in
+      test "to_string" (fun { expect; _ } ->
+          (expect.string (to_string tz1)).toEqual
+            "tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC";
+          (expect.string (to_string tz2)).toEqual
+            "tz2LcShRoD1PHxUYHq2DyEUjayG1kfqeqLVD";
+          (expect.string (to_string tz3)).toEqual
+            "tz3b8hJcRfJzz5ZNCTepE9kU1QnTrL8Acy3y");
+      test "of_string" (fun { expect; _ } ->
+          (expect.option (of_string "tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC"))
+            .toBe ~equals:Key_hash.equal (Some tz1);
+          (expect.option (of_string "tz2LcShRoD1PHxUYHq2DyEUjayG1kfqeqLVD"))
+            .toBe ~equals:Key_hash.equal (Some tz2);
+          (expect.option (of_string "tz3b8hJcRfJzz5ZNCTepE9kU1QnTrL8Acy3y"))
+            .toBe ~equals:Key_hash.equal (Some tz3));
+      test "invalid prefix" (fun { expect; _ } ->
+          (expect.option (of_string "tzaLzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC"))
+            .toBeNone ();
+          (expect.option (of_string "tz4LcShRoD1PHxUYHq2DyEUjayG1kfqeqLVD"))
+            .toBeNone ();
+          (expect.option (of_string "tzdb8hJcRfJzz5ZNCTepE9kU1QnTrL8Acy3y"))
+            .toBeNone ());
+      test "invalid checksum" (fun { expect; _ } ->
+          (expect.option (of_string "tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLA"))
+            .toBeNone ();
+          (expect.option (of_string "tz2LcrhRoD1PHxUYHq2DyEUjayG1kfqeqLVD"))
+            .toBeNone ();
+          (expect.option (of_string "tz3d8hJcRfJzz5ZNCTepE9kU1QnTrL8Acy3y"))
+            .toBeNone ());
+      test "invalid size" (fun { expect; _ } ->
+          (expect.option (of_string "tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCL"))
+            .toBeNone ();
+          (expect.option (of_string "tz2LcShRD1PHxUYHq2DyEUjayG1kfqeqLVD"))
+            .toBeNone ();
+          (expect.option (of_string "tz38hJcRfJzz5ZNCTepE9kU1QnTrL8Acy3y"))
+            .toBeNone ()))
+let () =
+  describe "secret" (fun { test; _ } ->
+      let open Secret in
+      let edsk = genesis_key in
+      let spsk = TZ2_ex.sk in
+      let p2sk = TZ3_ex.sk in
+      test "to_string" (fun { expect; _ } ->
+          (expect.string (to_string edsk)).toEqual
+            "edsk4bfbFdb4s2BdkW3ipfB23i9u82fgji6KT3oj2SCWTeHUthbSVd";
+          (expect.string (to_string spsk)).toEqual
+            "spsk3LfH15rYByf7whY9YNAxS5ghpjzCr96jZ16Jt4pv2mnshf8Tcy";
+          (expect.string (to_string p2sk)).toEqual
+            "p2sk2s8WFJdvL6J9JxY7R3tWwMnaqJotbcTFgXg3pSVNPvrxKL1AkQ");
+      test "of_string" (fun { expect; _ } ->
+          (expect.option
+             (of_string "edsk4bfbFdb4s2BdkW3ipfB23i9u82fgji6KT3oj2SCWTeHUthbSVd"))
+            .toBe
+            ~equals:Secret.equal (Some edsk);
+          (expect.option
+             (of_string "spsk3LfH15rYByf7whY9YNAxS5ghpjzCr96jZ16Jt4pv2mnshf8Tcy"))
+            .toBe
+            ~equals:Secret.equal (Some spsk);
+          (expect.option
+             (of_string "p2sk2s8WFJdvL6J9JxY7R3tWwMnaqJotbcTFgXg3pSVNPvrxKL1AkQ"))
+            .toBe
+            ~equals:Secret.equal (Some p2sk));
+      test "invalid prefix" (fun { expect; _ } ->
+          (expect.option
+             (of_string "edsa4bfbFdb4s2BdkW3ipfB23i9u82fgji6KT3oj2SCWTeHUthbSVd"))
+            .toBeNone
+            ();
+          (expect.option
+             (of_string "spdk3LfH15rYByf7whY9YNAxS5ghpjzCr96jZ16Jt4pv2mnshf8Tcy"))
+            .toBeNone
+            ();
+          (expect.option
+             (of_string "p3sk2s8WFJdvL6J9JxY7R3tWwMnaqJotbcTFgXg3pSVNPvrxKL1AkQ"))
+            .toBeNone
+            ());
+      test "invalid checksum" (fun { expect; _ } ->
+          (expect.option
+             (of_string "edsk4bfbFdb4s2BdkW3ipfB23i9u82fgji6KT3oj2SCWTeHUthbSVb"))
+            .toBeNone
+            ();
+          (expect.option
+             (of_string "spsk3LfH15dYByf7whY9YNAxS5ghpjzCr96jZ16Jt4pv2mnshf8Tcy"))
+            .toBeNone
+            ();
+          (expect.option
+             (of_string "p2sk3s8WFJdvL6J9JxY7R3tWwMnaqJotbcTFgXg3pSVNPvrxKL1AkQ"))
+            .toBeNone
+            ());
+      test "invalid size" (fun { expect; _ } ->
+          (expect.option
+             (of_string "edsk4bfbFdb4s2BdkW3ipfB23i9u82fgji6KT3oj2SCWTeHUthbSV"))
+            .toBeNone
+            ();
+          (expect.option
+             (of_string "spsk3LfH15YByf7whY9YNAxS5ghpjzCr96jZ16Jt4pv2mnshf8Tcy"))
+            .toBeNone
+            ();
+          (expect.option
+             (of_string "p2sk2s8wFJdvL6J9JxY7R3tWwMnaqJotbcTFgXg3pSVNPvrxKL1AkQ"))
+            .toBeNone
+            ()))
+let () =
+  describe "signature" (fun { test; _ } ->
+      let open BLAKE2B in
+      let open Signature in
+      let edpk = genesis_wallet in
+      let edsk = genesis_key in
+      let tuturu = hash "tuturu" in
+      let tuturu2 = hash "tuturu2" in
+      let edsig = sign edsk tuturu in
+      let sppk = TZ2_ex.pk in
+      let spsk = TZ2_ex.sk in
+      let spsig = sign spsk tuturu in
+      let p2pk = TZ3_ex.pk in
+      let p2sk = TZ3_ex.sk in
+      let p2sig = sign p2sk tuturu in
+      test "check" (fun { expect; _ } ->
+          (expect.bool (verify edpk edsig tuturu)).toBeTrue ();
+          (expect.bool (verify sppk spsig tuturu)).toBeTrue ();
+          (expect.bool (verify p2pk p2sig tuturu)).toBeTrue ());
+      test "invalid message" (fun { expect; _ } ->
+          (expect.bool (verify edpk edsig tuturu2)).toBeFalse ();
+          (expect.bool (verify sppk spsig tuturu2)).toBeFalse ();
+          (expect.bool (verify p2pk p2sig tuturu2)).toBeFalse ());
+      test "invalid key" (fun { expect; _ } ->
+          let secret, key =
+            let secret, key = Ed25519.generate () in
+            (Secret.Ed25519 secret, Key.Ed25519 key) in
+          let edsig_from_key = sign secret tuturu in
+          (expect.bool (verify key edsig_from_key tuturu)).toBeTrue ();
+          (expect.bool (verify edpk edsig_from_key tuturu)).toBeFalse ();
+          let secret, key =
+            let secret, key = Crypto.Secp256k1.generate () in
+            (Secret.Secp256k1 secret, Key.Secp256k1 key) in
+          let pksig_from_key = sign secret tuturu in
+          (expect.bool (verify key pksig_from_key tuturu)).toBeTrue ();
+          (expect.bool (verify sppk pksig_from_key tuturu)).toBeFalse ();
+          let secret, key =
+            let secret, key = Crypto.P256.generate () in
+            (Secret.P256 secret, Key.P256 key) in
+          let p2sig_from_key = sign secret tuturu in
+          (expect.bool (verify key p2sig_from_key tuturu)).toBeTrue ();
+          (expect.bool (verify p2pk p2sig_from_key tuturu)).toBeFalse ());
+      test "to_string" (fun { expect; _ } ->
+          (expect.string (to_string edsig)).toEqual
+            "edsigtp1tNe8hVhfn9QPoGaLyxqksCbRxk6w3wTjbMDyu4QckAyhMDwUQc3yDCjfSqFXeccLkRjE1c1Lbm71i7uhGZqx7V8nSq4";
+          (expect.string (to_string spsig)).toEqual
+            "spsig1ao4VRH1rAXpfUDT6B7y2ScbbM5RSP9ZRqtkKuKbE4Eo1QGAKqMVKieYtvFcUDUeqSpGWcqVMedfsfKr45yuQqWpz7Wgqh";
+          (expect.string (to_string p2sig)).toEqual
+            "p2sigt13usEEBey8JkpRCarwHnMUZ744xeAQFv65ZT5UZeNgoGaFDdFfw27MEGpGSSAdxpSyBdfBhkrtUf7cwHx6NQnCpjWbpo");
+      test "of_string" (fun { expect; _ } ->
+          (expect.option
+             (of_string
+                "edsigtp1tNe8hVhfn9QPoGaLyxqksCbRxk6w3wTjbMDyu4QckAyhMDwUQc3yDCjfSqFXeccLkRjE1c1Lbm71i7uhGZqx7V8nSq4"))
+            .toBe
+            ~equals:Signature.equal (Some edsig);
+          (expect.option
+             (of_string
+                "spsig1ao4VRH1rAXpfUDT6B7y2ScbbM5RSP9ZRqtkKuKbE4Eo1QGAKqMVKieYtvFcUDUeqSpGWcqVMedfsfKr45yuQqWpz7Wgqh"))
+            .toBe
+            ~equals:Signature.equal (Some spsig);
+          (expect.option
+             (of_string
+                "p2sigt13usEEBey8JkpRCarwHnMUZ744xeAQFv65ZT5UZeNgoGaFDdFfw27MEGpGSSAdxpSyBdfBhkrtUf7cwHx6NQnCpjWbpo"))
+            .toBe
+            ~equals:Signature.equal (Some p2sig));
+      test "invalid prefix" (fun { expect; _ } ->
+          (expect.option
+             (of_string
+                "edsiatp1tNe8hVhfn9QPoGaLyxqksCbRxk6w3wTjbMDyu4QckAyhMDwUQc3yDCjfSqFXeccLkRjE1c1Lbm71i7uhGZqx7V8nSq4"))
+            .toBeNone
+            ();
+          (expect.option
+             (of_string
+                "spsdg1ao4VRH1rAXpfUDT6B7y2ScbbM5RSP9ZRqtkKuKbE4Eo1QGAKqMVKieYtvFcUDUeqSpGWcqVMedfsfKr45yuQqWpz7Wgqh"))
+            .toBeNone
+            ();
+          (expect.option
+             (of_string
+                "p3sigt13usEEBey8JkpRCarwHnMUZ744xeAQFv65ZT5UZeNgoGaFDdFfw27MEGpGSSAdxpSyBdfBhkrtUf7cwHx6NQnCpjWbpo"))
+            .toBeNone
+            ());
+      test "invalid checksum" (fun { expect; _ } ->
+          (expect.option
+             (of_string
+                "edsigtp1tNe8hVhfn9QPoGaLyxqksCbRxk6w3wTjbMDyu4QckAyhMDwUQc3yDCjfSqFXeccLkRjE1c1Lbm71i7uhGZqx7V8nSq3"))
+            .toBeNone
+            ();
+          (expect.option
+             (of_string
+                "spsig1ao4VRH1rAXpaUDT6B7y2ScbbM5RSP9ZRqtkKuKbE4Eo1QGAKqMVKieYtvFcUDUeqSpGWcqVMedfsfKr45yuQqWpz7Wgqh"))
+            .toBeNone
+            ();
+          (expect.option
+             (of_string
+                "p2sigt13useEBey8JkpRCarwHnMUZ744xeAQFv65ZT5UZeNgoGaFDdFfw27MEGpGSSAdxpSyBdfBhkrtUf7cwHx6NQnCpjWbpo"))
+            .toBeNone
+            ());
+      test "invalid size" (fun { expect; _ } ->
+          (expect.option
+             (of_string
+                "edsigtp1tNe8hVhfn9QPoGaLyxqksCbRxk6w3wTjbMDyu4QckAyhMDwUQc3yDCjfSqFXeccLkRjE1c1Lbm71i7uhGZqx7V8nSq"))
+            .toBeNone
+            ();
+          (expect.option
+             (of_string
+                "spsig1ao4VRH1rAXpfUDT67y2ScbbM5RSP9ZRqtkKuKbE4Eo1QGAKqMVKieYtvFcUDUeqSpGWcqVMedfsfKr45yuQqWpz7Wgqh"))
+            .toBeNone
+            ();
+          (expect.option
+             (of_string
+                "p2sigt13usEEBeyJkpRCarwHnMUZ744xeAQFv65ZT5UZeNgoGaFDdFfw27MEGpGSSAdxpSyBdfBhkrtUf7cwHx6NQnCpjWbpo"))
+            .toBeNone
+            ()))
+let () =
+  describe "contract_hash" (fun { test; _ } ->
+      let open Contract_hash in
+      let kt1 = some_contract_hash in
+      test "to_string" (fun { expect; _ } ->
+          (expect.string (to_string kt1)).toEqual
+            "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc");
+      test "of_string" (fun { expect; _ } ->
+          (expect.option (of_string "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc"))
+            .toBe ~equals:Contract_hash.equal (Some kt1));
+      test "invalid prefix" (fun { expect; _ } ->
+          (expect.option (of_string "KT2Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc"))
+            .toBeNone ());
+      test "invalid checksum" (fun { expect; _ } ->
+          (expect.option (of_string "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTd"))
+            .toBeNone ());
+      test "invalid size" (fun { expect; _ } ->
+          (expect.option (of_string "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABT"))
+            .toBeNone ()))
+let () =
+  describe "address" (fun { test; _ } ->
+      let open Address in
+      let tz1 = Implicit (Key_hash.of_key genesis_wallet) in
+      let tz2 = Implicit (Key_hash.of_key TZ2_ex.pk) in
+      let tz3 = Implicit (Key_hash.of_key TZ3_ex.pk) in
+      let kt1 =
+        Originated { contract = some_contract_hash; entrypoint = None } in
+      let kt1_tuturu =
+        Originated { contract = some_contract_hash; entrypoint = Some "tuturu" }
+      in
+      test "to_string" (fun { expect; _ } ->
+          (expect.string (to_string tz1)).toEqual
+            "tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC";
+          (expect.string (to_string tz2)).toEqual
+            "tz2LcShRoD1PHxUYHq2DyEUjayG1kfqeqLVD";
+          (expect.string (to_string tz3)).toEqual
+            "tz3b8hJcRfJzz5ZNCTepE9kU1QnTrL8Acy3y";
+          (expect.string (to_string kt1)).toEqual
+            "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc";
+          (expect.string (to_string kt1_tuturu)).toEqual
+            "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc%tuturu");
+      test "of_string" (fun { expect; _ } ->
+          (expect.option (of_string "tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC"))
+            .toBe ~equals:Address.equal (Some tz1);
+          (expect.option (of_string "tz2LcShRoD1PHxUYHq2DyEUjayG1kfqeqLVD"))
+            .toBe ~equals:Address.equal (Some tz2);
+          (expect.option (of_string "tz3b8hJcRfJzz5ZNCTepE9kU1QnTrL8Acy3y"))
+            .toBe ~equals:Address.equal (Some tz3);
+          (expect.option (of_string "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc"))
+            .toBe ~equals:Address.equal (Some kt1);
+          (expect.option
+             (of_string "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc%tuturu"))
+            .toBe ~equals:Address.equal (Some kt1_tuturu);
+          (expect.option
+             (of_string "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc%default"))
+            .toBeNone ());
+      test "invalid prefix" (fun { expect; _ } ->
+          (expect.option (of_string "tz4LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC"))
+            .toBeNone ();
+          (expect.option (of_string "td2LcShRoD1PHxUYHq2DyEUjayG1kfqeqLVD"))
+            .toBeNone ();
+          (expect.option (of_string "tzab8hJcRfJzz5ZNCTepE9kU1QnTrL8Acy3y"))
+            .toBeNone ());
+      test "invalid checksum" (fun { expect; _ } ->
+          (expect.option (of_string "tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLd"))
+            .toBeNone ();
+          (expect.option (of_string "tz2LcShaoD1PHxUYHq2DyEUjayG1kfqeqLVD"))
+            .toBeNone ();
+          (expect.option (of_string "tz3b8hdcRfJzz5ZNCTepE9kU1QnTrL8Acy3y"))
+            .toBeNone ());
+      test "invalid size" (fun { expect; _ } ->
+          (expect.option (of_string "tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCL"))
+            .toBeNone ();
+          (expect.option (of_string "tz2LcShRoDPHxUYHq2DyEUjayG1kfqeqLVD"))
+            .toBeNone ();
+          (expect.option (of_string "tz3b8hJRfJzz5ZNCTepE9kU1QnTrL8Acy3y"))
+            .toBeNone ()))
+let () =
+  describe "ticket" (fun { test; _ } ->
+      let open Ticket_id in
+      let kt1 =
+        Address.Originated { contract = some_contract_hash; entrypoint = None }
+      in
+      let ticket = { ticketer = kt1; data = Bytes.of_string "a" } in
+      test "to_string" (fun { expect; _ } ->
+          (expect.string (to_string ticket)).toEqual
+            {|(Pair "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc" 0x61)|});
+      test "of_string" (fun { expect; _ } ->
+          (expect.option
+             (of_string {|(Pair "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc" 0x61)|}))
+            .toBe
+            ~equals:equal (Some ticket));
+      test "invalid address" (fun { expect; _ } ->
+          (expect.option
+             (of_string {|(Pair "BT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc" 0x61)|}))
+            .toBeNone
+            ());
+      test "invalid bytes" (fun { expect; _ } ->
+          (expect.option
+             (of_string {|(Pair "BT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc" 0x6Z)|}))
+            .toBeNone
+            ()))
+let () =
+  describe "operation_hash" (fun { test; _ } ->
+      let open Operation_hash in
+      let op =
+        of_string "opCAkifFMh1Ya2J4WhRHskaXc297ELtx32wnc2WzeNtdQHp7DW4"
+        |> Option.get in
+      test "to_string" (fun { expect; _ } ->
+          (expect.string (to_string op)).toEqual
+            "opCAkifFMh1Ya2J4WhRHskaXc297ELtx32wnc2WzeNtdQHp7DW4");
+      test "of_string" (fun { expect; _ } ->
+          (expect.option
+             (of_string {|opCAkifFMh1Ya2J4WhRHskaXc297ELtx32wnc2WzeNtdQHp7DW4|}))
+            .toBe
+            ~equals:Operation_hash.equal (Some op));
+      test "invalid prefix" (fun { expect; _ } ->
+          (expect.option
+             (of_string "obCAkifFMh1Ya2J4WhRHskaXc297ELtx32wnc2WzeNtdQHp7DW4"))
+            .toBeNone
+            ());
+      test "invalid checksum" (fun { expect; _ } ->
+          (expect.option
+             (of_string "opCAkifFMh1Ya2J4WhRHskaXc297ELtx32wnc2WzeNtdQHp7DW5"))
+            .toBeNone
+            ());
+      test "invalid size" (fun { expect; _ } ->
+          (expect.option
+             (of_string "opCAkifFMh1Ya2J4WhRHskaXc297ELtx32wnc2WzeNtdQHp7DW"))
+            .toBeNone
+            ()))
+let () =
+  describe "operation forging" (fun { test; _ } ->
+      let open Tezos in
+      let open Operation in
+      let forge_transaction ~branch ~fee ~gas_limit ~storage_limit ~amount
+          ~destination ~source ~counter ~secret ~entrypoint ~value =
+        let branch = Block_hash.of_string branch |> Option.get in
+        let fee = Tez.of_mutez fee |> Option.get in
+        let gas_limit = Gas.of_int gas_limit |> Option.get in
+        let storage_limit = Z.of_int storage_limit in
+        let amount = Tez.of_mutez amount |> Option.get in
+        let destination = Address.of_string destination |> Option.get in
+        let source = Key_hash.of_string source |> Option.get in
+        let counter = Z.of_int counter in
+        let secret = Secret.of_string secret |> Option.get in
+        let operation =
+          {
+            source;
+            fee;
+            counter;
+            content = Transaction { amount; destination; entrypoint; value };
+            gas_limit;
+            storage_limit;
+          } in
+        Tezos.Operation.forge ~secret ~branch ~operations:[operation] in
+      test "same result as taquito" (fun { expect; _ } ->
+          let forged_bytes =
+            forge_transaction
+              ~branch:"BLBQQXyZ1qTwxZiT5FkJwvKj4YnCmx6xhqnhgaZg1Z13aQDJiCk"
+              ~fee:443L ~gas_limit:1520 ~storage_limit:0 ~amount:2000000L
+              ~destination:"tz1ULf5uGJXefx8c8iLfHfuW1doMPpVicg7u"
+              ~source:"tz1M6iKVFN8RhHjVSL3oF75nF2FJ1yMkrk5t" ~counter:3305389
+              ~secret:"edsk4RbgwutwsEdVNuJsE5JDsxeJ6qFcG8F5rKFGnj5finT6FV46sd"
+              ~entrypoint:"default" ~value:Michelson.unit in
+          let taquito_forged_bytes =
+            "3d95683f0d29a6deb044f4ecd86efd9cbae6b373b7b9d7c2db16456783e664566c001004051072b588b39e25b9f4dbf4673abcd63147bb03addfc901f00b0080897a00005f70062003e798791cb04f51bcec1d3358ac64a600468a797b657cff8b585c18cb599443d7c0982220cfa9231270138c7a3e0996d8ea42a2912d51c44681877b2d3a3e8051ebd1498305f8f73cf68967f60349fc00"
+          in
+          (expect.string forged_bytes).toEqual taquito_forged_bytes);
+      test "parameter unit and entrypoint default" (fun { expect; _ } ->
+          let forged_bytes =
+            forge_transaction
+              ~branch:"BMb1r7vPdSkTb8ACDpuk4vKXPqEm6knqKjEzqpNj8Prxb2KWMP3"
+              ~fee:420L ~gas_limit:1303 ~storage_limit:0 ~amount:0L
+              ~destination:"KT1GAr6WWLeavRVHgxEJq1F7tNLzavCLu9YB"
+              ~source:"tz1M6iKVFN8RhHjVSL3oF75nF2FJ1yMkrk5t" ~counter:3305396
+              ~secret:"edsk4RbgwutwsEdVNuJsE5JDsxeJ6qFcG8F5rKFGnj5finT6FV46sd"
+              ~entrypoint:"default" ~value:Michelson.unit in
+          let taquito_forged_bytes =
+            "f6e43992b2f45aedbfdc7f5f6a21aa68c99973afffa0ddbe8b98e33672dec6396c001004051072b588b39e25b9f4dbf4673abcd63147a403b4dfc901970a000001533ace00d71497d23fdac2a8809bb1e9df14c579000048a432efc5ef0e700c2f696957996e90194787995d43826b18ade1823d05857f35787f4e7a223d3ea226f22b1809ee56a9046bd313f547e3746fb46bc8ed3803"
+          in
+          (expect.string forged_bytes).toEqual taquito_forged_bytes))
+let () =
+  describe "pack" (fun { test; _ } ->
+      let open Pack in
+      let test name input output =
+        test name (fun { expect; _ } ->
+            let (`Hex result) = to_bytes input |> Hex.of_bytes in
+            (expect.string result).toEqual output) in
+      let int n = int (Z.of_int n) in
+      let bytes s = bytes (Bytes.of_string (Hex.to_string (`Hex s))) in
+      test "int(1)" (int 1) "050001";
+      test "int(-1)" (int (-1)) "050041";
+      test "bytes(0x)" (bytes "") "050a00000000";
+      test "bytes(0x050001)" (bytes "050001") "050a00000003050001";
+      test "pair(1, 0x)" (pair (int 1) (bytes "")) "05070700010a00000000";
+      test "pair(1, (0xAA, -1))"
+        (pair (int 1) (pair (bytes "AA") (int (-1))))
+        "050707000107070a00000001aa0041";
+      test "list([])" (list []) "050200000000";
+      test "list([1])" (list [int 1]) "0502000000020001";
+      test "list([(1, (0x, -1))])"
+        (list [pair (int 1) (pair (bytes "") (int (-1)))])
+        "05020000000d0707000107070a000000000041";
+      test "key(\"edpkvDqjL7aXdsXSiK5ChCMAfqaqmCFWCv7DaT3dK1egJt136WBiT6\")"
+        (key genesis_wallet)
+        "050a0000002100d00725159de904a28aaed9adb2320f95bd2117959e41c1c2377ac11045d18bd7";
+      test "key(\"sppk7aCim2kYBWGoEQGezcg8LbHi99XxrAE5dh6DDUru26pT93V2c5U\")"
+        (key TZ2_ex.pk)
+        "050a0000002201027643ad744d2e26125b38726114eadf9f5f75af61838e7dee1bb7dda9df1984fd";
+      test "key(\"p2pk67mCLEZ2iFivprKpjugLakXfahdq9VUqmiTho1fhtv9P3AeJoc7\")"
+        (key TZ3_ex.pk)
+        "050a000000220203a4242cde26340f1eb943956bf1209c5247c76ff4ddf51eb8cf050a70312c9c19";
+      test "key_hash(\"tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC\")"
+        (key_hash (Key_hash.of_key genesis_wallet))
+        "050a00000015000ec89608700c0414159d93552ef9361cea96da13";
+      test "key_hash(\"tz2LcShRoD1PHxUYHq2DyEUjayG1kfqeqLVD\")"
+        (key_hash (Key_hash.of_key TZ2_ex.pk))
+        "050a000000150186e2a0c1f9a83eb066b54c8a594b3af88445b395";
+      test "key_hash(\"tz3b8hJcRfJzz5ZNCTepE9kU1QnTrL8Acy3y\")"
+        (key_hash (Key_hash.of_key TZ3_ex.pk))
+        "050a0000001502a2645b31bbb34a3a070378905f2b03a823b63227";
+      test "address(\"tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC\")"
+        (address (Implicit (Key_hash.of_key genesis_wallet)))
+        "050a0000001600000ec89608700c0414159d93552ef9361cea96da13";
+      test "address(\"tz2LcShRoD1PHxUYHq2DyEUjayG1kfqeqLVD\")"
+        (address (Implicit (Key_hash.of_key TZ2_ex.pk)))
+        "050a00000016000186e2a0c1f9a83eb066b54c8a594b3af88445b395";
+      test "address(\"tz3b8hJcRfJzz5ZNCTepE9kU1QnTrL8Acy3y\")"
+        (address (Implicit (Key_hash.of_key TZ3_ex.pk)))
+        "050a000000160002a2645b31bbb34a3a070378905f2b03a823b63227";
+      test "address(\"KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc\")"
+        (address
+           (Originated { contract = some_contract_hash; entrypoint = None }))
+        "050a0000001601370027c6c8f3fbafda4f9bfd08b14f45e6a29ce300")
+let () =
+  describe "consensus" (fun { test; _ } ->
+      let open Helpers in
+      let open Deku.Consensus in
+      let hash_exn s = BLAKE2B.of_string s |> Option.get in
+      let key_hash_exn s = Key_hash.of_string s |> Option.get in
+      let address_exn s = Address.of_string s |> Option.get in
+      test "hash_validators" (fun { expect; _ } ->
+          let hash =
+            [
+              key_hash_exn "tz1XoDYhrUJT4HtskbEUrJusHtFHx6ZXcemd";
+              key_hash_exn "tz1R1XF4NnYkiCxcVphdLTYokQiyL38rtSQF";
+              key_hash_exn "tz1d6QHk2oFzrYYasZWof8BU26D7jXAXeajv";
+              key_hash_exn "tz1da6gqyddChGTwzW5aUA3Bia7DaAXmtqAE";
+            ]
+            |> hash_validators in
+          let hash = BLAKE2B.to_string hash in
+          (expect.string hash).toEqual
+            "6d6ecacbc858e3a89d87f0d9bd76b0c11b07aa95191129104395d17c6c96d36b");
+      test "hash_block" (fun { expect; _ } ->
+          let hash =
+            hash_block ~block_height:121L
+              ~block_payload_hash:
+                (hash_exn
+                   "2d92960a592c56de3046e200969c230a2eda71fc4b775e0cc09a189e5ddc5dbd")
+              ~state_root_hash:
+                (hash_exn
+                   "bdd051ddb07925a0d88dc27583e38ae560aa1b4429cc93b9ec35dacdbd74ffb2")
+              ~withdrawal_handles_hash:
+                (hash_exn
+                   "0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8")
+              ~validators_hash:
+                (hash_exn
+                   "546d2bb2375cc919efc81a103a7ad3bd1227546b320f275e357bd9a5d5eef946")
+          in
+          let hash = BLAKE2B.to_string hash in
+          (expect.string hash).toEqual
+            "7cb600c19817b899d4c28c521dd9ebf95f688e1444afe7d0e7740bebe848b030");
+      test "hash_withdraw_handle" (fun { expect; _ } ->
+          let hash =
+            hash_withdraw_handle ~id:(Z.of_int 0)
+              ~owner:(address_exn "tz1YywYq77UAMbVgoYndnZLkRawjUhX3nVh4")
+              ~amount:(Z.of_int 10)
+              ~ticketer:(address_exn "KT1AS9rCk1wpybsvZ5Tnd4yRxDvtN39uxMoq")
+              ~data:(Bytes.of_string "") in
+          let hash = BLAKE2B.to_string hash in
+          (expect.string hash).toEqual
+            "63dfd90ec7be98a9c23bf374692de4d36f41fe03c4c768fc0c650641d3ed4f86"))
+let () =
+  describe "discovery" (fun { test; _ } ->
+      let open Discovery in
+      let secret = genesis_key in
+      test "sign" (fun { expect; _ } ->
+          let signature =
+            sign secret ~nonce:1L (Uri.of_string "http://localhost") in
+          (expect.string (Signature.to_string signature)).toEqual
+            "edsigtpGEA7XKPKMFkFiEA6SfJaaha4Ai2XbteJG5FYvuMtMRyPnXRuZNi54P7BWvV6GaWTijf8EBjGb8MZZvdTrWCGFCVCXL7r"))

--- a/tests/test_validators.ml
+++ b/tests/test_validators.ml
@@ -1,78 +1,79 @@
 open Setup
 open Protocol
-open Validators;;
-describe "validators" (fun { test; _ } ->
-    let make_validator () =
-      let open Crypto in
-      let _key, wallet = Ed25519.generate () in
-      let address = Key_hash.of_key (Ed25519 wallet) in
-      let open Validators in
-      { address } in
-    let setup_two () =
-      let a = make_validator () in
-      let b = make_validator () in
-      let t = empty |> add a |> add b in
-      (t, a, b) in
-    test "empty" (fun { expect; _ } ->
-        let t = empty in
-        expect.equal (current t) None;
-        expect.equal (to_list t) [];
-        expect.equal (length t) 0);
-    test "add" (fun { expect; _ } ->
+open Validators
+let () =
+  describe "validators" (fun { test; _ } ->
+      let make_validator () =
+        let open Crypto in
+        let _key, wallet = Ed25519.generate () in
+        let address = Key_hash.of_key (Ed25519 wallet) in
+        let open Validators in
+        { address } in
+      let setup_two () =
         let a = make_validator () in
-        let t = empty |> add a in
-        expect.equal (current t) (Some a);
-        expect.equal (to_list t) [a];
-        expect.equal (length t) 1;
         let b = make_validator () in
-        let t = t |> add b in
-        expect.equal (current t) (Some a);
-        expect.equal (to_list t) [a; b];
-        expect.equal (length t) 2);
-    test "remove" (fun { expect; _ } ->
-        (let t, a, b = setup_two () in
-         let t = t |> remove b in
-         expect.equal (current t) (Some a);
-         expect.equal (to_list t) [a];
-         expect.equal (length t) 1;
-         let t = t |> remove a in
-         expect.equal t empty);
-        (let t, a, b = setup_two () in
-         let t = t |> remove a in
-         expect.equal (current t) (Some b);
-         expect.equal (to_list t) [b];
-         expect.equal (length t) 1;
-         let t = t |> remove b in
-         expect.equal t empty);
-        (let t, _, _ = setup_two () in
-         let unknown = make_validator () in
-         expect.equal (remove unknown t) t);
-        ());
-    test "after_current" (fun { expect; _ } ->
-        expect.equal (after_current 0 empty) None;
-        expect.equal (after_current 1 empty) None;
-        expect.equal (after_current (-1) empty) None;
-        let t, a, b = setup_two () in
-        let c = make_validator () in
-        let t = t |> add c in
-        expect.equal (current t) (Some a);
-        expect.equal (to_list t) [a; b; c];
-        expect.equal (length t) 3;
-        expect.equal (after_current 0 t) (Some a);
-        expect.equal (after_current 1 t) (Some b);
-        expect.equal (after_current 2 t) (Some c);
-        expect.equal (after_current 3 t) (Some a);
-        expect.equal (after_current 4 t) (Some b);
-        expect.equal (after_current (-1) t) (Some c);
-        expect.equal (after_current (-2) t) (Some b);
-        expect.equal (after_current (-3) t) (Some a);
-        expect.equal (after_current (-4) t) (Some c));
-    test "update_current" (fun { expect; _ } ->
-        let t, a, b = setup_two () in
-        expect.equal (current t) (Some a);
-        let t = update_current b.address t in
-        expect.equal (current t) (Some b);
-        expect.equal (update_current b.address t) t;
-        let unknown = make_validator () in
-        expect.equal (update_current unknown.address t |> current) None;
-        ()))
+        let t = empty |> add a |> add b in
+        (t, a, b) in
+      test "empty" (fun { expect; _ } ->
+          let t = empty in
+          expect.equal (current t) None;
+          expect.equal (to_list t) [];
+          expect.equal (length t) 0);
+      test "add" (fun { expect; _ } ->
+          let a = make_validator () in
+          let t = empty |> add a in
+          expect.equal (current t) (Some a);
+          expect.equal (to_list t) [a];
+          expect.equal (length t) 1;
+          let b = make_validator () in
+          let t = t |> add b in
+          expect.equal (current t) (Some a);
+          expect.equal (to_list t) [a; b];
+          expect.equal (length t) 2);
+      test "remove" (fun { expect; _ } ->
+          (let t, a, b = setup_two () in
+           let t = t |> remove b in
+           expect.equal (current t) (Some a);
+           expect.equal (to_list t) [a];
+           expect.equal (length t) 1;
+           let t = t |> remove a in
+           expect.equal t empty);
+          (let t, a, b = setup_two () in
+           let t = t |> remove a in
+           expect.equal (current t) (Some b);
+           expect.equal (to_list t) [b];
+           expect.equal (length t) 1;
+           let t = t |> remove b in
+           expect.equal t empty);
+          (let t, _, _ = setup_two () in
+           let unknown = make_validator () in
+           expect.equal (remove unknown t) t);
+          ());
+      test "after_current" (fun { expect; _ } ->
+          expect.equal (after_current 0 empty) None;
+          expect.equal (after_current 1 empty) None;
+          expect.equal (after_current (-1) empty) None;
+          let t, a, b = setup_two () in
+          let c = make_validator () in
+          let t = t |> add c in
+          expect.equal (current t) (Some a);
+          expect.equal (to_list t) [a; b; c];
+          expect.equal (length t) 3;
+          expect.equal (after_current 0 t) (Some a);
+          expect.equal (after_current 1 t) (Some b);
+          expect.equal (after_current 2 t) (Some c);
+          expect.equal (after_current 3 t) (Some a);
+          expect.equal (after_current 4 t) (Some b);
+          expect.equal (after_current (-1) t) (Some c);
+          expect.equal (after_current (-2) t) (Some b);
+          expect.equal (after_current (-3) t) (Some a);
+          expect.equal (after_current (-4) t) (Some c));
+      test "update_current" (fun { expect; _ } ->
+          let t, a, b = setup_two () in
+          expect.equal (current t) (Some a);
+          let t = update_current b.address t in
+          expect.equal (current t) (Some b);
+          expect.equal (update_current b.address t) t;
+          let unknown = make_validator () in
+          expect.equal (update_current unknown.address t |> current) None;
+          ()))


### PR DESCRIPTION
## Depends

- [x] #476

## Problem

`reason_to_ocaml.sh` generates `;;` everywhere. But I think that's kind of unidiomatic - it would be better to use `let () = ` in most cases. 

## Solution

Convert every usage of `;;` to `let () = `
 