### PR TITLE
chore: OCaml 5 bug changed the process name

### DIFF
--- a/src/bin/deku_cli.ml
+++ b/src/bin/deku_cli.ml
@@ -550,6 +550,10 @@ let remove_trusted_validator node_folder address =
 let remove_trusted_validator =
   let open Term in
   lwt_ret (const remove_trusted_validator $ folder_node $ validator_address)
+
+(* TODO: https://github.com/ocaml/ocaml/issues/11090 *)
+let () = Domain.set_name "deku-cli"
+
 let () =
   Term.exit
   @@ Term.eval_choice show_help

--- a/src/bin/deku_node.ml
+++ b/src/bin/deku_node.ml
@@ -140,6 +140,9 @@ let node folder =
        ]
   @@ Dream.not_found
 
+(* TODO: https://github.com/ocaml/ocaml/issues/11090 *)
+let () = Domain.set_name "deku-node"
+
 let node =
   let folder_node =
     let docv = "folder_node" in


### PR DESCRIPTION
## Problem

Due to https://github.com/ocaml/ocaml/issues/11090 deku processes are currently named Domain0, breaking commands like `killall`.

## Solution

This is a workaround until it is fixed on upstream, manually setting the domain name fixes the problem.