### PR TITLE
fix: use default confirmation polling timeout

### DIFF
--- a/src/tezos_interop/fetch_storage.js
+++ b/src/tezos_interop/fetch_storage.js
@@ -47,7 +47,6 @@ const error = (error) =>
       shouldObservableSubscriptionRetry: true,
       streamerPollingIntervalMilliseconds: 1000,
       confirmationPollingIntervalSecond: 1,
-      confirmationPollingTimeoutSecond: 4,
     },
   });
   const block = await client.getBlock(); // fetches the head

--- a/src/tezos_interop/listen_transactions.js
+++ b/src/tezos_interop/listen_transactions.js
@@ -48,7 +48,6 @@ Tezos.setProvider({
     shouldObservableSubscriptionRetry: true,
     streamerPollingIntervalMilliseconds: 1000,
     confirmationPollingIntervalSecond: 1,
-    confirmationPollingTimeoutSecond: 4,
   },
 });
 

--- a/src/tezos_interop/run_entrypoint.js
+++ b/src/tezos_interop/run_entrypoint.js
@@ -52,7 +52,6 @@ const error = (error) =>
       shouldObservableSubscriptionRetry: true,
       streamerPollingIntervalMilliseconds: 1000,
       confirmationPollingIntervalSecond: 1,
-      confirmationPollingTimeoutSecond: 4,
     },
   });
 


### PR DESCRIPTION



## Problem

The e2e test added in #470 is failing because the confirmation polling is timing out. You can see an example here: https://github.com/marigold-dev/deku/runs/5500148802?check_suite_focus=true#step:8:61

This doesn't happen locally, at least not for me. I think it has to do with the speedo f the machine involved.

## Solution

Raise the confirmation timeout. I'm not sure if this has any bad effects. If needed, we could make it configurable through an environment variable
that we set in the CI, but I doubt an increase of 6 seconds is going to break us.

## Related

<!--- add here all the related issues to your PR --->
- #470
 