### PR TITLE
tezos_interop: move scripts blob to it's own file

### DIFF
--- a/src/tezos_interop/scripts.ml
+++ b/src/tezos_interop/scripts.ml
@@ -1,0 +1,21 @@
+open Helpers
+
+let fetch_storage = [%blob "fetch_storage.bundle.js"]
+let run_entrypoint = [%blob "run_entrypoint.bundle.js"]
+let listen_transactions = [%blob "listen_transactions.bundle.js"]
+
+let make_file ~prefix content =
+  let%await file, oc = Lwt_io.open_temp_file ~prefix ~suffix:".js" () in
+  let%await () = Lwt_io.write oc content in
+  await file
+
+let file_fetch_storage, file_run_entrypoint, file_listen_transactions =
+  Lwt_main.run
+    (let%await file_fetch_storage =
+       make_file ~prefix:"fetch_storage" fetch_storage in
+     let%await file_run_entrypoint =
+       make_file ~prefix:"run_entrypoint" run_entrypoint in
+     let%await file_listen_transactions =
+       make_file ~prefix:"listen_transactions" listen_transactions in
+     Lwt.return
+       (file_fetch_storage, file_run_entrypoint, file_listen_transactions))

--- a/src/tezos_interop/scripts.mli
+++ b/src/tezos_interop/scripts.mli
@@ -1,0 +1,3 @@
+val file_fetch_storage : string
+val file_run_entrypoint : string
+val file_listen_transactions : string

--- a/src/tezos_interop/tezos_interop.ml
+++ b/src/tezos_interop/tezos_interop.ml
@@ -48,11 +48,7 @@ module Run_contract = struct
       let%ok { error } = T.error_of_yojson json in
       Ok (Error error)
     | _ -> Error "invalid status"
-  let file =
-    let%await file, oc = Lwt_io.open_temp_file ~suffix:".js" () in
-    let%await () = Lwt_io.write oc [%blob "run_entrypoint.bundle.js"] in
-    await file
-  let file = Lwt_main.run file
+  let file = Scripts.file_run_entrypoint
   let run ~context ~destination ~entrypoint ~payload =
     let input =
       {
@@ -117,11 +113,7 @@ end = struct
       Error
         "JSON output %s did not contain 'success' or 'error' for field `status`"
   let command = "node"
-  let file =
-    let%await file, oc = Lwt_io.open_temp_file ~suffix:".js" () in
-    let%await () = Lwt_io.write oc [%blob "fetch_storage.bundle.js"] in
-    await file
-  let file = Lwt_main.run file
+  let file = Scripts.file_fetch_storage
   let run ~rpc_node ~confirmation ~contract_address =
     let input =
       {
@@ -155,11 +147,7 @@ module Listen_transactions = struct
       destination : string;
     }
     [@@deriving to_yojson]
-    let file =
-      let%await file, oc = Lwt_io.open_temp_file ~suffix:".js" () in
-      let%await () = Lwt_io.write oc [%blob "listen_transactions.bundle.js"] in
-      await file
-    let file = Lwt_main.run file
+    let file = Scripts.file_listen_transactions
     let node = "node"
     let run ~context ~destination ~on_message ~on_fail =
       let send f pr data =


### PR DESCRIPTION
## Problem

Due to a weird interaction between esy and `ppx_blob`, merlin cannot find the needed asset leading to the entire `Tezos_interop` not showing properly on the LSP.

## Solution

This is more like an workaround, by moving all the blobs to a different module(`Scripts`), now LSP on `Tezos_interop` is working properly.