### PR TITLE
chore: add nixfmt ci

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -16,5 +16,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_SIGNING_KEY }}"
       - name: "Run nix flake check"
         run: nix flake check
+      - name: "Check nix formatting"
+        run: nix develop -c nixfmt --check ./flake.nix ./nix/*.nix
       - name: "Build deku via flakes"
         run: nix build --verbose .#deku


### PR DESCRIPTION
## Problem

nix code formatting isn't checked.

## Solution

Check formatting in CI, just like ocaml code.

We may want to use e.g. https://github.com/numtide/treefmt in the future.