### PR TITLE
Testing for Lambda VM

### DIFF
--- a/src/lambda_vm/compiler.ml
+++ b/src/lambda_vm/compiler.ml
@@ -29,7 +29,8 @@ let compile_prim prim =
 module Vars = Map_with_cardinality.Make (String)
 
 let burn_gas gas vars code =
-  (match code with
+  check_gas gas;
+  match code with
   | Var _
   | Lam _ ->
     let cardinality = Vars.cardinal vars in
@@ -39,8 +40,7 @@ let burn_gas gas vars code =
   | Prim _
   | If _
   | Pair _ ->
-    Gas.burn_constant gas);
-  check_gas gas
+    Gas.burn_constant gas
 
 let rec compile_expr ~stack gas next_ident vars code =
   let stack = stack - 1 in
@@ -105,8 +105,8 @@ let compile gas script =
   | Error error -> Error error
 
 let burn_gas gas =
-  Gas.burn_constant gas;
-  check_gas gas
+  check_gas gas;
+  Gas.burn_constant gas
 
 let rec compile_value ~stack gas value =
   let compile_value value = compile_value ~stack:(stack - 1) gas value in

--- a/src/lambda_vm/dune
+++ b/src/lambda_vm/dune
@@ -1,3 +1,5 @@
 (library
  (name lambda_vm)
- (modules_without_implementation ir ast))
+ (modules_without_implementation ast)
+ (preprocess
+  (pps ppx_deriving.show)))

--- a/src/lambda_vm/ident.ml
+++ b/src/lambda_vm/ident.ml
@@ -4,3 +4,7 @@ type t = int
 let compare = Int.compare
 let initial = 0
 let next t = t + 1
+
+let to_string = string_of_int
+
+let pp fmt t = Format.pp_print_string fmt (to_string t)

--- a/src/lambda_vm/ident.mli
+++ b/src/lambda_vm/ident.mli
@@ -3,3 +3,7 @@ type t
 val compare : t -> t -> int
 val initial : t
 val next : t -> t
+
+val to_string : t -> string
+
+val pp : Format.formatter -> t -> unit

--- a/src/lambda_vm/interpreter.ml
+++ b/src/lambda_vm/interpreter.ml
@@ -54,7 +54,8 @@ end
 module Env = Map_with_cardinality.Make (Ident)
 
 let burn_gas gas env code =
-  (match code with
+  check_gas gas;
+  match code with
   | E_var _
   | E_app _ ->
     let cardinality = Env.cardinal env in
@@ -64,8 +65,7 @@ let burn_gas gas env code =
   | E_prim _
   | E_if _
   | E_pair _ ->
-    Gas.burn_constant gas);
-  check_gas gas
+    Gas.burn_constant gas
 
 let eval_prim prim ~arg ~args =
   let op1_int64 f =
@@ -137,7 +137,8 @@ let rec eval ~stack gas env code =
     match Env.find var env with
     | Some value -> value
     | None ->
-      (* TODO: could we eliminate this using GADTs? *) raise Undefined_variable)
+      (* TODO: could we eliminate this using GADTs? *)
+      raise Undefined_variable)
   | E_lam (param, body) -> V_closure { env; param; body }
   | E_app { funct; arg } -> (
     let funct = eval_call env funct in
@@ -165,6 +166,7 @@ let rec eval ~stack gas env code =
     let first = eval_call env first in
     let second = eval_call env second in
     V_pair { first; second }
+
 let eval gas env code =
   let stack = max_stack_depth in
   eval ~stack gas env code

--- a/src/lambda_vm/ir.ml
+++ b/src/lambda_vm/ir.ml
@@ -1,5 +1,7 @@
 type ident = Ident.t
 
+let pp_ident = Ident.pp
+
 type prim =
   | P_neg
   | P_add
@@ -15,6 +17,13 @@ type prim =
   | P_asr
   | P_fst
   | P_snd
+[@@deriving show]
+
+module Env = struct
+  include Map_with_cardinality.Make (Ident)
+
+  let pp _ fmt _ = Format.fprintf fmt "<env>"
+end
 
 type expr =
   (* calculus *)
@@ -39,6 +48,7 @@ type expr =
       first : expr;
       second : expr;
     }
+[@@deriving show]
 
 type value =
   | V_int64     of int64
@@ -47,7 +57,7 @@ type value =
       second : value;
     }
   | V_closure   of {
-      env : env;
+      env : value Env.t;
       param : Ident.t;
       body : expr;
     }
@@ -55,7 +65,7 @@ type value =
       args : value list;
       prim : prim;
     }
-and env = value Map_with_cardinality.Make(Ident).t
+[@@deriving show]
 
 type script = {
   param : Ident.t;

--- a/src/lambda_vm/lambda_vm.ml
+++ b/src/lambda_vm/lambda_vm.ml
@@ -1,12 +1,17 @@
 module Ast = Ast
 module Gas = Gas
 
+include Checks
+
 type script = Ir.script
 type value = Ir.value
+
+let pp_value = Ir.pp_value
 
 type compile_error = Compiler.error =
   (* user program bugs *)
   | Undefined_variable
+[@@deriving show]
 
 include Compiler
 
@@ -19,5 +24,6 @@ type execution_error = Interpreter.error =
   | Value_is_not_int64
   | Value_is_not_function
   | Value_is_not_zero
+[@@deriving show]
 
 include Interpreter

--- a/src/lambda_vm/lambda_vm.mli
+++ b/src/lambda_vm/lambda_vm.mli
@@ -1,13 +1,19 @@
 module Ast = Ast
 module Gas : module type of Gas
 
+exception Out_of_stack
+exception Out_of_gas
+
 (* ir *)
 type script
 type value
 
+val pp_value : Format.formatter -> value -> unit
+
 (* compiler *)
 type compile_error = (* user program bugs *)
   | Undefined_variable
+[@@deriving show]
 
 val compile : Gas.t -> Ast.script -> (script, compile_error) result
 val compile_value : Gas.t -> Ast.value -> (value, compile_error) result
@@ -22,6 +28,7 @@ type execution_error =
   | Value_is_not_int64
   | Value_is_not_function
   | Value_is_not_zero
+[@@deriving show]
 
 type script_result = {
   storage : value;

--- a/tests/vm/dune
+++ b/tests/vm/dune
@@ -1,0 +1,5 @@
+(test
+ (name test_vm)
+ (libraries lambda_vm alcotest qcheck-alcotest)
+ (preprocess
+  (pps ppx_lambda_vm)))

--- a/tests/vm/test_errors.ml
+++ b/tests/vm/test_errors.ml
@@ -1,0 +1,117 @@
+open Lambda_vm
+
+module Testable = Vm_test.Testable
+
+let check_execution_error result expected_error =
+  let open Vm_test in
+  match result with
+  | Error (Execution_error error) ->
+    Alcotest.(check Testable.execution_error) "Same error" expected_error error
+  | Ok _ -> Alcotest.fail "Ast shouldn't execute"
+  | Error (Compilation_error error) ->
+    Alcotest.failf "%a" pp_compile_error error
+
+let check_compilation_error result expected_error =
+  let open Vm_test in
+  match result with
+  | Error (Compilation_error error) ->
+    Alcotest.(check Testable.compilation_error)
+      "Same error" expected_error error
+  | Ok _ -> Alcotest.fail "Ast shouldn't execute"
+  | Error (Execution_error error) ->
+    Alcotest.failf "%a" pp_execution_error error
+
+let test_compilation_undefined_variable () =
+  let script = [%lambda_vm.script fun _ -> x] in
+  check_compilation_error
+    (Vm_test.execute_ast 2000 (Int64 0L) script)
+    Undefined_variable
+
+let test_fst_value_is_not_pair () =
+  let script = [%lambda_vm.script fun _ -> (fst 1L, (0L, 0L))] in
+  check_execution_error
+    (Vm_test.execute_ast 1201 (Int64 0L) script)
+    Value_is_not_pair
+
+let test_snd_value_is_not_pair () =
+  let script = [%lambda_vm.script fun _ -> (snd 1L, (0L, 0L))] in
+  check_execution_error
+    (Vm_test.execute_ast 1201 (Int64 0L) script)
+    Value_is_not_pair
+
+let test_neg_value_is_not_int64 () =
+  let script = [%lambda_vm.script fun _ -> (not (0L, 0L), (0L, 0L))] in
+  check_execution_error
+    (Vm_test.execute_ast 1601 (Int64 0L) script)
+    Value_is_not_int64
+
+let test_op2_value_is_not_int64 () =
+  let script = [%lambda_vm.script fun _ -> ((0L, 0L) + 0L, (0L, 0L))] in
+  check_execution_error
+    (Vm_test.execute_ast 2001 (Int64 0L) script)
+    Value_is_not_int64
+
+let test_if_value_is_not_int64 () =
+  let script =
+    [%lambda_vm.script fun _ -> if (0L, 0L) then 1L else (1L, (0L, 0L))] in
+  check_execution_error
+    (Vm_test.execute_ast 1601 (Int64 0L) script)
+    Value_is_not_int64
+
+let test_value_is_not_function () =
+  let script = [%lambda_vm.script fun _ -> (0L 0L, (0L, 0L))] in
+  check_execution_error
+    (Vm_test.execute_ast 1201 (Int64 0L) script)
+    Value_is_not_function
+
+let test_pattern1_value_is_not_pair () =
+  let script = [%lambda_vm.script fun _ -> (0L, 0L)] in
+  check_execution_error
+    (Vm_test.execute_ast 701 (Int64 0L) script)
+    Value_is_not_pair
+
+let test_pattern2_value_is_not_pair () =
+  let script = [%lambda_vm.script fun _ -> 0L] in
+  check_execution_error
+    (Vm_test.execute_ast 301 (Int64 0L) script)
+    Value_is_not_pair
+
+let test_pattern3_value_is_not_zero () =
+  let script = [%lambda_vm.script fun _ -> (0L, (1L, 0L))] in
+  check_execution_error
+    (Vm_test.execute_ast 1101 (Int64 0L) script)
+    Value_is_not_zero
+
+let test_pattern4_value_is_not_zero () =
+  let script = [%lambda_vm.script fun _ -> (0L, (0L, 1L))] in
+  check_execution_error
+    (Vm_test.execute_ast 1101 (Int64 0L) script)
+    Value_is_not_zero
+
+let test_compilation =
+  let open Alcotest in
+  ( "Compilation and execution errors",
+    [
+      test_case "Compilation - Undefined variable" `Quick
+        test_compilation_undefined_variable;
+      test_case "Fst - Value should be pair" `Quick test_fst_value_is_not_pair;
+      test_case "Snd - Value should be pair" `Quick test_snd_value_is_not_pair;
+      test_case "Neg - Value should be int64" `Quick test_neg_value_is_not_int64;
+      test_case "Op2 - Value should be int64" `Quick test_op2_value_is_not_int64;
+      test_case "If - Value should be int64" `Quick test_if_value_is_not_int64;
+      test_case "Value is not a function" `Quick test_value_is_not_function;
+    ] )
+
+let test_execution =
+  let open Alcotest in
+  ( "Execution pattern errors",
+    [
+      test_case "Pattern 1 - Value should be pair" `Quick
+        test_pattern1_value_is_not_pair;
+      test_case "Pattern 2 - Value should be pair" `Quick
+        test_pattern2_value_is_not_pair;
+      test_case "Pattern 3 - Value should be zero" `Quick
+        test_pattern3_value_is_not_zero;
+      test_case "Pattern 4 - Value should be zero" `Quick
+        test_pattern4_value_is_not_zero;
+    ] )

--- a/tests/vm/test_gas.ml
+++ b/tests/vm/test_gas.ml
@@ -1,0 +1,45 @@
+open Lambda_vm
+
+let counter =
+  [%lambda_vm.script
+    fun x ->
+      ( (fun f -> f f x) (fun f n ->
+            if n then
+              1L + f f (n - 1L)
+            else
+              0L),
+        (0L, 0L) )]
+
+let test_compile_value () =
+  let gas = Gas.make ~initial_gas:100 in
+  let _ = Vm_test.compile_value_exn gas (Int64 0L) in
+  Alcotest.(check bool) "Should be empty" (Gas.is_empty gas) true
+
+let test_compile_ast () =
+  let ast = [%lambda_vm.script fun x -> x + 1L] in
+
+  let gas = Gas.make ~initial_gas:500 in
+  let _ = Vm_test.compile_exn gas ast in
+  Alcotest.(check bool) "Should be empty" (Gas.is_empty gas) true
+
+let test_execute_ir () =
+  let x = 4096L in
+  let arg =
+    let gas = Gas.make ~initial_gas:101 in
+    Vm_test.compile_value_exn gas (Int64 x) in
+  let ir =
+    let gas = Gas.make ~initial_gas:5000 in
+    Vm_test.compile_exn gas counter in
+
+  let gas = Gas.make ~initial_gas:14747900 in
+  let _ = Vm_test.execute_exn gas arg ir in
+  Alcotest.(check bool) "Should be empty" (Gas.is_empty gas) true
+
+let test =
+  let open Alcotest in
+  ( "Gas model",
+    [
+      test_case "Compile value" `Quick test_compile_value;
+      test_case "Compile AST" `Quick test_compile_ast;
+      test_case "Execute IR" `Quick test_execute_ir;
+    ] )

--- a/tests/vm/test_prim.ml
+++ b/tests/vm/test_prim.ml
@@ -1,0 +1,81 @@
+open Lambda_vm
+
+module Testable = Vm_test.Testable
+
+let script_op2 prim =
+  let prim = Ast.Prim prim in
+  [%lambda_vm.script fun param -> ([%e prim] (fst param) (snd param), (0L, 0L))]
+
+let script_op1 prim =
+  let prim = Ast.Prim prim in
+  [%lambda_vm.script fun param -> ([%e prim] param, (0L, 0L))]
+
+let make_op2_test ~name prim f =
+  QCheck_alcotest.to_alcotest
+    QCheck.(
+      Test.make ~name ~count:10_000 (pair int64 int64) (fun (a, b) ->
+          let result =
+            Vm_test.execute_ast_exn 2901
+              (Pair (Int64 a, Int64 b))
+              (script_op2 prim) in
+          let expected_result =
+            Vm_test.compile_value_exn
+              (Gas.make ~initial_gas:200)
+              (Int64 (f a b)) in
+          result.storage = expected_result))
+
+let test_sum = make_op2_test ~name:"Adding pairs" Add Int64.add
+
+let test_sub = make_op2_test ~name:"Subtracting pairs" Sub Int64.sub
+
+let test_mul = make_op2_test ~name:"Multiplying pairs" Mul Int64.mul
+
+let test_div = make_op2_test ~name:"Dividing pairs" Div Int64.div
+
+let test_rem = make_op2_test ~name:"Modulo pairs" Rem Int64.rem
+
+let test_and = make_op2_test ~name:"Anding pairs" Land Int64.logand
+
+let test_or = make_op2_test ~name:"Oring pairs" Lor Int64.logor
+
+let test_xor = make_op2_test ~name:"Xoring pairs" Lxor Int64.logxor
+
+let test_lsl =
+  make_op2_test ~name:"Left shifting pairs" Lsl (fun a b ->
+      Int64.shift_left a (Int64.to_int b))
+
+let test_lsr =
+  make_op2_test ~name:"Logical right shifting pairs" Lsr (fun a b ->
+      Int64.shift_right_logical a (Int64.to_int b))
+
+let test_asr =
+  make_op2_test ~name:"Right shifting pairs" Asr (fun a b ->
+      Int64.shift_right a (Int64.to_int b))
+
+let test_neg =
+  QCheck_alcotest.to_alcotest
+    QCheck.(
+      Test.make ~name:"Negative numbers" ~count:10_000 int64 (fun x ->
+          let result = Vm_test.execute_ast_exn 1501 (Int64 x) (script_op1 Neg) in
+          let expected_result =
+            Vm_test.compile_value_exn
+              (Gas.make ~initial_gas:200)
+              (Int64 Int64.(neg x)) in
+          result.storage = expected_result))
+
+let test =
+  ( "Primitive operations",
+    [
+      test_sum;
+      test_sub;
+      test_mul;
+      test_div;
+      test_rem;
+      test_and;
+      test_or;
+      test_xor;
+      test_neg;
+      test_lsl;
+      test_lsr;
+      test_asr;
+    ] )

--- a/tests/vm/test_recursion.ml
+++ b/tests/vm/test_recursion.ml
@@ -1,0 +1,114 @@
+open Lambda_vm
+
+let factorial =
+  [%lambda_vm.script
+    fun x ->
+      ( (fun f -> f f x) (fun f n -> if n then n * f f (n - 1L) else 1L),
+        (0L, 0L) )]
+
+let test_factorial =
+  let rec fac = function
+    | 0L -> 1L
+    | n -> Int64.(mul n (fac (sub n 1L))) in
+  QCheck_alcotest.to_alcotest
+    QCheck.(
+      Test.make ~name:"Recursion with factorial" ~count:10000 (1 -- 26)
+        (fun x ->
+          (* Less than 0 is infinite recursion, greater than 25 is integer overflow. *)
+          let x = Int64.of_int x in
+          let result = Vm_test.execute_ast_exn 1_000_000 (Int64 x) factorial in
+          let expected_result =
+            Vm_test.compile_value_exn
+              (Gas.make ~initial_gas:101)
+              (Int64 (fac x)) in
+          expected_result = result.storage))
+
+let fibonacci =
+  [%lambda_vm.script
+    fun x ->
+      ( (fun f -> f f x) (fun f n ->
+            if (0L - n) * (1L - n) then
+              f f (n - 2L) + f f (n - 1L)
+            else
+              1L),
+        (0L, 0L) )]
+
+let test_fibonacci =
+  let rec fib = function
+    | 0L
+    | 1L ->
+      1L
+    | n -> Int64.add (fib (Int64.sub n 1L)) (fib (Int64.sub n 2L)) in
+  QCheck_alcotest.to_alcotest
+    QCheck.(
+      Test.make ~name:"Fibonacci" ~count:100 (0 -- 25) (fun x ->
+          let x = Int64.of_int x in
+          let result =
+            Vm_test.execute_ast_exn 100000000000 (Int64 x) fibonacci in
+          let expected_value =
+            Vm_test.compile_value_exn
+              (Gas.make ~initial_gas:101)
+              (Int64 (fib x)) in
+          expected_value = result.storage))
+
+let counter =
+  [%lambda_vm.script
+    fun x ->
+      ( (fun f -> f f x) (fun f n ->
+            if n then
+              1L + f f (n - 1L)
+            else
+              0L),
+        (0L, 0L) )]
+
+let test_counter =
+  QCheck_alcotest.to_alcotest
+    QCheck.(
+      Test.make ~name:"Counter" ~count:1000 (0 -- 10000) (fun x ->
+          let x = Int64.of_int x in
+          let result = Vm_test.execute_ast_exn 1000000000 (Int64 x) counter in
+          let expected_value =
+            Vm_test.compile_value_exn (Gas.make ~initial_gas:101) (Int64 x)
+          in
+          expected_value = result.storage))
+
+let test_stack_limit () =
+  Alcotest.check_raises "Stack has a limit" Out_of_stack (fun () ->
+      let _ =
+        Vm_test.execute_ast_exn 71_990_801
+          (Int64 19996L) (* Bare minimum close to the limit of 20k *)
+          counter in
+      ())
+
+let infinite_recursion_y =
+  [%lambda_vm.script fun _ -> (fun f -> f f) (fun f -> f f + 0L)]
+
+let test_y_combinator () =
+  Alcotest.check_raises "Stack limit avoids infinite recursion" Out_of_stack
+    (fun () ->
+      let _ =
+        Vm_test.execute_ast_exn 10000000000000000 (Int64 0L)
+          infinite_recursion_y in
+      ())
+
+let infinite_recursion_z =
+  [%lambda_vm.script fun _ -> (fun f -> f f 0L) (fun f v -> f f (v + 0L))]
+
+let test_z_combinator () =
+  Alcotest.check_raises "Gas limit is triggered" Out_of_gas (fun () ->
+      let _ =
+        Vm_test.execute_ast_exn 10000000000 (Int64 0L) infinite_recursion_z
+      in
+      ())
+
+let test =
+  let open Alcotest in
+  ( "Recursion",
+    [
+      test_factorial;
+      test_fibonacci;
+      test_counter;
+      test_case "Stack limit" `Slow test_stack_limit;
+      test_case "Infinite recursion - Y" `Slow test_y_combinator;
+      test_case "Infinite recursion - Z" `Slow test_z_combinator;
+    ] )

--- a/tests/vm/test_simple_expr.ml
+++ b/tests/vm/test_simple_expr.ml
@@ -1,0 +1,93 @@
+open Lambda_vm
+module Testable = Vm_test.Testable
+
+let test_increment () =
+  let script = [%lambda_vm.script fun x -> (x + 1L, (0L, 0L))] in
+  let result = Vm_test.execute_ast_exn 1901 (Int64 42L) script in
+  let expected_value =
+    Vm_test.compile_value_exn (Gas.make ~initial_gas:101) (Int64 43L) in
+  Alcotest.(check Testable.value) "Same value" expected_value result.storage
+
+let test_decrement () =
+  let script = [%lambda_vm.script fun x -> (x - 1L, (0L, 0L))] in
+  let result = Vm_test.execute_ast_exn 1901 (Int64 42L) script in
+  let expected_value =
+    Vm_test.compile_value_exn (Gas.make ~initial_gas:101) (Int64 41L) in
+  Alcotest.(check Testable.value) "Same value" expected_value result.storage
+
+let test_add_pair () =
+  let script = [%lambda_vm.script fun pair -> (fst pair + snd pair, (0L, 0L))] in
+
+  let result =
+    Vm_test.execute_ast_exn 2901 (Pair (Int64 23L, Int64 28L)) script in
+  let expected_value =
+    Vm_test.compile_value_exn (Gas.make ~initial_gas:101) (Int64 51L) in
+
+  Alcotest.(check Testable.value) "Same value" expected_value result.storage
+
+let test_if_expr () =
+  let script =
+    [%lambda_vm.script
+      fun param ->
+        ((if fst param then snd param + 1L else snd param - 1L), (0L, 0L))]
+  in
+
+  (* Check increment *)
+  let result =
+    Vm_test.execute_ast_exn 4001 (Pair (Int64 1L, Int64 51L)) script in
+  let expected_value =
+    Vm_test.compile_value_exn (Gas.make ~initial_gas:101) (Int64 52L) in
+  Alcotest.(check Testable.value) "Same value" expected_value result.storage;
+
+  (* Check decrement *)
+  let result =
+    Vm_test.execute_ast_exn 4001 (Pair (Int64 0L, Int64 33L)) script in
+  let expected_value =
+    Vm_test.compile_value_exn (Gas.make ~initial_gas:101) (Int64 32L) in
+  Alcotest.(check Testable.value) "Same value" expected_value result.storage
+
+let test_lambda () =
+  let script =
+    let increment_lambda = [%lambda_vm fun x -> x + 1L] in
+    let decrement_lambda = [%lambda_vm fun x -> x - 1L] in
+    [%lambda_vm.script
+      fun param ->
+        ( (fun inc ->
+            if inc then [%e increment_lambda] else [%e decrement_lambda])
+            (fst param) (snd param),
+          (0L, 0L) )] in
+  (* Check increment *)
+  let result =
+    Vm_test.execute_ast_exn 6501 (Pair (Int64 1L, Int64 99L)) script in
+  let expected_value =
+    Vm_test.compile_value_exn (Gas.make ~initial_gas:101) (Int64 100L) in
+
+  Alcotest.(check Testable.value) "Same value" expected_value result.storage;
+
+  (* Check decrement *)
+  let result =
+    Vm_test.execute_ast_exn 6501 (Pair (Int64 0L, Int64 33L)) script in
+  let expected_value =
+    Vm_test.compile_value_exn (Gas.make ~initial_gas:101) (Int64 32L) in
+
+  Alcotest.(check Testable.value) "Same value" expected_value result.storage
+
+let test_lambda_application () =
+  let script = [%lambda_vm.script fun y -> (fun x -> (x, (0L, 0L))) y] in
+  let result = Vm_test.execute_ast_exn 2000 (Int64 45L) script in
+  let expected_value =
+    Vm_test.compile_value_exn (Gas.make ~initial_gas:101) (Int64 45L) in
+
+  Alcotest.(check Testable.value) "Same value" expected_value result.storage
+
+let test =
+  let open Alcotest in
+  ( "Simple with simple expressions",
+    [
+      test_case "Increment" `Quick test_increment;
+      test_case "Decrement" `Quick test_decrement;
+      test_case "Add pair" `Quick test_add_pair;
+      test_case "If expr" `Quick test_if_expr;
+      test_case "Lambda" `Quick test_lambda;
+      test_case "Lambda application" `Quick test_lambda_application;
+    ] )

--- a/tests/vm/test_vm.ml
+++ b/tests/vm/test_vm.ml
@@ -1,0 +1,11 @@
+let () =
+  let open Alcotest in
+  run "Lambda VM"
+    [
+      Test_errors.test_compilation;
+      Test_errors.test_execution;
+      Test_prim.test;
+      Test_recursion.test;
+      Test_simple_expr.test;
+      Test_gas.test;
+    ]

--- a/tests/vm/vm_test.ml
+++ b/tests/vm/vm_test.ml
@@ -1,0 +1,48 @@
+open Lambda_vm
+
+type error =
+  | Compilation_error of compile_error
+  | Execution_error   of execution_error
+
+let failwith s = Format.kasprintf failwith s
+
+let compile_exn gas script =
+  match compile gas script with
+  | Ok value -> value
+  | Error error -> failwith "Compilation_error(%a)" pp_compile_error error
+
+let compile_value_exn gas value =
+  match compile_value gas value with
+  | Ok value -> value
+  | Error error -> failwith "Compilation_error(%a)" pp_compile_error error
+
+let execute_exn gas arg script =
+  match execute gas ~arg script with
+  | Ok value -> value
+  | Error error -> failwith "Execution_error(%a)" pp_execution_error error
+
+let execute_ast_exn gas arg script =
+  (* TODO: Use different gas to different stuff *)
+  let gas = Gas.make ~initial_gas:gas in
+  let script = compile_exn gas script in
+  let arg = compile_value_exn gas arg in
+  execute_exn gas arg script
+
+let execute_ast gas arg script =
+  let gas = Gas.make ~initial_gas:gas in
+  match (compile_value gas arg, compile gas script) with
+  | Ok arg, Ok ir -> (
+    match execute gas ~arg ir with
+    | Ok result -> Ok result
+    | Error error -> Error (Execution_error error))
+  | Error error, _
+  | _, Error error ->
+    Error (Compilation_error error)
+
+module Testable = struct
+  let value = Alcotest.of_pp Lambda_vm.pp_value
+
+  let execution_error = Alcotest.of_pp pp_execution_error
+
+  let compilation_error = Alcotest.of_pp pp_compile_error
+end


### PR DESCRIPTION
<!---
  if some of the following sections doesn't apply,
  delete the section.

  Also feel free to delete the comments.
--->

## Depends

<!--- All PR or issues that are required to be closed / merged before this can be merged --->
- [x] #463 
- [ ] #505
- [ ] #504 

## Problem

<!--- Restate the problem addressed by the PR here --->
Lambda VM needs proper testing and practical examples of use.

## Solution

<!--- Restate the basic ideas behind your solution --->
I tested all the base structures of the interpreter and AST, errors and primitive operations. For the basic interpreter features I've just built simple increment/decrement programs. For primitive operations I've built qcheck tests generating int64 for all the operations.

All gas value were adjusted to the bare minimum, so they won't get larger without being noticed.
<!--- Here it is also a good space to put details of your implementation --->

### Simple expressions

I've built a few simple programs to test the basic functionality the AST provides, like applications, primitives for arithmetic operations, if expressions, lambdas and manipulating pairs.

### Compilation and execution errors

Checked for different situations that would happen in real programs, making sure the runtime checks works.

### Primitive operations

Used QCheck to make property based testing for all available primitive operations, generating random 64-bit integers and running operations on them.

### Recursion

Making sure that is possible and viable to run complex programs with loops and recursion, and that gas and limits work in order to prevent exhaustion of resources by third party executed code. Examples include factorial, Fibonacci, a counter and infinite non tail recursion.

### Gas model

Also added a few tests in order to validate an constraint gas model, the way this works is by running this examples in the limit both above and below the necessary to run out of gas and so making sure that's constant and in case it changes it is detectable by the test suite.

I believe a better way to do this would be by benchmarking the VM and comparing with the corresponding gas consumption to check if they're correlated in a way that enough gas is charged in order to run a corresponding expensive computation. 
