### PR TITLE
Lambda VM IO primitives

### DIFF
--- a/ppx_lambda_vm/ppx_lambda_vm.ml
+++ b/ppx_lambda_vm/ppx_lambda_vm.ml
@@ -87,6 +87,7 @@ let rec expr_of_ocaml_expr expr =
     | "asr" -> [%expr Prim Asr]
     | "fst" -> [%expr Prim Fst]
     | "snd" -> [%expr Prim Snd]
+    | "sender" -> [%expr Prim Sender]
     | name ->
       let var = estring ~loc:var.loc name in
       [%expr Var [%e var]])

--- a/src/core/contract_vm.mli
+++ b/src/core/contract_vm.mli
@@ -19,6 +19,7 @@ end
 module Interpreter : sig
   val invoke :
     Contract.t ->
+    source:Crypto.Key_hash.t ->
     arg:Invocation_payload.t ->
     gas:int ->
     (* TODO: unit should be user operation list *)

--- a/src/core/state.ml
+++ b/src/core/state.ml
@@ -82,7 +82,8 @@ let apply_user_operation t user_operation =
       |> Option.fold ~none:(Error "Contract not found") ~some:Result.ok
       |> wrap_error in
     let%ok contract, _user_op_list =
-      Contract_vm.Interpreter.invoke ~arg:argument ~gas:initial_gas contract
+      Contract_vm.Interpreter.invoke ~source ~arg:argument ~gas:initial_gas
+        contract
       |> wrap_error in
     let contract_storage =
       Contract_storage.update_contract_storage contract_storage

--- a/src/lambda_vm/ast.ml
+++ b/src/lambda_vm/ast.ml
@@ -15,6 +15,7 @@ type prim =
   | Asr
   | Fst
   | Snd
+  | Sender
 [@@deriving yojson, show]
 
 type expr =
@@ -52,3 +53,18 @@ type script = {
   code : expr;
 }
 [@@deriving yojson, show]
+
+let value_of_string gas str =
+  let append list item = Pair (item, list) in
+  (* TODO: burn gas properly for conversions *)
+  Gas.burn_constant gas;
+  let rec aux idx list =
+    if idx >= 0 then
+      let c = str.[idx] |> Char.code |> Int64.of_int in
+      Int64 c |> append list |> aux (idx - 1)
+    else
+      list in
+  let length = String.length str in
+  let length' = Int64 (Int64.of_int length) in
+  let list = aux (length - 1) (Pair (Int64 0L, Int64 0L)) in
+  Pair (length', list)

--- a/src/lambda_vm/compiler.ml
+++ b/src/lambda_vm/compiler.ml
@@ -26,6 +26,7 @@ let compile_prim prim =
   | Asr -> P_asr
   | Fst -> P_fst
   | Snd -> P_snd
+  | Sender -> P_sender
 
 module Vars = Map_with_cardinality.Make (struct
   include String

--- a/src/lambda_vm/context.ml
+++ b/src/lambda_vm/context.ml
@@ -1,0 +1,37 @@
+exception Invalid_value
+
+type t = {
+  sender : unit -> Ir.value;
+  source : unit -> Ir.value;
+  gas : Gas.t;
+}
+
+let memo f =
+  let memoized = ref None in
+  fun () ->
+    !memoized
+    |> Option.fold ~some:Fun.id
+         ~none:
+           (let res = f () in
+            memoized := Some res;
+            res)
+
+let make : sender:string -> source:string -> Gas.t -> t =
+ fun ~sender ~source gas ->
+  let source =
+    memo (fun () ->
+        source
+        |> Ast.value_of_string gas
+        |> Compiler.compile_value gas
+        |> Result.fold ~ok:Fun.id ~error:(fun _ -> raise Invalid_value)) in
+  let sender =
+    memo (fun () ->
+        sender
+        |> Ast.value_of_string gas
+        |> Compiler.compile_value gas
+        |> Result.fold ~ok:Fun.id ~error:(fun _ -> raise Invalid_value)) in
+  { sender; source; gas }
+
+let[@inline always] sender t = t.sender
+let[@inline always] source t = t.source
+let[@inline always] gas t = t.gas

--- a/src/lambda_vm/context.mli
+++ b/src/lambda_vm/context.mli
@@ -1,0 +1,9 @@
+exception Invalid_value
+
+type t
+
+(* TODO: decide on whether we accept crypto primitives or michelson*)
+val make : sender:string -> source:string -> Gas.t -> t
+val source : t -> unit -> Ir.value
+val sender : t -> unit -> Ir.value
+val gas : t -> Gas.t

--- a/src/lambda_vm/interpreter.mli
+++ b/src/lambda_vm/interpreter.mli
@@ -13,4 +13,6 @@ type script_result = {
   storage : Ir.value;
   operations : unit;
 }
-val execute : Gas.t -> arg:Ir.value -> Ir.code -> (script_result, error) result
+
+val execute :
+  context:Context.t -> arg:Ir.value -> Ir.code -> (script_result, error) result

--- a/src/lambda_vm/ir.ml
+++ b/src/lambda_vm/ir.ml
@@ -15,6 +15,7 @@ type prim =
   | P_asr
   | P_fst
   | P_snd
+  | P_sender
 [@@deriving show, yojson, eq]
 
 module Env = struct

--- a/src/lambda_vm/lambda_vm.ml
+++ b/src/lambda_vm/lambda_vm.ml
@@ -41,6 +41,8 @@ module Compiler = struct
   let compile_value gas value = wrap (fun () -> compile_value gas value)
 end
 
+module Context = Context
+
 module Interpreter = struct
   include Interpreter
 
@@ -66,5 +68,6 @@ module Interpreter = struct
     | `Error error -> Error (Interpreter_error error)
     | `Limits error -> Error (Runtime_limits_error error)
 
-  let execute gas ~arg script = wrap (fun () -> execute gas ~arg script)
+  let execute ~context ~arg script =
+    wrap (fun () -> execute ~context ~arg script)
 end

--- a/tests/vm/dune
+++ b/tests/vm/dune
@@ -1,5 +1,5 @@
 (test
  (name test_vm)
- (libraries lambda_vm alcotest qcheck-alcotest)
+ (libraries lambda_vm core alcotest qcheck-alcotest)
  (preprocess
   (pps ppx_lambda_vm)))

--- a/tests/vm/test_errors.ml
+++ b/tests/vm/test_errors.ml
@@ -2,6 +2,9 @@ open Lambda_vm
 
 module Testable = Vm_test.Testable
 
+let sender =
+  "tz1ibMpWS6n6MJn73nQHtK5f4ogyYC1z9T9z" |> Core.Address.of_string |> Option.get
+
 let check_execution_error ~actual ~expected =
   let open Vm_test in
   match actual with
@@ -19,71 +22,72 @@ let check_compilation_error ~actual ~expected =
   | Ok _ -> Alcotest.fail "Ast shouldn't execute"
   | Error (Execution_error error) ->
     Alcotest.failf "%a" Interpreter.pp_error error
+
 let test_compilation_undefined_variable () =
   let script = [%lambda_vm.script fun _ -> x] in
   check_compilation_error
-    ~actual:(Vm_test.execute_ast 2000 (Int64 0L) script)
+    ~actual:(Vm_test.execute_ast sender 2000 (Int64 0L) script)
     ~expected:(Compiler_error Compiler.Undefined_variable)
 
 let test_fst_value_is_not_pair () =
   let script = [%lambda_vm.script fun _ -> (fst 1L, (0L, 0L))] in
   check_execution_error
-    ~actual:(Vm_test.execute_ast 1201 (Int64 0L) script)
+    ~actual:(Vm_test.execute_ast sender 1201 (Int64 0L) script)
     ~expected:(Interpreter_error Interpreter.Value_is_not_pair)
 
 let test_snd_value_is_not_pair () =
   let script = [%lambda_vm.script fun _ -> (snd 1L, (0L, 0L))] in
   check_execution_error
-    ~actual:(Vm_test.execute_ast 1201 (Int64 0L) script)
+    ~actual:(Vm_test.execute_ast sender 1201 (Int64 0L) script)
     ~expected:(Interpreter_error Interpreter.Value_is_not_pair)
 
 let test_neg_value_is_not_int64 () =
   let script = [%lambda_vm.script fun _ -> (not (0L, 0L), (0L, 0L))] in
   check_execution_error
-    ~actual:(Vm_test.execute_ast 1601 (Int64 0L) script)
+    ~actual:(Vm_test.execute_ast sender 1601 (Int64 0L) script)
     ~expected:(Interpreter_error Interpreter.Value_is_not_int64)
 
 let test_op2_value_is_not_int64 () =
   let script = [%lambda_vm.script fun _ -> ((0L, 0L) + 0L, (0L, 0L))] in
   check_execution_error
-    ~actual:(Vm_test.execute_ast 2001 (Int64 0L) script)
+    ~actual:(Vm_test.execute_ast sender 2001 (Int64 0L) script)
     ~expected:(Interpreter_error Interpreter.Value_is_not_int64)
 
 let test_if_value_is_not_int64 () =
   let script =
     [%lambda_vm.script fun _ -> if (0L, 0L) then 1L else (1L, (0L, 0L))] in
   check_execution_error
-    ~actual:(Vm_test.execute_ast 1601 (Int64 0L) script)
+    ~actual:(Vm_test.execute_ast sender 1601 (Int64 0L) script)
     ~expected:(Interpreter_error Interpreter.Value_is_not_int64)
 
 let test_value_is_not_function () =
   let script = [%lambda_vm.script fun _ -> (0L 0L, (0L, 0L))] in
   check_execution_error
-    ~actual:(Vm_test.execute_ast 1201 (Int64 0L) script)
+    ~actual:(Vm_test.execute_ast sender 1201 (Int64 0L) script)
     ~expected:(Interpreter_error Interpreter.Value_is_not_function)
 
 let test_pattern1_value_is_not_pair () =
   let script = [%lambda_vm.script fun _ -> (0L, 0L)] in
   check_execution_error
-    ~actual:(Vm_test.execute_ast 701 (Int64 0L) script)
+    ~actual:(Vm_test.execute_ast sender 701 (Int64 0L) script)
     ~expected:(Interpreter_error Interpreter.Value_is_not_pair)
 
 let test_pattern2_value_is_not_pair () =
   let script = [%lambda_vm.script fun _ -> 0L] in
   check_execution_error
-    ~actual:(Vm_test.execute_ast 301 (Int64 0L) script)
+    ~actual:(Vm_test.execute_ast sender 301 (Int64 0L) script)
     ~expected:(Interpreter_error Interpreter.Value_is_not_pair)
 
 let test_pattern3_value_is_not_zero () =
   let script = [%lambda_vm.script fun _ -> (0L, (1L, 0L))] in
   check_execution_error
-    ~actual:(Vm_test.execute_ast 1101 (Int64 0L) script)
+    ~actual:(Vm_test.execute_ast sender 1101 (Int64 0L) script)
     ~expected:(Interpreter_error Interpreter.Value_is_not_zero)
 
 let test_pattern4_value_is_not_zero () =
   let script = [%lambda_vm.script fun _ -> (0L, (0L, 1L))] in
   check_execution_error
-    ~actual:(Vm_test.execute_ast 1101 (Int64 0L) script)
+    ~actual:(Vm_test.execute_ast sender 1101 (Int64 0L) script)
     ~expected:(Interpreter_error Interpreter.Value_is_not_zero)
 
 let test_compilation =

--- a/tests/vm/test_gas.ml
+++ b/tests/vm/test_gas.ml
@@ -1,5 +1,8 @@
 open Lambda_vm
 
+let sender =
+  "tz1ibMpWS6n6MJn73nQHtK5f4ogyYC1z9T9z" |> Core.Address.of_string |> Option.get
+
 let counter =
   [%lambda_vm.script
     fun x ->
@@ -32,7 +35,7 @@ let test_execute_ir () =
     Vm_test.compile_exn gas counter in
 
   let gas = Gas.make ~initial_gas:14747900 in
-  let _ = Vm_test.execute_exn gas arg ir in
+  let _ = Vm_test.execute_exn sender gas arg ir in
   Alcotest.(check bool) "Should be empty" (Gas.is_empty gas) true
 
 let test =

--- a/tests/vm/test_io.ml
+++ b/tests/vm/test_io.ml
@@ -1,0 +1,40 @@
+open Lambda_vm
+
+let compare =
+  [%lambda_vm
+    let delta f = f f in
+    let aux aux size a b =
+      if size then
+        if fst a - fst b then
+          0L
+        else
+          aux aux (size - 1L) (snd a) (snd b)
+      else
+        1L in
+    let aux = delta aux in
+    fun a b ->
+      let size_a = fst a in
+      let size_b = fst b in
+      if size_a - size_b then
+        0L
+      else
+        aux size_a (snd a) (snd b)]
+
+let code =
+  [%lambda_vm.script
+    fun address -> ([%e compare] address (sender 0L), (0L, 0L))]
+
+let test_sender () =
+  let address = "tz1ibMpWS6n6MJn73nQHtK5f4ogyYC1z9T9z" in
+  let result =
+    let sender = address |> Core.Address.of_string |> Option.get in
+    let gas = Gas.make ~initial_gas:10000 in
+    Vm_test.execute_ast_exn sender 1000000
+      (Ast.value_of_string gas address)
+      code in
+  let expected =
+    Vm_test.compile_value_exn (Gas.make ~initial_gas:100) [%lambda_vm.value 1L]
+  in
+  Alcotest.check Vm_test.Testable.value "Same value" expected result.storage
+
+let test = Alcotest.("Test IO", [test_case "Sender" `Quick test_sender])

--- a/tests/vm/test_prim.ml
+++ b/tests/vm/test_prim.ml
@@ -2,6 +2,9 @@ open Lambda_vm
 
 module Testable = Vm_test.Testable
 
+let sender =
+  "tz1ibMpWS6n6MJn73nQHtK5f4ogyYC1z9T9z" |> Core.Address.of_string |> Option.get
+
 let script_op2 prim =
   let prim = Ast.Prim prim in
   [%lambda_vm.script fun param -> ([%e prim] (fst param) (snd param), (0L, 0L))]
@@ -15,7 +18,7 @@ let make_op2_test ~name prim f =
     QCheck.(
       Test.make ~name ~count:10_000 (pair int64 int64) (fun (a, b) ->
           let result =
-            Vm_test.execute_ast_exn 2901
+            Vm_test.execute_ast_exn sender 2901
               (Pair (Int64 a, Int64 b))
               (script_op2 prim) in
           let expected_result =
@@ -56,7 +59,8 @@ let test_neg =
   QCheck_alcotest.to_alcotest
     QCheck.(
       Test.make ~name:"Negative numbers" ~count:10_000 int64 (fun x ->
-          let result = Vm_test.execute_ast_exn 1501 (Int64 x) (script_op1 Neg) in
+          let result =
+            Vm_test.execute_ast_exn sender 1501 (Int64 x) (script_op1 Neg) in
           let expected_result =
             Vm_test.compile_value_exn
               (Gas.make ~initial_gas:200)

--- a/tests/vm/test_recursion.ml
+++ b/tests/vm/test_recursion.ml
@@ -1,5 +1,8 @@
 open Lambda_vm
 
+let sender =
+  "tz1ibMpWS6n6MJn73nQHtK5f4ogyYC1z9T9z" |> Core.Address.of_string |> Option.get
+
 let factorial =
   [%lambda_vm.script
     fun x ->
@@ -16,7 +19,8 @@ let test_factorial =
         (fun x ->
           (* Less than 0 is infinite recursion, greater than 25 is integer overflow. *)
           let x = Int64.of_int x in
-          let result = Vm_test.execute_ast_exn 1_000_000 (Int64 x) factorial in
+          let result =
+            Vm_test.execute_ast_exn sender 1_000_000 (Int64 x) factorial in
           let expected_result =
             Vm_test.compile_value_exn
               (Gas.make ~initial_gas:101)
@@ -44,7 +48,8 @@ let test_fibonacci =
       Test.make ~name:"Fibonacci" ~count:100 (0 -- 25) (fun x ->
           let x = Int64.of_int x in
           let result =
-            Vm_test.execute_ast_exn 100000000000 (Int64 x) fibonacci in
+            Vm_test.execute_ast_exn sender 100000000000 (Int64 x) fibonacci
+          in
           let expected_value =
             Vm_test.compile_value_exn
               (Gas.make ~initial_gas:101)
@@ -66,7 +71,8 @@ let test_counter =
     QCheck.(
       Test.make ~name:"Counter" ~count:1000 (0 -- 10000) (fun x ->
           let x = Int64.of_int x in
-          let result = Vm_test.execute_ast_exn 1000000000 (Int64 x) counter in
+          let result =
+            Vm_test.execute_ast_exn sender 1000000000 (Int64 x) counter in
           let expected_value =
             Vm_test.compile_value_exn (Gas.make ~initial_gas:101) (Int64 x)
           in
@@ -84,7 +90,7 @@ let check_runtime_error ~msg ~actual ~expected =
 let test_stack_limit () =
   check_runtime_error ~msg:"Stack has a limit" ~expected:Out_of_stack
     ~actual:
-      (Vm_test.execute_ast 71_990_801
+      (Vm_test.execute_ast sender 71_990_801
          (Int64 19996L) (* Bare minimum close to the limit of 20k *)
          counter)
 
@@ -95,14 +101,16 @@ let test_y_combinator () =
   check_runtime_error ~msg:"Stack limit avoids infinite recursion"
     ~expected:Out_of_stack
     ~actual:
-      (Vm_test.execute_ast 10000000000000000 (Int64 0L) infinite_recursion_y)
+      (Vm_test.execute_ast sender 10000000000000000 (Int64 0L)
+         infinite_recursion_y)
 
 let infinite_recursion_z =
   [%lambda_vm.script fun _ -> (fun f -> f f 0L) (fun f v -> f f (v + 0L))]
 
 let test_z_combinator () =
   check_runtime_error ~msg:"Gas limit is triggered" ~expected:Out_of_gas
-    ~actual:(Vm_test.execute_ast 10000000000 (Int64 0L) infinite_recursion_z)
+    ~actual:
+      (Vm_test.execute_ast sender 10000000000 (Int64 0L) infinite_recursion_z)
 
 let test =
   let open Alcotest in

--- a/tests/vm/test_simple_expr.ml
+++ b/tests/vm/test_simple_expr.ml
@@ -1,16 +1,19 @@
 open Lambda_vm
 module Testable = Vm_test.Testable
 
+let sender =
+  "tz1ibMpWS6n6MJn73nQHtK5f4ogyYC1z9T9z" |> Core.Address.of_string |> Option.get
+
 let test_increment () =
   let script = [%lambda_vm.script fun x -> (x + 1L, (0L, 0L))] in
-  let result = Vm_test.execute_ast_exn 1901 (Int64 42L) script in
+  let result = Vm_test.execute_ast_exn sender 1901 (Int64 42L) script in
   let expected_value =
     Vm_test.compile_value_exn (Gas.make ~initial_gas:101) (Int64 43L) in
   Alcotest.(check Testable.value) "Same value" expected_value result.storage
 
 let test_decrement () =
   let script = [%lambda_vm.script fun x -> (x - 1L, (0L, 0L))] in
-  let result = Vm_test.execute_ast_exn 1901 (Int64 42L) script in
+  let result = Vm_test.execute_ast_exn sender 1901 (Int64 42L) script in
   let expected_value =
     Vm_test.compile_value_exn (Gas.make ~initial_gas:101) (Int64 41L) in
   Alcotest.(check Testable.value) "Same value" expected_value result.storage
@@ -19,7 +22,8 @@ let test_add_pair () =
   let script = [%lambda_vm.script fun pair -> (fst pair + snd pair, (0L, 0L))] in
 
   let result =
-    Vm_test.execute_ast_exn 2901 (Pair (Int64 23L, Int64 28L)) script in
+    Vm_test.execute_ast_exn sender 2901 (Pair (Int64 23L, Int64 28L)) script
+  in
   let expected_value =
     Vm_test.compile_value_exn (Gas.make ~initial_gas:101) (Int64 51L) in
 
@@ -34,14 +38,16 @@ let test_if_expr () =
 
   (* Check increment *)
   let result =
-    Vm_test.execute_ast_exn 4001 (Pair (Int64 1L, Int64 51L)) script in
+    Vm_test.execute_ast_exn sender 4001 (Pair (Int64 1L, Int64 51L)) script
+  in
   let expected_value =
     Vm_test.compile_value_exn (Gas.make ~initial_gas:101) (Int64 52L) in
   Alcotest.(check Testable.value) "Same value" expected_value result.storage;
 
   (* Check decrement *)
   let result =
-    Vm_test.execute_ast_exn 4001 (Pair (Int64 0L, Int64 33L)) script in
+    Vm_test.execute_ast_exn sender 4001 (Pair (Int64 0L, Int64 33L)) script
+  in
   let expected_value =
     Vm_test.compile_value_exn (Gas.make ~initial_gas:101) (Int64 32L) in
   Alcotest.(check Testable.value) "Same value" expected_value result.storage
@@ -58,7 +64,8 @@ let test_lambda () =
           (0L, 0L) )] in
   (* Check increment *)
   let result =
-    Vm_test.execute_ast_exn 6501 (Pair (Int64 1L, Int64 99L)) script in
+    Vm_test.execute_ast_exn sender 6501 (Pair (Int64 1L, Int64 99L)) script
+  in
   let expected_value =
     Vm_test.compile_value_exn (Gas.make ~initial_gas:101) (Int64 100L) in
 
@@ -66,7 +73,8 @@ let test_lambda () =
 
   (* Check decrement *)
   let result =
-    Vm_test.execute_ast_exn 6501 (Pair (Int64 0L, Int64 33L)) script in
+    Vm_test.execute_ast_exn sender 6501 (Pair (Int64 0L, Int64 33L)) script
+  in
   let expected_value =
     Vm_test.compile_value_exn (Gas.make ~initial_gas:101) (Int64 32L) in
 
@@ -74,7 +82,7 @@ let test_lambda () =
 
 let test_lambda_application () =
   let script = [%lambda_vm.script fun y -> (fun x -> (x, (0L, 0L))) y] in
-  let result = Vm_test.execute_ast_exn 2000 (Int64 45L) script in
+  let result = Vm_test.execute_ast_exn sender 2000 (Int64 45L) script in
   let expected_value =
     Vm_test.compile_value_exn (Gas.make ~initial_gas:101) (Int64 45L) in
 

--- a/tests/vm/test_vm.ml
+++ b/tests/vm/test_vm.ml
@@ -8,4 +8,5 @@ let () =
       Test_recursion.test;
       Test_simple_expr.test;
       Test_gas.test;
+      Test_io.test;
     ]


### PR DESCRIPTION

## Depends

- [x] #508 

## Problem

Lambda VM needs a way to access external information that are not the parameters of the smart contract, such as the operation sender or contract address.

## Solution

<!--- Restate the basic ideas behind your solution --->
Introduce IO primitives for Lambda VM, currently only for sender address.

<!--- Here it is also a good space to put details of your implementation --->
I also moved gas as well as sender address to a single record named `context`. `sender` should be of `value Lazy.t`, because it needs to be encoded as Lambda VM value, and so it requires to be compiled, which requires gas. So in order to avoid increasing gas cost for contracts that do not use the sender address, this is lazy so it's only compiled after actually been required.
