### PR TITLE
feat: add block-by-level rpc

### DIFF
--- a/src/bin/deku_node.ml
+++ b/src/bin/deku_node.ml
@@ -53,6 +53,17 @@ let handle_block_by_hash =
     (fun _update_state request ->
       let block = Flows.find_block_by_hash (Server.get_state ()) request.hash in
       Ok block)
+let handle_block_by_level =
+  handle_request
+    (module Networking.Block_by_level_spec)
+    (fun _update_state request ->
+      let state = Server.get_state () in
+      let block =
+        List.find_opt
+          (fun block ->
+            Int64.equal block.Protocol.Block.block_height request.level)
+          state.applied_blocks in
+      Ok block)
 let handle_block_level =
   handle_request
     (module Networking.Block_level)
@@ -131,6 +142,7 @@ let node folder prometheus_port =
              handle_received_block_and_signature;
              handle_received_signature;
              handle_block_by_hash;
+             handle_block_by_level;
              handle_protocol_snapshot;
              handle_request_nonce;
              handle_register_uri;

--- a/src/node/networking.ml
+++ b/src/node/networking.ml
@@ -64,6 +64,11 @@ module Block_by_hash_spec = struct
   type response = Block.t option [@@deriving yojson]
   let path = "/block-by-hash"
 end
+module Block_by_level_spec = struct
+  type request = { level : int64 } [@@deriving yojson]
+  type response = Block.t option [@@deriving yojson]
+  let path = "/block-by-level"
+end
 module Block_level = struct
   type request = unit [@@deriving yojson]
   type response = { level : int64 } [@@deriving yojson]
@@ -151,6 +156,7 @@ module Trusted_validators_membership_change = struct
 end
 let request_block_by_hash = request (module Block_by_hash_spec)
 let request_block_level = request (module Block_level)
+let request_block_by_level = request (module Block_by_level_spec)
 let request_protocol_snapshot = request (module Protocol_snapshot)
 let request_nonce = request (module Request_nonce)
 let request_register_uri = request (module Register_uri)

--- a/src/node/state.ml
+++ b/src/node/state.ml
@@ -24,6 +24,10 @@ type t = {
   data_folder : string;
   pending_operations : pending_operation list;
   block_pool : Block_pool.t;
+  (* TODO: we need a bound on the size of this and put
+     behind an abstract type. We should also change how
+     this works once we have an indexer. See https://github.com/marigold-dev/deku/issues/535 *)
+  applied_blocks : Block.t list;
   protocol : Protocol.t;
   snapshots : Snapshots.t;
   uri_state : string Uri_map.t;
@@ -55,6 +59,7 @@ let make ~identity ~trusted_validator_membership_change
     data_folder;
     pending_operations = [];
     block_pool = initial_block_pool;
+    applied_blocks = [];
     protocol = initial_protocol;
     snapshots = initial_snapshots;
     uri_state = Uri_map.empty;
@@ -82,7 +87,15 @@ let apply_block state block =
     List.fold_left
       (fun results (hash, receipt) -> BLAKE2B.Map.add hash receipt results)
       state.recent_operation_receipts receipts in
-  Ok { state with protocol; recent_operation_receipts; snapshots }
+  let applied_blocks = block :: state.applied_blocks in
+  Ok
+    {
+      state with
+      protocol;
+      recent_operation_receipts;
+      snapshots;
+      applied_blocks;
+    }
 let signatures_required state =
   let number_of_validators = Validators.length state.protocol.validators in
   let open Float in

--- a/src/node/state.mli
+++ b/src/node/state.mli
@@ -23,6 +23,7 @@ type t = {
   data_folder : string;
   pending_operations : pending_operation list;
   block_pool : Block_pool.t;
+  applied_blocks : Block.t list;
   protocol : Protocol.t;
   snapshots : Snapshots.t;
   uri_state : string Uri_map.t;


### PR DESCRIPTION

## Problem

There is no way to inspect the contents of blocks from outside a deku node.

## Solution

Add a `block-by-level` rpc that takes a block level as an int and returns the block with that block height, or `null` if it doesn't know the contents of that block.

This is a workaround to the fact we have no indexer, see #535. But it's pretty essential for using Deku at all, so I think the work-around is justified for now.
