### PR TITLE
Temporary Hack: Turn off Nix CI

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,9 +1,5 @@
 name: "Test in nix"
-on:
-  pull_request:
-  push:
-    branches:
-      - main
+on: [workflow_dispatch]
 jobs:
   linux:
     runs-on: ubuntu-latest


### PR DESCRIPTION


## Problem

Nix CI is currently broken. 

## Solution

Turn it off temporarily. I'm working on a PR to fix it but it's very low priority and I don't want people to have to wait with red CI. I also think it will be cleaner if we fix #487 first.