### PR TITLE
Rework development workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ In either case, if all goes well, you should see the block height displayed in t
 
 #### Experimental: Tilt
 
-Our experimental workflow uses [Tilt](https://tilt.dev) which is an advanced orchestrator. If you're using `nix` everything is already provided. If not, you will have to install the things in [requirements](#requirements) + `tilt` and `docker-compose`.
+Our experimental workflow uses [Tilt](https://tilt.dev) which is an advanced orchestrator. If you're using `nix` everything is already provided. If not, you will have to install the things in [requirements](#requirements) + [tilt](https://docs.tilt.dev/install.html) and [docker-compose](https://docs.docker.com/compose/install/).
 
 When the requirements are in place you should just have to run `tilt up` and everything will be running.
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ You may have to stop the session with `killall deku-node` to fully shutdown the 
 
 In either case, if all goes well, you should see the block height displayed in the terminal and increasing every second or so.
 
+#### Experimental: Tilt
+
+Our experimental workflow uses [Tilt](https://tilt.dev) which is an advanced orchestrator. If you're using `nix` everything is already provided. If not, you will have to install the things in [requirements](#requirements) + `tilt` and `docker-compose`.
+
+When the requirements are in place you should just have to run `tilt up` and everything will be running.
+
 ## Contributing
 
 Please refer the developer wiki [here](https://github.com/marigold-dev/sidechain/wiki)

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,66 @@
+# Run docker-compose
+docker_compose(["./docker-compose.yml", "./docker-compose.override.yml"])
+
+dc_resource("db", labels=["database"], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
+dc_resource("elastic", labels=["database"], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
+
+dc_resource("flextesa", labels=["tezos"])
+dc_resource("gui", labels=["tezos"], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
+dc_resource("api", labels=["tezos"], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
+
+dc_resource("metrics", labels=["infra"], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
+dc_resource("indexer", labels=["infra"], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
+dc_resource("prometheus", labels=["infra"], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
+
+# deku nodes should not start before we have run the setup since they depend on state generated there
+dc_resource("deku-node-0", labels=["deku"], resource_deps=["deku-setup"])
+dc_resource("deku-node-1", labels=["deku"], resource_deps=["deku-setup", "deku-node-0"])
+dc_resource("deku-node-2", labels=["deku"], resource_deps=["deku-setup", "deku-node-1"])
+
+docker_build(
+  'ghcr.io/marigold-dev/deku', # image name, should match with what's in docker-compose
+  '.', # context
+  dockerfile='./docker/static.Dockerfile',
+  ignore=["data"])
+
+# since everyone won't have dune available in their environment these are removed for now
+# run dune build and tests on changes
+# local_resource(
+#   "build",
+#   "dune build @install --force",
+#   deps=["src", "nix", "ppx_lambda_vm", "ppx_let_binding"],
+#   labels=["deku"],
+#   )
+# local_resource(
+#   "tests",
+#   "dune runtest --force",
+#   deps=["src", "tests"],
+#   labels=["deku"],
+#   )
+
+# run setup when we build
+local_resource(
+  "deku-setup",
+  "sleep 10 && ./sandbox.sh setup docker",
+  resource_deps=["flextesa"],
+  labels=["scripts"],
+  )
+
+# bootstrap the deku network, it will be run after deku-setup and the nodes have started
+local_resource(
+  "deku-net",
+  "./sandbox.sh start docker",
+  resource_deps=["deku-setup", "deku-node-0", "deku-node-1", "deku-node-2"],
+  labels=["scripts"],
+  auto_init=True, # trigger once at start
+  trigger_mode=TRIGGER_MODE_MANUAL,
+  )
+
+# action to manually trigger a teardown, this should almost never be needed
+local_resource(
+  "deku-tear-down",
+  "./sandbox.sh tear-down",
+  auto_init=False,
+  trigger_mode=TRIGGER_MODE_MANUAL,
+  labels=["scripts"],
+  )

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,26 @@
+version: "3.8"
+services:
+  deku-node-0:
+    container_name: deku-node-0
+    restart: always
+    image: ghcr.io/marigold-dev/deku
+    expose:
+      - 4040
+    volumes:
+      - ./data/0:/app/data
+  deku-node-1:
+    container_name: deku-node-1
+    restart: always
+    image: ghcr.io/marigold-dev/deku
+    expose:
+      - 4040
+    volumes:
+      - ./data/1:/app/data
+  deku-node-2:
+    container_name: deku-node-2
+    restart: always
+    image: ghcr.io/marigold-dev/deku
+    expose:
+      - 4040
+    volumes:
+      - ./data/2:/app/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,7 +130,6 @@ services:
     container_name: deku_prometheus
     restart: always
     image: prom/prometheus
-    network_mode: "host"  
     ports:
       - "9090:9090"
     expose:

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -17,6 +17,8 @@ pkgs.mkShell {
       docker
       nodejs-17_x
       shellcheck
+      tilt
+      docker-compose # This is needed by tilt
 
       # formatters
       nixfmt

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -14,7 +14,7 @@ export PATH
 [ "$USE_NIX" ] && dune build @install
 
 tezos-client() {
-  docker exec -it deku_flextesa tezos-client "$@"
+  docker exec -t deku_flextesa tezos-client "$@"
 }
 
 ligo() {

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -2,6 +2,13 @@
 
 set -e
 
+if [ "$2" = "docker" ]
+then
+  mode="docker"
+else
+  mode="local"
+fi
+
 data_directory="data"
 
 # shellcheck disable=SC2016
@@ -21,7 +28,12 @@ ligo() {
   docker run --rm -v "$PWD":"$PWD" -w "$PWD" ligolang/ligo:0.28.0 "$@"
 }
 
-RPC_NODE=http://localhost:20000
+if [ $mode  = "docker" ]
+then
+  RPC_NODE=http://flextesa:20000
+else
+  RPC_NODE=http://localhost:20000
+fi
 
 # This secret key never changes.
 SECRET_KEY="edsk3QoqBuvdamxouPhin7swCvkQNgq4jP5KZPbwWNnwdZpSpJiEbq"
@@ -82,7 +94,12 @@ create_new_deku_environment() {
     FOLDER="$DATA_DIRECTORY/$i"
     mkdir -p "$FOLDER"
 
-    deku-cli setup-identity "$FOLDER" --uri "http://localhost:444$i"
+    if [ $mode = "docker" ]
+    then
+      deku-cli setup-identity "$FOLDER" --uri "http://deku-node-$i:4440"
+    else
+      deku-cli setup-identity "$FOLDER" --uri "http://localhost:444$i"
+    fi
     KEY=$(deku-cli self "$FOLDER" | grep "key:" | awk '{ print $2 }')
     ADDRESS=$(deku-cli self "$FOLDER" | grep "address:" | awk '{ print $2 }')
     URI=$(deku-cli self "$FOLDER" | grep "uri:" | awk '{ print $2 }')
@@ -179,20 +196,35 @@ start_deku_cluster() {
   SERVERS=()
   echo "Starting nodes."
   for i in "${VALIDATORS[@]}"; do
-    deku-node "$data_directory/$i" --listen-prometheus="900$i" &
-    SERVERS+=($!)
+    if [ "$mode" = "local" ]
+    then
+      deku-node "$data_directory/$i" --listen-prometheus="900$i" &
+      SERVERS+=($!)
+    fi
   done
 
   sleep 1
 
   echo "Producing a block"
-  HASH=$(deku-cli produce-block "$data_directory/0" | awk '{ print $2 }')
+  if [ "$mode" = "docker" ]
+  then
+    HASH=$(docker exec -t deku-node-0 /app/deku_cli.exe produce-block /app/data | awk '{ print $2 }' | tail -n1 | tr -d " \t\n\r" )
+  else
+    HASH=$(deku-cli produce-block "$data_directory/0" | awk '{ print $2 }')
+  fi
 
   sleep 0.1
 
   echo "Signing"
   for i in "${VALIDATORS[@]}"; do
-    deku-cli sign-block "$data_directory/$i" "$HASH"
+    if [ "$mode" = "docker" ]
+    then
+      echo "hash: $HASH"
+      echo "deku-node-$i"
+      docker exec -t "deku-node-$i" /app/deku_cli.exe sign-block /app/data "$HASH"
+    else
+      deku-cli sign-block "$data_directory/$i" "$HASH"
+    fi
   done
 
   for PID in "${SERVERS[@]}"; do
@@ -215,8 +247,9 @@ help() {
   echo "  Starts a Deku cluster configured with this script."
   echo "tear-down"
   echo "  Stops the Tezos node and destroys the Deku state"
-
 }
+
+message "Running in $mode mode"
 
 case "$1" in
 setup)


### PR DESCRIPTION
<!---
  if some of the following sections doesn't apply,
  delete the section.

  Also feel free to delete the comments.
--->

## Problem

<!--- Restate the problem addressed by the PR here --->

Even with `sandbox.sh` the setup still requires some steps, we want to get this down to as few commands as possible.

## Solution

<!--- Restate the basic ideas behind your solution --->
<!--- Here it is also a good space to put details of your implementation --->

This PR implements a [Tilt](https://tilt.dev/) setup which allows us to run the network with just 1 command (`tilt up`) and have it automatically rebuild and restart when making changes.

It has 2 dependencies which are the `tilt` command and `docker-compose` because it currently doesn't work with `docker compose`. These are added in the `nix` setup for convenience but needs to be installed by other means if not using `nix`.

Tilt also includes a nice dashboard where you get a overview of what is running and you can do some manual tasks.

![image](https://user-images.githubusercontent.com/1607770/163349460-30273b03-20b9-4e69-b053-da30b7d616d3.png)

![image](https://user-images.githubusercontent.com/1607770/163349545-0abfad6f-1ec4-4e3e-9dbb-319c5b718672.png)

Commit f2fd6ea1a2d31a8cd5b24cbc27138e007fce24bc, 28f50a1bd7882b013dc4a495665fc59ba114224c and aafc25b9d507bdee6d97f61a025af6547d066d9e could go in separately since they are just fixes.