### PR TITLE
tezos_interop: make run_entrypoint long lived

### DIFF
--- a/src/bin/deku_cli.ml
+++ b/src/bin/deku_cli.ml
@@ -419,10 +419,9 @@ let info_setup_tezos =
 let setup_tezos node_folder rpc_node secret consensus_contract
     required_confirmations =
   let%await () = ensure_folder node_folder in
-  let context =
-    let open Tezos_interop.Context in
-    { rpc_node; secret; consensus_contract; required_confirmations } in
-  let%await () = write_interop_context ~node_folder context in
+  let%await () =
+    write_interop_context ~node_folder
+      { rpc_node; secret; consensus_contract; required_confirmations } in
   await (`Ok ())
 let setup_tezos =
   let folder_dest =

--- a/src/bin/deku_node.ml
+++ b/src/bin/deku_node.ml
@@ -115,8 +115,8 @@ let handle_ticket_balance =
       Ok { amount })
 let node folder prometheus_port =
   let node = Node_state.get_initial_state ~folder |> Lwt_main.run in
-  Tezos_interop.Consensus.listen_operations
-    ~context:node.Node.State.interop_context ~on_operation:(fun operation ->
+  Tezos_interop.Consensus.listen_operations node.Node.State.interop_context
+    ~on_operation:(fun operation ->
       Flows.received_tezos_operation (Server.get_state ()) update_state
         operation);
   Node.Server.start ~initial:node;

--- a/src/bin/files.ml
+++ b/src/bin/files.ml
@@ -49,7 +49,7 @@ module Interop_context = struct
       | _ -> Error "expected a string"
     let to_yojson t = `String (to_string t)
   end
-  type t = Tezos_interop.Context.t = {
+  type t = {
     rpc_node : Uri.t;
     secret : Secret.t;
     consensus_contract : Tezos.Address.t;

--- a/src/bin/files.mli
+++ b/src/bin/files.mli
@@ -18,8 +18,14 @@ module Validators : sig
   val write : (Crypto.Key_hash.t * Uri.t) list -> file:string -> unit Lwt.t
 end
 module Interop_context : sig
-  val read : file:string -> Tezos_interop.Context.t Lwt.t
-  val write : Tezos_interop.Context.t -> file:string -> unit Lwt.t
+  type t = {
+    rpc_node : Uri.t;
+    secret : Crypto.Secret.t;
+    consensus_contract : Tezos.Address.t;
+    required_confirmations : int;
+  }
+  val read : file:string -> t Lwt.t
+  val write : t -> file:string -> unit Lwt.t
 end
 module State_bin : sig
   val read : file:string -> Protocol.t Lwt.t

--- a/src/bin/node_state.ml
+++ b/src/bin/node_state.ml
@@ -12,9 +12,13 @@ let get_initial_state ~folder =
     Trusted_validators_membership_change.Set.of_list
       trusted_validator_membership_change_list in
   let%await interop_context =
-    Files.Interop_context.read ~file:(folder ^ "/tezos.json") in
+    let%await { rpc_node; secret; consensus_contract; required_confirmations } =
+      Files.Interop_context.read ~file:(folder ^ "/tezos.json") in
+    Lwt.return
+      (Tezos_interop.make ~rpc_node ~secret ~consensus_contract
+         ~required_confirmations) in
   let%await validator_res =
-    Tezos_interop.Consensus.fetch_validators ~context:interop_context in
+    Tezos_interop.Consensus.fetch_validators interop_context in
   let%await local_validators =
     Files.Validators.read ~file:(folder ^ "/validators.json") in
   let validators =

--- a/src/node/flows.ml
+++ b/src/node/flows.ml
@@ -176,7 +176,7 @@ let try_to_sign_block state update_state block =
   else
     state
 let commit_state_hash state =
-  Tezos_interop.Consensus.commit_state_hash ~context:state.Node.interop_context
+  Tezos_interop.Consensus.commit_state_hash state.Node.interop_context
 let try_to_commit_state_hash ~prev_validators state block signatures =
   let open Node in
   let signatures_map =

--- a/src/node/state.ml
+++ b/src/node/state.ml
@@ -20,7 +20,7 @@ type t = {
   identity : identity;
   trusted_validator_membership_change :
     Trusted_validators_membership_change.Set.t;
-  interop_context : Tezos_interop.Context.t;
+  interop_context : Tezos_interop.t;
   data_folder : string;
   pending_operations : pending_operation list;
   block_pool : Block_pool.t;

--- a/src/node/state.mli
+++ b/src/node/state.mli
@@ -19,7 +19,7 @@ type t = {
   identity : identity;
   trusted_validator_membership_change :
     Trusted_validators_membership_change.Set.t;
-  interop_context : Tezos_interop.Context.t;
+  interop_context : Tezos_interop.t;
   data_folder : string;
   pending_operations : pending_operation list;
   block_pool : Block_pool.t;
@@ -36,7 +36,7 @@ val make :
   trusted_validator_membership_change:Trusted_validators_membership_change.Set.t ->
   persist_trusted_membership_change:
     (Trusted_validators_membership_change.t list -> unit Lwt.t) ->
-  interop_context:Tezos_interop.Context.t ->
+  interop_context:Tezos_interop.t ->
   data_folder:string ->
   initial_validators_uri:Uri.t Address_map.t ->
   t

--- a/src/tezos_interop/run_entrypoint.js
+++ b/src/tezos_interop/run_entrypoint.js
@@ -73,23 +73,20 @@ const read = (callback) => {
       }
       buf = buf + chunk;
 
-      const newline = buf.indexOf("\n");
-      if (newline === -1) {
-        done();
-        return;
-      }
+      const parts = buf.split("\n");
+      const messages = parts.slice(0, -1); // everything except last
 
-      const message = buf.slice(0, newline);
-      // skips the newline
-      buf = buf.slice(newline + 1);
+      buf = parts.slice(-1)[0]; // last
 
-      try {
-        const json = JSON.parse(message);
-        this.push(json);
-        done();
-      } catch (err) {
-        done(err);
+      for (const message of messages) {
+        try {
+          const json = JSON.parse(message);
+          this.push(json);
+        } catch (err) {
+          return done(err);
+        }
       }
+      return done();
     },
   });
   const errorHandler = (err = "close") => failure(err);

--- a/src/tezos_interop/run_entrypoint.js
+++ b/src/tezos_interop/run_entrypoint.js
@@ -1,11 +1,11 @@
 "use strict";
 
-const fs = require("fs");
 const { TezosToolkit } = require("@taquito/taquito");
 const { InMemorySigner } = require("@taquito/signer");
+const { pipeline, Transform } = require("stream");
 
 /**
- * @typedef Input
+ * @typedef TransactionRequest
  * @type {object}
  * @property {string} rpc_node
  * @property {string} secret
@@ -13,51 +13,132 @@ const { InMemorySigner } = require("@taquito/signer");
  * @property {string} destination
  * @property {string} entrypoint
  * @property {object} payload
- */
-/** @returns {Input} */
-const input = () => JSON.parse(fs.readFileSync(process.stdin.fd));
 
-/**
- * @typedef OutputFinished
+ * @typedef RequestHeader
+ * @type {object}
+ * @property {number} id
+
+ * @typedef Request
+ * @type {RequestHeader & TransactionRequest}
+
+ * @typedef ResponseHeader
+ * @type {object}
+ * @property {number} id
+
+ * @typedef TransactionResponseSuccess
  * @type {object}
  * @property {"applied" | "failed" | "skipped" | "backtracked" | "unknown"} status
  * @property {string} hash
- */
-/**
- * @typedef OutputError
+
+ * @typedef TransactionResponseError
  * @type {object}
  * @property {"error"} status
  * @property {string} error
+
+ * @typedef TransactionResponse
+ * @type {TransactionResponseSuccess | TransactionResponseError}
+
+ * @typedef Response
+ * @type {ResponseHeader & TransactionResponse}
  */
-/** @param {OutputFinished | OutputError} data */
-const output = (data) =>
-  fs.writeFileSync(process.stdout.fd, JSON.stringify(data, null, 2));
 
-const finished = (status, hash) => output({ status, hash });
-const error = (error) =>
-  output({ status: "error", error: JSON.stringify(error) });
+const failure = (err) => {
+  console.error(err);
+  process.exit(1);
+};
 
-(async () => {
-  const { rpc_node, secret, confirmation, destination, entrypoint, payload } =
-    input();
+/** @param {Response} message */
+const write = (message) => {
+  const callback = (err) => {
+    if (err) {
+      failure(err);
+    }
+  };
+  const messageString = JSON.stringify(message);
+  process.stdout.write(messageString + "\n", callback);
+};
+
+const read = (callback) => {
+  let buf = "";
+  /* WARNING: inputs are separated by new lines,
+    that means each input must be contained in a single line
+
+    similar to http://ndjson.org/
+  */
+  const parseStream = Transform({
+    objectMode: true,
+    transform(chunk, encoding, done) {
+      if (encoding !== "utf8") {
+        throw TypeError("encoding expected to be utf8");
+      }
+      buf = buf + chunk;
+
+      const newline = buf.indexOf("\n");
+      if (newline === -1) {
+        done();
+        return;
+      }
+
+      const message = buf.slice(0, newline);
+      // skips the newline
+      buf = buf.slice(newline + 1);
+
+      try {
+        const json = JSON.parse(message);
+        this.push(json);
+        done();
+      } catch (err) {
+        done(err);
+      }
+    },
+  });
+  const errorHandler = (err = "close") => failure(err);
+
+  pipeline(process.stdin, parseStream, errorHandler).on("data", callback);
+};
+
+// This is also defined on the other JS scripts
+const config = {
+  shouldObservableSubscriptionRetry: true,
+  streamerPollingIntervalMilliseconds: 1000,
+  confirmationPollingIntervalSecond: 1,
+};
+
+/** @param {Request} request */
+const onRequest = async (request) => {
+  const {
+    id,
+    rpc_node,
+    secret,
+    confirmation,
+    destination,
+    entrypoint,
+    payload,
+  } = request;
+
   const args = Object.entries(payload)
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([_, value]) => value);
   const Tezos = new TezosToolkit(rpc_node);
   const signer = await InMemorySigner.fromSecretKey(secret);
-  // This is also defined on the other JS scripts
-  Tezos.setProvider({
-    signer,
-    config: {
-      shouldObservableSubscriptionRetry: true,
-      streamerPollingIntervalMilliseconds: 1000,
-      confirmationPollingIntervalSecond: 1,
-    },
-  });
+  Tezos.setProvider({ signer, config });
 
   const contract = await Tezos.contract.at(destination);
   const operation = await contract.methods[entrypoint](...args).send();
   await operation.confirmation(confirmation);
 
-  finished(operation.status, operation.hash);
-})().catch(error);
+  const status = operation.status;
+  const hash = operation.hash;
+  write({ id, status, hash });
+};
+
+read((request) =>
+  onRequest(request)
+    .catch((err) => {
+      const id = request.id;
+      const status = "error";
+      const error = JSON.stringify(err);
+      write({ id, status, error });
+    })
+    .catch(failure)
+);

--- a/src/tezos_interop/run_entrypoint.ml
+++ b/src/tezos_interop/run_entrypoint.ml
@@ -1,0 +1,64 @@
+open Helpers
+open Crypto
+open Tezos
+
+type input = {
+  rpc_node : string;
+  secret : string;
+  confirmation : int;
+  destination : string;
+  entrypoint : string;
+  payload : Yojson.Safe.t;
+}
+[@@deriving to_yojson]
+type output =
+  | Applied     of { hash : string }
+  | Failed      of { hash : string }
+  | Skipped     of { hash : string }
+  | Backtracked of { hash : string }
+  | Unknown     of { hash : string }
+  | Error       of string
+let output_of_yojson json =
+  let module T = struct
+    type t = { status : string } [@@deriving of_yojson { strict = false }]
+
+    and finished = { hash : string }
+
+    and error = { error : string }
+  end in
+  let finished make =
+    let%ok { hash } = T.finished_of_yojson json in
+    Ok (make hash) in
+  let%ok { status } = T.of_yojson json in
+  match status with
+  | "applied" -> finished (fun hash -> Applied { hash })
+  | "failed" -> finished (fun hash -> Failed { hash })
+  | "skipped" -> finished (fun hash -> Skipped { hash })
+  | "backtracked" -> finished (fun hash -> Backtracked { hash })
+  | "unknown" -> finished (fun hash -> Unknown { hash })
+  | "error" ->
+    let%ok { error } = T.error_of_yojson json in
+    Ok (Error error)
+  | _ -> Error "invalid status"
+let file = Scripts.file_run_entrypoint
+let run ~rpc_node ~secret ~required_confirmations ~destination ~entrypoint
+    ~payload =
+  let input =
+    {
+      rpc_node = Uri.to_string rpc_node;
+      secret = Secret.to_string secret;
+      confirmation = required_confirmations;
+      destination = Address.to_string destination;
+      entrypoint;
+      payload;
+    } in
+  let command = "node" in
+  let%await output =
+    Lwt_process.pmap
+      (command, [|command; file|])
+      (Yojson.Safe.to_string (input_to_yojson input)) in
+  match Yojson.Safe.from_string output |> output_of_yojson with
+  | Ok data ->
+    Format.eprintf "Commit operation result: %s\n%!" output;
+    await data
+  | Error error -> await (Error error)

--- a/src/tezos_interop/run_entrypoint.ml
+++ b/src/tezos_interop/run_entrypoint.ml
@@ -2,48 +2,212 @@ open Helpers
 open Crypto
 open Tezos
 
-type input = {
-  rpc_node : string;
-  secret : string;
-  confirmation : int;
-  destination : string;
-  entrypoint : string;
-  payload : Yojson.Safe.t;
-}
-[@@deriving to_yojson]
-type output =
-  | Applied     of { hash : string }
-  | Failed      of { hash : string }
-  | Skipped     of { hash : string }
-  | Backtracked of { hash : string }
-  | Unknown     of { hash : string }
-  | Error       of string
-let output_of_yojson json =
-  let module T = struct
-    type t = { status : string } [@@deriving of_yojson { strict = false }]
+type id = int [@@deriving yojson]
+let initial_id = 0
+module Id_map = Map.Make (Int)
 
-    and finished = { hash : string }
+module Request = struct
+  type transaction = {
+    rpc_node : string;
+    secret : string;
+    confirmation : int;
+    destination : string;
+    entrypoint : string;
+    payload : Yojson.Safe.t;
+  }
 
-    and error = { error : string }
-  end in
-  let finished make =
-    let%ok { hash } = T.finished_of_yojson json in
-    Ok (make hash) in
-  let%ok { status } = T.of_yojson json in
-  match status with
-  | "applied" -> finished (fun hash -> Applied { hash })
-  | "failed" -> finished (fun hash -> Failed { hash })
-  | "skipped" -> finished (fun hash -> Skipped { hash })
-  | "backtracked" -> finished (fun hash -> Backtracked { hash })
-  | "unknown" -> finished (fun hash -> Unknown { hash })
-  | "error" ->
-    let%ok { error } = T.error_of_yojson json in
-    Ok (Error error)
-  | _ -> Error "invalid status"
-let file = Scripts.file_run_entrypoint
-let run ~rpc_node ~secret ~required_confirmations ~destination ~entrypoint
+  type t = {
+    id : id;
+    content : transaction;
+  }
+
+  let to_yojson request =
+    let module T = struct
+      type t = {
+        id : id;
+        rpc_node : string;
+        secret : string;
+        confirmation : int;
+        destination : string;
+        entrypoint : string;
+        payload : Yojson.Safe.t;
+      }
+      [@@deriving to_yojson]
+    end in
+    let { id; content } = request in
+    let { rpc_node; secret; confirmation; destination; entrypoint; payload } =
+      content in
+    T.to_yojson
+      { id; rpc_node; secret; confirmation; destination; entrypoint; payload }
+end
+
+module Response = struct
+  type transaction =
+    | Applied     of { hash : string }
+    | Failed      of { hash : string }
+    | Skipped     of { hash : string }
+    | Backtracked of { hash : string }
+    | Unknown     of { hash : string }
+    | Error       of string
+  type t = {
+    id : id;
+    content : transaction;
+  }
+
+  let transaction_of_yojson json =
+    let module T = struct
+      type t = { status : string }
+      and finished = { hash : string }
+      and error = { error : string } [@@deriving of_yojson { strict = false }]
+    end in
+    let finished make =
+      let%ok { hash } = T.finished_of_yojson json in
+      Ok (make hash) in
+    let%ok { status } = T.of_yojson json in
+    match status with
+    | "applied" -> finished (fun hash -> Applied { hash })
+    | "failed" -> finished (fun hash -> Failed { hash })
+    | "skipped" -> finished (fun hash -> Skipped { hash })
+    | "backtracked" -> finished (fun hash -> Backtracked { hash })
+    | "unknown" -> finished (fun hash -> Unknown { hash })
+    | "error" ->
+      let%ok { error } = T.error_of_yojson json in
+      Ok (Error error)
+    | _ -> Error "invalid status"
+
+  let of_yojson json =
+    let module T = struct
+      type header = { id : int } [@@deriving of_yojson { strict = false }]
+    end in
+    let%ok { id } = T.header_of_yojson json in
+    let%ok content = transaction_of_yojson json in
+    Ok { id; content }
+end
+
+module Process : sig
+  type t
+  val spawn : unit -> t
+  val request : t -> Request.transaction -> Response.transaction Lwt.t
+end = struct
+  exception Failed_to_parse_json of string
+  exception Process_closed of Unix.process_status
+  exception Unknown_responde_id of Response.t
+
+  type t = {
+    mutable next_id : id;
+    mutable request_promise : Request.t Lwt.t;
+    mutable request_resolver : Request.t Lwt.u;
+    mutable response_pending : Response.transaction Lwt.u Id_map.t;
+  }
+
+  let make () =
+    let request_promise, request_resolver = Lwt.wait () in
+    {
+      next_id = initial_id;
+      request_promise;
+      request_resolver;
+      response_pending = Id_map.empty;
+    }
+
+  let on_fail exn =
+    Format.eprintf "tezos_interop failure: %s\n%!" (Printexc.to_string exn);
+    exit 1
+
+  let spawn_node_process ~file ~to_yojson ~of_yojson input_stream =
+    let node = "node" in
+    let command = (node, [|node; file|]) in
+
+    let process = Lwt_process.open_process command in
+
+    (* handle process failure *)
+    Lwt.async (fun () ->
+        Lwt.catch
+          (fun () ->
+            (* this should never return *)
+            let%await status = process#status in
+            raise (Process_closed status))
+          on_fail);
+
+    (* TODO: test that exception on input and output kill the node *)
+    let input_stream =
+      Lwt_stream.map
+        (fun input ->
+          let json = to_yojson input in
+          Yojson.Safe.to_string json)
+        input_stream in
+    (* handle input exceptions *)
+    Lwt.async (fun () ->
+        Lwt.catch
+          (fun () -> Lwt_io.write_lines process#stdin input_stream)
+          on_fail);
+
+    let output_stream = Lwt_io.read_lines process#stdout in
+    let output_stream =
+      Lwt_stream.map
+        (fun line ->
+          Format.eprintf "Run_entrypoint: %s\n%!" line;
+          (* TODO: are exceptions on Lwt_stream.map safe? *)
+          let json = Yojson.Safe.from_string line in
+          match of_yojson json with
+          | Ok value -> value
+          | Error error -> raise (Failed_to_parse_json error))
+        output_stream in
+    (* handle output exceptions *)
+    let output_stream =
+      Lwt_stream.map
+        (function
+          | Ok value -> value
+          | Error exn -> on_fail exn)
+        (Lwt_stream.wrap_exn output_stream) in
+    output_stream
+
+  let handle_output process response =
+    let id = response.Response.id in
+    match Id_map.find_opt id process.response_pending with
+    | Some resolver -> Lwt.wakeup_later resolver response.content
+    | None -> raise (Unknown_responde_id response)
+  let handle_outputs process output_stream =
+    Lwt_stream.iter (fun output -> handle_output process output) output_stream
+
+  let spawn () =
+    let t = make () in
+
+    let file = Scripts.file_run_entrypoint in
+    let input_stream =
+      Lwt_stream.from (fun () ->
+          let%await request = t.request_promise in
+          Lwt.return (Some request)) in
+    let output_stream =
+      spawn_node_process ~file ~to_yojson:Request.to_yojson
+        ~of_yojson:Response.of_yojson input_stream in
+
+    Lwt.async (fun () ->
+        Lwt.catch (fun () -> handle_outputs t output_stream) on_fail);
+
+    t
+
+  let request t content =
+    let id = t.next_id in
+    let request_resolver = t.request_resolver in
+    let new_request_promise, new_request_resolver = Lwt.wait () in
+    let response_promise, response_resolver = Lwt.wait () in
+    let response_pending = Id_map.add id response_resolver t.response_pending in
+
+    t.next_id <- id + 1;
+    t.request_promise <- new_request_promise;
+    t.request_resolver <- new_request_resolver;
+    t.response_pending <- response_pending;
+
+    let request = Request.{ id; content } in
+    (* resolved only after updating t.request_resolver *)
+    Lwt.wakeup_later request_resolver request;
+
+    response_promise
+end
+
+let run t ~rpc_node ~secret ~required_confirmations ~destination ~entrypoint
     ~payload =
-  let input =
+  Process.request t
     {
       rpc_node = Uri.to_string rpc_node;
       secret = Secret.to_string secret;
@@ -51,14 +215,4 @@ let run ~rpc_node ~secret ~required_confirmations ~destination ~entrypoint
       destination = Address.to_string destination;
       entrypoint;
       payload;
-    } in
-  let command = "node" in
-  let%await output =
-    Lwt_process.pmap
-      (command, [|command; file|])
-      (Yojson.Safe.to_string (input_to_yojson input)) in
-  match Yojson.Safe.from_string output |> output_of_yojson with
-  | Ok data ->
-    Format.eprintf "Commit operation result: %s\n%!" output;
-    await data
-  | Error error -> await (Error error)
+    }

--- a/src/tezos_interop/run_entrypoint.ml
+++ b/src/tezos_interop/run_entrypoint.ml
@@ -91,7 +91,7 @@ module Process : sig
 end = struct
   exception Failed_to_parse_json of string
   exception Process_closed of Unix.process_status
-  exception Unknown_responde_id of Response.t
+  exception Unknown_response_id of Response.t
 
   type t = {
     mutable next_id : id;
@@ -110,6 +110,7 @@ end = struct
     }
 
   let on_fail exn =
+    (* TODO: https://github.com/marigold-dev/deku/issues/502 *)
     Format.eprintf "tezos_interop failure: %s\n%!" (Printexc.to_string exn);
     exit 1
 
@@ -165,7 +166,7 @@ end = struct
     let id = response.Response.id in
     match Id_map.find_opt id process.response_pending with
     | Some resolver -> Lwt.wakeup_later resolver response.content
-    | None -> raise (Unknown_responde_id response)
+    | None -> raise (Unknown_response_id response)
   let handle_outputs process output_stream =
     Lwt_stream.iter (fun output -> handle_output process output) output_stream
 

--- a/src/tezos_interop/run_entrypoint.mli
+++ b/src/tezos_interop/run_entrypoint.mli
@@ -1,0 +1,19 @@
+open Crypto
+open Tezos
+
+type output =
+  | Applied     of { hash : string }
+  | Failed      of { hash : string }
+  | Skipped     of { hash : string }
+  | Backtracked of { hash : string }
+  | Unknown     of { hash : string }
+  | Error       of string
+
+val run :
+  rpc_node:Uri.t ->
+  secret:Secret.t ->
+  required_confirmations:int ->
+  destination:Address.t ->
+  entrypoint:string ->
+  payload:Yojson.Safe.t ->
+  output Lwt.t

--- a/src/tezos_interop/run_entrypoint.mli
+++ b/src/tezos_interop/run_entrypoint.mli
@@ -1,19 +1,26 @@
 open Crypto
 open Tezos
 
-type output =
-  | Applied     of { hash : string }
-  | Failed      of { hash : string }
-  | Skipped     of { hash : string }
-  | Backtracked of { hash : string }
-  | Unknown     of { hash : string }
-  | Error       of string
+module Process : sig
+  type t
+  val spawn : unit -> t
+end
+module Response : sig
+  type transaction =
+    | Applied     of { hash : string }
+    | Failed      of { hash : string }
+    | Skipped     of { hash : string }
+    | Backtracked of { hash : string }
+    | Unknown     of { hash : string }
+    | Error       of string
+end
 
 val run :
+  Process.t ->
   rpc_node:Uri.t ->
   secret:Secret.t ->
   required_confirmations:int ->
   destination:Address.t ->
   entrypoint:string ->
   payload:Yojson.Safe.t ->
-  output Lwt.t
+  Response.transaction Lwt.t

--- a/src/tezos_interop/tezos_interop.ml
+++ b/src/tezos_interop/tezos_interop.ml
@@ -12,66 +12,13 @@ let make ~rpc_node ~secret ~consensus_contract ~required_confirmations =
   { rpc_node; secret; consensus_contract; required_confirmations }
 
 module Run_contract = struct
-  type input = {
-    rpc_node : string;
-    secret : string;
-    confirmation : int;
-    destination : string;
-    entrypoint : string;
-    payload : Yojson.Safe.t;
-  }
-  [@@deriving to_yojson]
-  type output =
-    | Applied     of { hash : string }
-    | Failed      of { hash : string }
-    | Skipped     of { hash : string }
-    | Backtracked of { hash : string }
-    | Unknown     of { hash : string }
-    | Error       of string
-  let output_of_yojson json =
-    let module T = struct
-      type t = { status : string } [@@deriving of_yojson { strict = false }]
-
-      and finished = { hash : string }
-
-      and error = { error : string }
-    end in
-    let finished make =
-      let%ok { hash } = T.finished_of_yojson json in
-      Ok (make hash) in
-    let%ok { status } = T.of_yojson json in
-    match status with
-    | "applied" -> finished (fun hash -> Applied { hash })
-    | "failed" -> finished (fun hash -> Failed { hash })
-    | "skipped" -> finished (fun hash -> Skipped { hash })
-    | "backtracked" -> finished (fun hash -> Backtracked { hash })
-    | "unknown" -> finished (fun hash -> Unknown { hash })
-    | "error" ->
-      let%ok { error } = T.error_of_yojson json in
-      Ok (Error error)
-    | _ -> Error "invalid status"
-  let file = Scripts.file_run_entrypoint
-  let run (t : t) ~destination ~entrypoint ~payload =
-    let input =
-      {
-        rpc_node = t.rpc_node |> Uri.to_string;
-        secret = t.secret |> Secret.to_string;
-        confirmation = t.required_confirmations;
-        destination = Address.to_string destination;
-        entrypoint;
-        payload;
-      } in
-    let command = "node" in
-    let%await output =
-      Lwt_process.pmap
-        (command, [|command; file|])
-        (Yojson.Safe.to_string (input_to_yojson input)) in
-    match Yojson.Safe.from_string output |> output_of_yojson with
-    | Ok data ->
-      Format.eprintf "Commit operation result: %s\n%!" output;
-      await data
-    | Error error -> await (Error error)
+  let run t ~destination ~entrypoint ~payload =
+    let { rpc_node; secret; required_confirmations; consensus_contract = _ } =
+      t in
+    Run_entrypoint.run ~rpc_node ~secret ~required_confirmations ~destination
+      ~entrypoint ~payload
 end
+
 let michelson_of_yojson json =
   let%ok json = Yojson.Safe.to_string json |> Data_encoding.Json.from_string in
   try
@@ -131,6 +78,7 @@ end = struct
     | Ok storage -> await (Ok storage)
     | Error error -> await (Error error)
 end
+
 module Listen_transactions = struct
   type transaction = {
     entrypoint : string;

--- a/src/tezos_interop/tezos_interop.mli
+++ b/src/tezos_interop/tezos_interop.mli
@@ -1,17 +1,18 @@
 open Helpers
 open Crypto
 open Tezos
-module Context : sig
-  type t = {
-    rpc_node : Uri.t;
-    secret : Secret.t;
-    consensus_contract : Address.t;
-    required_confirmations : int;
-  }
-end
+
+type t
+val make :
+  rpc_node:Uri.t ->
+  secret:Secret.t ->
+  consensus_contract:Address.t ->
+  required_confirmations:int ->
+  t
+
 module Consensus : sig
   val commit_state_hash :
-    context:Context.t ->
+    t ->
     block_height:int64 ->
     block_payload_hash:BLAKE2B.t ->
     state_hash:BLAKE2B.t ->
@@ -19,8 +20,7 @@ module Consensus : sig
     validators:Key_hash.t list ->
     signatures:(Key.t * Signature.t) option list ->
     unit Lwt.t
-    [@@ocaml.doc
-      " ~signatures should be in the same order as the old validators "]
+  (** ~signatures should be in the same order as the old validators *)
 
   type transaction =
     | Deposit          of {
@@ -33,10 +33,8 @@ module Consensus : sig
     hash : Operation_hash.t;
     transactions : transaction list;
   }
-  val listen_operations :
-    context:Context.t -> on_operation:(operation -> unit) -> unit
-  val fetch_validators :
-    context:Context.t -> (Key_hash.t list, string) result Lwt.t
+  val listen_operations : t -> on_operation:(operation -> unit) -> unit
+  val fetch_validators : t -> (Key_hash.t list, string) result Lwt.t
 end
 module Discovery : sig
   val sign : Secret.t -> nonce:int64 -> Uri.t -> Signature.t


### PR DESCRIPTION
## Depends

- [x] #495

## Problem

Due to Multicore not working with `Unix.fork` we had some problems on #414, this happens because spawning processes doesn't work after multiple domains are running.

## Solution

To work around this problem, this PR makes `run_entrypoint.js` long lived and critical, so if it fails the node also dies with it.

## **Warning**

I didn't review this PR, so please be careful. But it seems to work locally