### PR TITLE
Serialization at interop.go and docker error

### DIFF
--- a/go_interop/interop.go
+++ b/go_interop/interop.go
@@ -2,7 +2,6 @@ package deku_interop
 
 import (
 	"encoding/binary"
-	"encoding/json"
 	"fmt"
 	"os"
 )
@@ -52,10 +51,8 @@ func Get(key string) []byte {
 // Set(key,value) synchronously sets a key in the Deku state
 // to the given value. That value must be serializable
 // with json.Marshal.
-func Set(key string, value interface{}) {
-	b, err := json.Marshal(value)
-	check(err)
-	value_str := string(b)
+func Set(key string, value []byte) {
+	value_str := string(value)
 	message := []byte(fmt.Sprintf("[\"Set\",{\"key\":\"%s\",\"value\":%s}]", key, value_str))
 	write(message)
 }

--- a/tezos-testnet.docker-compose.yml
+++ b/tezos-testnet.docker-compose.yml
@@ -130,9 +130,7 @@ services:
     container_name: deku_prometheus
     restart: always
     image: prom/prometheus
-    network_mode: "host" 
-    ports:
-      - "9090:9090"
+    network_mode: "host"
     expose:
       - 9090/tcp
     volumes:


### PR DESCRIPTION
The two commits in this pull request tackle two issues:

1- Serialization at Set method in interop.go: As mentioned before in Slack, when set is called, "value" is already serialized(type []byte). So Set should expect []byte "value" and should not serialize it again.
 
2- Port mapping and "host" network_mode in docker-compose for prometheus: 
In recent Docker versions this configuration throws a breaking error: 'docker.errors.InvalidArgument: "host" network_mode is incompatible with port_bindings'. In older versions port mapping is just ignored if network_mode is "host", so removing port mapping will make it work for new docker versions and it should not break anything in older versions.