### PR TITLE
Add block rate and operation rate metrics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,6 +126,17 @@ services:
       - api
     ports:
       - 127.0.0.1:8000:80
+  prometheus:
+    container_name: deku_prometheus
+    restart: always
+    image: prom/prometheus
+    network_mode: "host"  
+    ports:
+      - "9090:9090"
+    expose:
+      - 9090/tcp
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
 
 volumes:
   esdata:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,8 @@
+scrape_configs:
+  - job_name: 'deku'
+    scrape_interval: 1s
+    static_configs:
+      # TODO: currently these are hard-coded for development/local benchmarking
+      # But we might want to do this more dynamically. Maybe Prometheus has some
+      # dynamic config?
+      - targets: ['localhost:9000', 'localhost:9001', 'localhost:9002']

--- a/src/metrics/metrics.ml
+++ b/src/metrics/metrics.ml
@@ -1,2 +1,8 @@
+(* Note: By not depending on the Protocol or Node
+   libraries, we make it harder to leak sensitive data via
+   this module. Although we advise node operators not to expose
+   the port metrics are scraped from, we still don't want sensitive
+   data leaking into the metrics. *)
 module Config = Config
 module Blocks = Blocks
+module Througput = Throughput

--- a/src/metrics/throughput.ml
+++ b/src/metrics/throughput.ml
@@ -1,0 +1,22 @@
+open Prometheus
+open Config
+
+let operations_per_block =
+  let help = "The number of operations in each block" in
+  Gauge.v ~help ~namespace ~subsystem "operations_per_block"
+
+let block_rate =
+  let help = "Time between blocks" in
+  Gauge.v ~help ~namespace ~subsystem "block_rate"
+
+let previous_timestamp = ref None
+
+let collect_block_metrics ~timestamp ~operation_count =
+  Gauge.set operations_per_block (Float.of_int operation_count);
+  match !previous_timestamp with
+  | Some previous_timestamp ->
+    let delta = timestamp -. previous_timestamp in
+    Gauge.set block_rate delta
+  | None ->
+    ();
+    previous_timestamp := Some timestamp

--- a/src/metrics/throughput.mli
+++ b/src/metrics/throughput.mli
@@ -1,0 +1,1 @@
+val collect_block_metrics : timestamp:float -> operation_count:int -> unit

--- a/src/node/state.ml
+++ b/src/node/state.ml
@@ -82,6 +82,11 @@ let apply_block state block =
     List.fold_left
       (fun results (hash, receipt) -> BLAKE2B.Map.add hash receipt results)
       state.recent_operation_receipts receipts in
+  (* TODO: we might want to use a monotonic clock so we don't get weird things like
+     negative block rates. *)
+  let timestamp = Unix.time () in
+  let operation_count = List.length block.operations in
+  Metrics.Througput.collect_block_metrics ~timestamp ~operation_count;
   Ok { state with protocol; recent_operation_receipts; snapshots }
 let signatures_required state =
   let number_of_validators = Validators.length state.protocol.validators in


### PR DESCRIPTION

## Depends

- [ ] #533

## Problem

We want metrics for block rate and operations per block (from which you can derive operations rate - i.e tps - in prometheus dashboard)

## Solution

Adds these metrics.