### PR TITLE
add auto-build to ./sandbox.sh

### DIFF
--- a/sandbox.sh
+++ b/sandbox.sh
@@ -7,6 +7,8 @@ data_directory="data"
 [ "$USE_NIX" ] || export LD_LIBRARY_PATH=$(esy x sh -c 'echo $LD_LIBRARY_PATH')
 [ "$USE_NIX" ] || export PATH=$(esy x sh -c 'echo $PATH')
 
+[ "$USE_NIX" ] && dune build @install
+
 tezos-client() {
   docker exec -it deku_flextesa tezos-client "$@"
 }


### PR DESCRIPTION

## Problem

You don't want to run `./sandbox.sh` with old code - you'll inevitably get confused and lose time debugging.

Esy users dodge this because `esy x` rebuilds the environment. Nix users hit this.

## Solution

I'm not sure if this is a great solution, but it's simple enough. What do you guys think?
