### PR TITLE
Add deku-cli and deku-node as apps in nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,5 +41,16 @@
       in {
         devShell = import ./nix/shell.nix { inherit pkgs deku npmPackages; };
         packages = { inherit deku; };
+
+        apps = {
+          deku-cli = {
+            type = "app";
+            program = "${deku}/bin/deku-cli";
+          };
+          deku-node = {
+            type = "app";
+            program = "${deku}/bin/deku-node";
+          };
+        };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,8 @@
 
   # Setup trusted binary caches
   nixConfig = {
-    trusted-substituters = [
-      "https://cache.nixos.org/"
-      "https://deku.cachix.org"
-    ];
+    trusted-substituters =
+      [ "https://cache.nixos.org/" "https://deku.cachix.org" ];
   };
 
   inputs = {
@@ -18,29 +16,30 @@
     nix-npm-buildpackage.url = "github:serokell/nix-npm-buildpackage";
   };
 
-  outputs = { self, nixpkgs, flake-utils, nix-npm-buildpackage, ocaml-overlays }:
+  outputs =
+    { self, nixpkgs, flake-utils, nix-npm-buildpackage, ocaml-overlays }:
     with flake-utils.lib;
-    eachSystem [ system.x86_64-linux ]
-      (system:
-        let
-          pkgs = import nixpkgs {
-            inherit system;
-            overlays = [ ocaml-overlays.overlay (import ./nix/overlay.nix) ];
-          };
+    eachSystem [ system.x86_64-linux ] (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ ocaml-overlays.overlay (import ./nix/overlay.nix) ];
+        };
 
-          bp = pkgs.callPackage nix-npm-buildpackage { nodejs = pkgs.nodejs-12_x; };
-          npmPackages = bp.buildNpmPackage { src = ./.; npmBuild = "echo ok"; };
+        bp =
+          pkgs.callPackage nix-npm-buildpackage { nodejs = pkgs.nodejs-12_x; };
+        npmPackages = bp.buildNpmPackage {
+          src = ./.;
+          npmBuild = "echo ok";
+        };
 
-          deku = pkgs.callPackage ./nix/deku.nix {
-            doCheck = true;
-            nodejs = pkgs.nodejs-12_x;
-            inherit npmPackages;
-          };
-        in
-        {
-          devShell = import ./nix/shell.nix { inherit pkgs deku npmPackages; };
-          packages = {
-            inherit deku;
-          };
-        });
+        deku = pkgs.callPackage ./nix/deku.nix {
+          doCheck = true;
+          nodejs = pkgs.nodejs-12_x;
+          inherit npmPackages;
+        };
+      in {
+        devShell = import ./nix/shell.nix { inherit pkgs deku npmPackages; };
+        packages = { inherit deku; };
+      });
 }

--- a/nix/deku.nix
+++ b/nix/deku.nix
@@ -7,7 +7,8 @@ pkgs.ocamlPackages.buildDunePackage {
   src = lib.filterSource {
     src = ./..;
     dirs = [ "src" "ppx_let_binding" "ppx_lambda_vm" "tests" ];
-    files = [ "dune-project" "sidechain.opam" "package.json" "package-lock.json" ];
+    files =
+      [ "dune-project" "sidechain.opam" "package.json" "package-lock.json" ];
   };
 
   configurePhase = ''
@@ -19,9 +20,7 @@ pkgs.ocamlPackages.buildDunePackage {
 
   inherit doCheck;
 
-  nativeBuildInputs = [
-    nodejs
-  ] ++ (with pkgs.ocamlPackages; [
+  nativeBuildInputs = [ nodejs ] ++ (with pkgs.ocamlPackages; [
     cmdliner
     ppx_deriving
     ppx_deriving_yojson
@@ -44,9 +43,7 @@ pkgs.ocamlPackages.buildDunePackage {
     reason
   ]);
 
-  propagatedBuildInputs = [
-    npmPackages
-  ];
+  propagatedBuildInputs = [ npmPackages ];
 
   checkInputs = with pkgs.ocamlPackages; [
     alcotest

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,42 +1,45 @@
 final: prev:
-let disableCheck = package:
-  package.overrideAttrs (o: { doCheck = false; });
-in
-{
-  ocamlPackages = prev.ocaml-ng.ocamlPackages_5_00.overrideScope' (oself: osuper: rec {
-    rely = osuper.reason-native.rely.overrideAttrs (_: {
-      postPatch = ''
-        substituteInPlace src/rely/TestSuiteRunner.re --replace "Pervasives" "Stdlib"
-      '';
+let disableCheck = package: package.overrideAttrs (o: { doCheck = false; });
+in {
+  ocamlPackages = prev.ocaml-ng.ocamlPackages_5_00.overrideScope'
+    (oself: osuper: rec {
+      rely = osuper.reason-native.rely.overrideAttrs (_: {
+        postPatch = ''
+          substituteInPlace src/rely/TestSuiteRunner.re --replace "Pervasives" "Stdlib"
+        '';
+      });
+      alcotest = osuper.alcotest.overrideAttrs (o: {
+        src = prev.fetchurl {
+          url =
+            "https://github.com/mirage/alcotest/releases/download/1.5.0/alcotest-js-1.5.0.tbz";
+          sha256 = "0v4ghia378g3l53r61fj98ljha0qxl82xp26y9frjy1dw03ija2l";
+        };
+        propagatedBuildInputs =
+          prev.lib.lists.remove osuper.uuidm o.propagatedBuildInputs;
+      });
+      qcheck = osuper.qcheck.overrideAttrs (_: {
+        src = prev.fetchurl {
+          url = "https://github.com/c-cube/qcheck/archive/v0.18.1.tar.gz";
+          sha256 = "1jzhwrzsf5290rs7hsa1my5yh1x95sh2sz92c4svd8yahzdlny7m";
+        };
+      });
+      data-encoding = disableCheck osuper.data-encoding;
+      json-data-encoding = disableCheck osuper.json-data-encoding;
+      json-data-encoding-bson = disableCheck osuper.json-data-encoding-bson;
+      hxd = disableCheck (osuper.hxd.overrideAttrs (o: {
+        src = builtins.fetchurl {
+          url =
+            "https://github.com/dinosaure/hxd/releases/download/v0.3.1/hxd-v0.3.1.tbz";
+          sha256 = "1g19dgwj29ykrv3gk7q66fjjlc1n1z9bz1y2q3g2klvww68nq8hw";
+        };
+      }));
+      mrmime = disableCheck osuper.mrmime;
+      cmdliner = osuper.cmdliner.overrideAttrs (_: {
+        src = builtins.fetchurl {
+          url =
+            "https://github.com/dbuenzli/cmdliner/archive/refs/tags/v1.0.4.tar.gz";
+          sha256 = "13c53b1cxkq2nj444655skw5a1mcxzbaqwqsqjf7jbwradb3hmxa";
+        };
+      });
     });
-    alcotest = osuper.alcotest.overrideAttrs (o: {
-      src = prev.fetchurl {
-        url = "https://github.com/mirage/alcotest/releases/download/1.5.0/alcotest-js-1.5.0.tbz";
-        sha256 = "0v4ghia378g3l53r61fj98ljha0qxl82xp26y9frjy1dw03ija2l";
-      };
-      propagatedBuildInputs = prev.lib.lists.remove osuper.uuidm o.propagatedBuildInputs;
-    });
-    qcheck = osuper.qcheck.overrideAttrs (_: {
-      src = prev.fetchurl {
-        url = "https://github.com/c-cube/qcheck/archive/v0.18.1.tar.gz";
-        sha256 = "1jzhwrzsf5290rs7hsa1my5yh1x95sh2sz92c4svd8yahzdlny7m";
-      };
-    });
-    data-encoding = disableCheck osuper.data-encoding;
-    json-data-encoding = disableCheck osuper.json-data-encoding;
-    json-data-encoding-bson = disableCheck osuper.json-data-encoding-bson;
-    hxd = disableCheck (osuper.hxd.overrideAttrs (o: {
-      src = builtins.fetchurl {
-        url = "https://github.com/dinosaure/hxd/releases/download/v0.3.1/hxd-v0.3.1.tbz";
-        sha256 = "1g19dgwj29ykrv3gk7q66fjjlc1n1z9bz1y2q3g2klvww68nq8hw";
-      };
-    }));
-    mrmime = disableCheck osuper.mrmime;
-    cmdliner = osuper.cmdliner.overrideAttrs (_: {
-      src = builtins.fetchurl {
-        url = "https://github.com/dbuenzli/cmdliner/archive/refs/tags/v1.0.4.tar.gz";
-        sha256 = "13c53b1cxkq2nj444655skw5a1mcxzbaqwqsqjf7jbwradb3hmxa";
-      };
-    });
-  });
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -10,18 +10,18 @@ pkgs.mkShell {
     export USE_NIX=y
   '';
   inputsFrom = [ deku ];
-  packages = with pkgs; [
-    # Make developer life easier
-    ## General tooling
-    docker
-    nodejs-17_x
-
-    # formatters
-    nixfmt
-    nodePackages.prettier
-    ocamlformat
-  ] ++ (with pkgs.ocamlPackages;
+  packages = with pkgs;
     [
+      # Make developer life easier
+      ## General tooling
+      docker
+      nodejs-17_x
+
+      # formatters
+      nixfmt
+      nodePackages.prettier
+      ocamlformat
+    ] ++ (with pkgs.ocamlPackages; [
       # OCaml developer tooling
       ocaml
       findlib


### PR DESCRIPTION
## Problem

<!--- Restate the problem addressed by the PR here --->

Now that we have flakes it would be nice to have a simple way of running our tools with it

## Solution

<!--- Restate the basic ideas behind your solution --->
<!--- Here it is also a good space to put details of your implementation --->

Adding the `deku-cli` and `deku-node` as apps.
They can now be run from the repository like `nix run .#deku-cli` or `nix run .#deku-node`.
We should also be able to run `nix run github:marigold-dev/deku#deku-cli` from anywhere.

## Testing

Checkout branch and run  `nix run .#deku-cli` or `nix run .#deku-node`