### PR TITLE
chore: rename sidecli to deku-cli

### DIFF
--- a/docker/static.Dockerfile
+++ b/docker/static.Dockerfile
@@ -22,9 +22,9 @@ RUN esy build
 RUN esy build_static
 
 # Copy the static binaries to a known location
-RUN esy cp "#{self.target_dir / 'default' / 'src' / 'bin' / 'sidecli.exe'}" sidecli.exe && \
+RUN esy cp "#{self.target_dir / 'default' / 'src' / 'bin' / 'deku_cli.exe'}" deku_cli.exe && \
     esy cp "#{self.target_dir / 'default' / 'src' / 'bin' / 'deku_node.exe'}" deku_node.exe
-RUN strip ./deku_node.exe && strip ./sidecli.exe
+RUN strip ./deku_node.exe && strip ./deku_cli.exe
 
 FROM scratch as runtime
 
@@ -37,7 +37,7 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 WORKDIR /app
 
 COPY --from=builder /app/deku_node.exe deku_node.exe
-COPY --from=builder /app/sidecli.exe sidecli.exe
+COPY --from=builder /app/deku_cli.exe deku_cli.exe
 
 ENTRYPOINT ["/app/deku_node.exe"]
 CMD ["/app/data"]

--- a/esy.json
+++ b/esy.json
@@ -3,7 +3,7 @@
   "esy": {
     "build": "dune build -p #{self.name}",
     "release": {
-      "bin": ["sidecli", "deku-node"]
+      "bin": ["deku-cli", "deku-node"]
     },
     "buildEnv": {
       "PATH": "%{localStore}%/../bin:$PATH"

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -12,9 +12,9 @@ SECRET_KEY="edsk3QoqBuvdamxouPhin7swCvkQNgq4jP5KZPbwWNnwdZpSpJiEbq"
 
 DATA_DIRECTORY="data"
 
-sidecli() {
-  SIDECLI=$(esy x which sidecli)
-  eval $SIDECLI '"$@"'
+deku_cli() {
+  DEKU_CLI=$(esy x which deku-cli)
+  eval $DEKU_CLI '"$@"'
 }
 
 tezos-client() {
@@ -79,10 +79,10 @@ create_new_deku_environment() {
     FOLDER="$DATA_DIRECTORY/$i"
     mkdir -p $FOLDER
 
-    sidecli setup-identity $FOLDER --uri "http://localhost:444$i"
-    KEY=$(sidecli self $FOLDER | grep "key:" | awk '{ print $2 }')
-    ADDRESS=$(sidecli self $FOLDER | grep "address:" | awk '{ print $2 }')
-    URI=$(sidecli self $FOLDER | grep "uri:" | awk '{ print $2 }')
+    deku_cli setup-identity $FOLDER --uri "http://localhost:444$i"
+    KEY=$(deku_cli self $FOLDER | grep "key:" | awk '{ print $2 }')
+    ADDRESS=$(deku_cli self $FOLDER | grep "address:" | awk '{ print $2 }')
+    URI=$(deku_cli self $FOLDER | grep "uri:" | awk '{ print $2 }')
     VALIDATORS[$i]="$i;$KEY;$URI;$ADDRESS"
   done
 
@@ -146,7 +146,7 @@ EOF
     i=$(echo $VALIDATOR | awk -F';' '{ print $1 }')
     FOLDER="$DATA_DIRECTORY/$i"
 
-    sidecli setup-tezos "$FOLDER" \
+    deku_cli setup-tezos "$FOLDER" \
       --tezos_consensus_contract="$TEZOS_CONSENSUS_ADDRESS" \
       --tezos_rpc_node=$RPC_NODE \
       --tezos_secret="$SECRET_KEY" \

--- a/src/bin/deku_cli.ml
+++ b/src/bin/deku_cli.ml
@@ -6,6 +6,7 @@ open Protocol
 open Cmdliner
 open Core
 open Bin_common;;
+
 Printexc.record_backtrace true
 let read_validators ~node_folder =
   Files.Validators.read ~file:(node_folder ^ "/validators.json")
@@ -473,7 +474,7 @@ let show_help =
   let exits = Term.default_exits in
   ( (let open Term in
     ret (const (`Help (`Pager, None)))),
-    Term.info "sidecli" ~version:"v0.0.1" ~doc ~sdocs ~exits ~man )
+    Term.info "deku-cli" ~version:"v0.0.1" ~doc ~sdocs ~exits ~man )
 let info_self =
   let doc = "Shows identity key and address of the node." in
   Term.info "self" ~version:"%\226\128\140%VERSION%%" ~doc ~exits ~man
@@ -483,6 +484,7 @@ let self node_folder =
   Format.printf "address: %s\n" (Key_hash.to_string identity.t);
   Format.printf "uri: %s\n" (Uri.to_string identity.uri);
   await (`Ok ())
+
 let self =
   let folder_dest =
     let docv = "folder_dest" in

--- a/src/bin/dune
+++ b/src/bin/dune
@@ -7,10 +7,10 @@
   (pps ppx_deriving.show ppx_deriving_yojson ppx_let_binding)))
 
 (executable
- (name sidecli)
+ (name deku_cli)
  (libraries node bin_common helpers cmdliner)
- (modules Sidecli)
- (public_name sidecli)
+ (modules Deku_cli)
+ (public_name deku-cli)
  (preprocess
   (pps ppx_deriving_yojson ppx_let_binding)))
 

--- a/start.sh
+++ b/start.sh
@@ -6,9 +6,9 @@ data_directory="data"
 LD_LIBRARY_PATH=$(esy x sh -c 'echo $LD_LIBRARY_PATH')
 export LD_LIBRARY_PATH
 
-SIDECLI=$(esy x which sidecli)
-sidecli () {
-  eval $SIDECLI '"$@"'
+DEKU_CLI=$(esy x which deku-cli)
+deku_cli () {
+  eval $DEKU_CLI '"$@"'
 }
 
 DEKU_NODE=$(esy x which deku-node)
@@ -27,13 +27,13 @@ done
 sleep 1
 
 echo "Producing a block"
-HASH=$(sidecli produce-block "$data_directory/0" | awk '{ print $2 }')
+HASH=$(deku_cli produce-block "$data_directory/0" | awk '{ print $2 }')
 
 sleep 0.1
 
 echo "Signing"
 for i in ${VALIDATORS[@]}; do
-  sidecli sign-block "$data_directory/$i" $HASH
+  deku_cli sign-block "$data_directory/$i" $HASH
 done
 
 for PID in ${SERVERS[@]}; do


### PR DESCRIPTION
## Problem

The name of Deku's CLI is outdated.

## Solution

This follows the name from `deku-node` and renames `sidecli` to `deku-cli`.