### PR TITLE
Add error logging to taquito scripts

### DIFF
--- a/src/tezos_interop/fetch_storage.js
+++ b/src/tezos_interop/fetch_storage.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const fs = require("fs");
+const { inspect } = require("util");
 const taquito = require("@taquito/taquito");
 const { RpcClient } = require("@taquito/rpc");
 const { InMemorySigner } = require("@taquito/signer");
@@ -34,8 +35,10 @@ const output = (data) =>
   fs.writeFileSync(process.stdout.fd, JSON.stringify(data, null, 2));
 
 const finished = (storage) => output({ status: "success", storage });
-const error = (error) =>
-  output({ status: "error", error: JSON.stringify(error) });
+const error = (error) => {
+  console.error(error);
+  output({ status: "error" });
+};
 
 (async () => {
   const { rpc_node, contract_address, confirmation } = input();

--- a/src/tezos_interop/run_entrypoint.js
+++ b/src/tezos_interop/run_entrypoint.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const fs = require("fs");
+const { inspect } = require("util");
 const { TezosToolkit } = require("@taquito/taquito");
 const { InMemorySigner } = require("@taquito/signer");
 
@@ -34,8 +35,10 @@ const output = (data) =>
   fs.writeFileSync(process.stdout.fd, JSON.stringify(data, null, 2));
 
 const finished = (status, hash) => output({ status, hash });
-const error = (error) =>
-  output({ status: "error", error: JSON.stringify(error) });
+const error = (error) => {
+  console.error(error);
+  output({ status: "error" });
+};
 
 (async () => {
   const { rpc_node, secret, confirmation, destination, entrypoint, payload } =


### PR DESCRIPTION

## Problem

I've found that any errors in Taquito aren't properly
logged, making it hard to debug them.

## Solution

Just add `console.error`.

