### PR TITLE
Improve docker file generation in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,12 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set outputs
+        id: vars
+        run: |
+          echo "::set-output name=date::$(date +%Y-%m-%d)"
+          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
       - name: Build and push
         # Only push if on main branch
         id: docker_build
@@ -36,4 +42,4 @@ jobs:
           push: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
           tags: |
             ghcr.io/marigold-dev/deku:latest
-            ghcr.io/marigold-dev/deku:${{ github.sha }}
+            ghcr.io/marigold-dev/deku:${{ steps.vars.outputs.date }}-${{ steps.vars.outputs.sha_short }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,3 +43,19 @@ jobs:
           tags: |
             ghcr.io/marigold-dev/deku:latest
             ghcr.io/marigold-dev/deku:${{ steps.vars.outputs.date }}-${{ steps.vars.outputs.sha_short }}
+
+      - name: Build and push - PR
+        # Only push if on main branch
+        id: docker_build_pr
+        uses: docker/build-push-action@v2
+        # Run this if the PR has the "docker" label
+        if: contains(github.event.pull_request.labels.*.name, 'docker')
+        with:
+          file: ./docker/static.Dockerfile
+          context: .
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: true
+          tags: |
+            ghcr.io/marigold-dev/deku:pr-${{ steps.vars.outputs.date }}-${{ steps.vars.outputs.sha_short }}


### PR DESCRIPTION
<!---
  if some of the following sections doesn't apply,
  delete the section.

  Also feel free to delete the comments.
--->

## Problem

<!--- Restate the problem addressed by the PR here --->

We can't test a PR in a nice way using docker images.
Our tags are not very descriptive when we just have a long git sha as tag

## Solution

<!--- Restate the basic ideas behind your solution --->
<!--- Here it is also a good space to put details of your implementation --->

We add another step that only triggers if a PR has the label "docker" and that will push with a special tag name.
Sets the tag to `YYYY-mm-dd-short_sha` and for the PR it will be prefixed with `pr-`