### PR TITLE
tezos_interop: increase polling rate for Taquito

### DIFF
--- a/src/tezos_interop/fetch_storage.js
+++ b/src/tezos_interop/fetch_storage.js
@@ -6,6 +6,7 @@ const { RpcClient } = require("@taquito/rpc");
 const { InMemorySigner } = require("@taquito/signer");
 
 const { TezosToolkit } = taquito;
+
 /**
  * @typedef Input
  * @type {object}
@@ -40,6 +41,14 @@ const error = (error) =>
   const { rpc_node, contract_address, confirmation } = input();
   const client = new RpcClient(rpc_node);
   const Tezos = new TezosToolkit(rpc_node);
+  Tezos.setProvider({
+    config: {
+      shouldObservableSubscriptionRetry: true,
+      streamerPollingIntervalMilliseconds: 1000,
+      confirmationPollingIntervalSecond: 1,
+      confirmationPollingTimeoutSecond: 4,
+    },
+  });
   const block = await client.getBlock(); // fetches the head
   const contract = await client.getContract(contract_address, {
     block: block.hash,

--- a/src/tezos_interop/fetch_storage.js
+++ b/src/tezos_interop/fetch_storage.js
@@ -41,6 +41,7 @@ const error = (error) =>
   const { rpc_node, contract_address, confirmation } = input();
   const client = new RpcClient(rpc_node);
   const Tezos = new TezosToolkit(rpc_node);
+  // This is also defined on the other JS scripts
   Tezos.setProvider({
     config: {
       shouldObservableSubscriptionRetry: true,

--- a/src/tezos_interop/listen_transactions.js
+++ b/src/tezos_interop/listen_transactions.js
@@ -42,6 +42,14 @@ const output = (operation) => {
 const { rpc_node, confirmation, destination } = input();
 
 const Tezos = new TezosToolkit(rpc_node);
+Tezos.setProvider({
+  config: {
+    shouldObservableSubscriptionRetry: true,
+    streamerPollingIntervalMilliseconds: 1000,
+    confirmationPollingIntervalSecond: 1,
+    confirmationPollingTimeoutSecond: 4,
+  },
+});
 
 const operationStream = Tezos.stream.subscribeOperation({
   kind: taquito.OpKind.TRANSACTION,

--- a/src/tezos_interop/listen_transactions.js
+++ b/src/tezos_interop/listen_transactions.js
@@ -42,6 +42,7 @@ const output = (operation) => {
 const { rpc_node, confirmation, destination } = input();
 
 const Tezos = new TezosToolkit(rpc_node);
+// This is also defined on the other JS scripts
 Tezos.setProvider({
   config: {
     shouldObservableSubscriptionRetry: true,

--- a/src/tezos_interop/run_entrypoint.js
+++ b/src/tezos_interop/run_entrypoint.js
@@ -45,7 +45,15 @@ const error = (error) =>
     .map(([_, value]) => value);
   const Tezos = new TezosToolkit(rpc_node);
   const signer = await InMemorySigner.fromSecretKey(secret);
-  Tezos.setProvider({ signer });
+  Tezos.setProvider({
+    signer,
+    config: {
+      shouldObservableSubscriptionRetry: true,
+      streamerPollingIntervalMilliseconds: 1000,
+      confirmationPollingIntervalSecond: 1,
+      confirmationPollingTimeoutSecond: 4,
+    },
+  });
 
   const contract = await Tezos.contract.at(destination);
   const operation = await contract.methods[entrypoint](...args).send();

--- a/src/tezos_interop/run_entrypoint.js
+++ b/src/tezos_interop/run_entrypoint.js
@@ -45,6 +45,7 @@ const error = (error) =>
     .map(([_, value]) => value);
   const Tezos = new TezosToolkit(rpc_node);
   const signer = await InMemorySigner.fromSecretKey(secret);
+  // This is also defined on the other JS scripts
   Tezos.setProvider({
     signer,
     config: {


### PR DESCRIPTION
## Problem

Currently Deku is loosing Tezos operations in some nodes, leading to nodes not agreeing on what is a valid Tezos operation and stalling the chain.

## Solution

The issue is only happening on Flextesa, due to the reduced block time and the internal polling rate of Taquito, this PR workaround it by increase the polling rate, in the future we should replace Taquito by Tezos_rpc.