### PR TITLE
Fix the land primitive on ppx_lambda_vm

### DIFF
--- a/ppx_lambda_vm/ppx_lambda_vm.ml
+++ b/ppx_lambda_vm/ppx_lambda_vm.ml
@@ -79,7 +79,7 @@ let rec expr_of_ocaml_expr expr =
     | "*" -> [%expr Prim Mul]
     | "/" -> [%expr Prim Div]
     | "mod" -> [%expr Prim Rem]
-    | "land" -> [%expr Prim And]
+    | "land" -> [%expr Prim Land]
     | "lor" -> [%expr Prim Lor]
     | "lxor" -> [%expr Prim Lxor]
     | "lsl" -> [%expr Prim Lsl]


### PR DESCRIPTION
<!---
  if some of the following sections doesn't apply,
  delete the section.

  Also feel free to delete the comments.
--->

## Depends

<!--- All PR or issues that are required to be closed / merged before this can be merged --->
- [x] #508 

## Problem

<!--- Restate the problem addressed by the PR here --->
Using the `land` primitive on ppx_lambda_vm translates to `And` and not `Land` which gives the following error:

```
1 | let _a = [%lambda_vm 0L land 1L]
                            ^^^^
Error: This variant expression is expected to have type prim
       There is no constructor And within type prim
```

## Solution

<!--- Restate the basic ideas behind your solution --->
Use the proper type constructor
<!--- Here it is also a good space to put details of your implementation --->


 