### PR TITLE
Specify -f flag for esy test on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ esy test
 dune build @runtest
 ```
 
+`esy test` will only run tests that the dependencies have changed since the last time
+you've ran it, so in order to run all the testsuite you must run `esy test -f` instead.
+
 ### Running a sidechain
 
 For convenient local development, we have included two components:


### PR DESCRIPTION
<!---
  if some of the following sections doesn't apply,
  delete the section.

  Also feel free to delete the comments.
--->

## Problem

<!--- Restate the problem addressed by the PR here --->
`esy test` may cause some confusion for newcomers when trying to run the whole testsuite. 

## Solution

<!--- Restate the basic ideas behind your solution --->
Specify that you must pass the `-f` flag in order to force it to run.
<!--- Here it is also a good space to put details of your implementation --->
