### PR TITLE
docker: fix static image

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -12,8 +12,7 @@
   "license": "MIT",
   "scripts": {
     "test": "dune test",
-    "format": "dune build @fmt --auto-promote",
-    "build_static": "dune build --profile=static --release"
+    "format": "dune build @fmt --auto-promote"
   },
   "dependencies": {
     "ocaml": "4.12.",

--- a/src/bin/dune
+++ b/src/bin/dune
@@ -23,12 +23,5 @@
 
 (env
  (static
-  (flags
-   (:standard
-    -O2
-    -ccopt
-    -static
-    -ccopt
-    %{env:CFLAGS=/lib}
-    -cclib
-    -L%{env:LD_LIBRARY_PATH=/lib}))))
+  (ocamlopt_flags
+   (:standard -O2 -ccopt -static))))


### PR DESCRIPTION
## Problem

Currently the static docker image is not working.

## Solution

Ensuring that only `deku_{node,cli}.exe` builds and also removing the unused / broken flags fix the static binary built. But Deku needs NodeJS to run, so for now let's use the Alpine image instead of scratch.