### PR TITLE
remove annoying log message

### DIFF
--- a/src/tezos_interop/tezos_interop.ml
+++ b/src/tezos_interop/tezos_interop.ml
@@ -170,7 +170,6 @@ module Listen_transactions = struct
         Lwt.catch
           (fun () ->
             let%await line = Lwt_io.read_line process#stdout in
-            print_endline line;
             Yojson.Safe.from_string line
             |> output_of_yojson
             |> Result.get_ok


### PR DESCRIPTION


## Problem

This one log is particularly annoying, and  I don't find it valuable.
It also doesn't use `Format` module, which means I miss it when I grep for our other logs by looking for `Format\..*`

## Solution

Remove it.
 