### PR TITLE
Fix broken Githun action ID

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,24 +23,25 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
-        # Only push if on main branch
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          file: ./docker/static.Dockerfile
-          context: .
-          platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          push: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
-          tags: |
-            ghcr.io/marigold-dev/deku:latest
-            ghcr.io/marigold-dev/deku:${{ github.sha }}
+      # TODO: fix our static build
+      # - name: Build and push
+      #   # Only push if on main branch
+      #   id: docker_build
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     file: ./docker/static.Dockerfile
+      #     context: .
+      #     platforms: linux/amd64
+      #     cache-from: type=gha
+      #     cache-to: type=gha,mode=max
+      #     push: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+      #     tags: |
+      #       ghcr.io/marigold-dev/deku:latest
+      #       ghcr.io/marigold-dev/deku:${{ github.sha }}
 
       - name: Build and push esy
         # Only push if on main branch
-        id: docker_build
+        id: docker_build_esy
         uses: docker/build-push-action@v2
         with:
           file: ./docker/esy.Dockerfile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,21 +23,20 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # TODO: fix our static build
-      # - name: Build and push
-      #   # Only push if on main branch
-      #   id: docker_build
-      #   uses: docker/build-push-action@v2
-      #   with:
-      #     file: ./docker/static.Dockerfile
-      #     context: .
-      #     platforms: linux/amd64
-      #     cache-from: type=gha
-      #     cache-to: type=gha,mode=max
-      #     push: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
-      #     tags: |
-      #       ghcr.io/marigold-dev/deku:latest
-      #       ghcr.io/marigold-dev/deku:${{ github.sha }}
+      - name: Build and push
+        # Only push if on main branch
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          file: ./docker/static.Dockerfile
+          context: .
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+          tags: |
+            ghcr.io/marigold-dev/deku:latest
+            ghcr.io/marigold-dev/deku:${{ github.sha }}
 
       - name: Build and push esy
         # Only push if on main branch


### PR DESCRIPTION

## Problem

Observe that our Docker CI is failing because we have multiple builds with id `docker_build`: https://github.com/marigold-dev/deku/actions/runs/2059345040

## Solution

- change the id's to be unique
- ~disable the docker static build, since it's broken anyway right now.~
