### PR TITLE
feat: add prometheus to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,6 +126,17 @@ services:
       - api
     ports:
       - 127.0.0.1:8000:80
+  prometheus:
+    container_name: deku_prometheus
+    restart: always
+    image: prom/prometheus
+    network_mode: "host"  
+    ports:
+      - "9090:9090"
+    expose:
+      - 9090/tcp
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
 
 volumes:
   esdata:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,8 @@
+scrape_configs:
+  - job_name: 'deku'
+    scrape_interval: 1s
+    static_configs:
+      # TODO: currently these are hard-coded for development/local benchmarking
+      # But we might want to do this more dynamically. Maybe Prometheus has some
+      # dynamic config?
+      - targets: ['localhost:9000', 'localhost:9001', 'localhost:9002']


### PR DESCRIPTION
## Problem

We'd like to make prometheus stats available to
devs when testing locally.

## Solution

Add Prometheus server to docker-compse. 
This makes the dashboard available on localhost:9090.

Please test it out! It's super cool :)

<!--- Here it is also a good space to put details of your implementation --->

## How to use Prometheus

Ask Infra, I'm a prometheus noob. But here's a screenshot: 
![image](https://user-images.githubusercontent.com/25231383/162262008-c701a722-8e65-433f-a4ab-684a561fadfb.png)

If you click the "world" button you can select from available metrics. Then click "execute"
![image](https://user-images.githubusercontent.com/25231383/162262136-30adbe87-db41-48cd-92a0-c7e5dbb53eff.png)

