### PR TITLE
[p] Remove Esy from sandbox scripts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45,6 +45,21 @@
         "type": "github"
       }
     },
+    "flake-utils_4": {
+      "locked": {
+        "lastModified": 1648297722,
+        "narHash": "sha256-W+qlPsiZd8F3XkzXOzAoR+mpFqzm3ekQkJNa+PIh1BQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "0f8662f1319ad6abf89b3380dd2722369fc51ade",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nix-npm-buildpackage": {
       "locked": {
         "lastModified": 1648040270,
@@ -125,7 +140,29 @@
         "nix-npm-buildpackage": "nix-npm-buildpackage",
         "nixpkgs": "nixpkgs",
         "ocaml-overlays": "ocaml-overlays",
-        "prometheus-web": "prometheus-web"
+        "prometheus-web": "prometheus-web",
+        "tezos": "tezos"
+      }
+    },
+    "tezos": {
+      "inputs": {
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1650261357,
+        "narHash": "sha256-PzjxPs5O1BhHjyCBLUAQ1Ft1VGBRIl2Qmvyliw5ToV8=",
+        "owner": "marigold-dev",
+        "repo": "tezos-nix",
+        "rev": "4227f1800f2562bee67ba143d98ccbad03115af2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "marigold-dev",
+        "repo": "tezos-nix",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -19,13 +19,23 @@
     prometheus-web.inputs.ocaml-overlay.follows = "ocaml-overlays";
 
     nix-npm-buildpackage.url = "github:serokell/nix-npm-buildpackage";
+    tezos.url = "github:marigold-dev/tezos-nix";
+    tezos.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, flake-utils, nix-npm-buildpackage, ocaml-overlays
-    , prometheus-web }:
+  outputs =
+    { self
+    , nixpkgs
+    , flake-utils
+    , nix-npm-buildpackage
+    , ocaml-overlays
+    , prometheus-web
+    , tezos
+    }:
     with flake-utils.lib;
     eachSystem defaultSystems (system:
       let
+        ligo = (import nixpkgs { inherit system; }).ligo;
         pkgs = import nixpkgs {
           inherit system;
           overlays = [
@@ -58,7 +68,7 @@
           inherit npmPackages;
         };
       in {
-        devShell = import ./nix/shell.nix { inherit pkgs deku npmPackages; };
+        devShell = import ./nix/shell.nix { inherit pkgs deku npmPackages ligo; };
         packages = {
           inherit deku deku-static;
           docker = import ./nix/docker.nix {

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs, esy ? pkgs.nodePackages.esy, deku, npmPackages }:
+{ pkgs, esy ? pkgs.nodePackages.esy, deku, npmPackages, ligo }:
 pkgs.mkShell {
   shellHook = ''
     export NODE_PATH=${npmPackages}/node_modules
@@ -20,6 +20,9 @@ pkgs.mkShell {
       tilt
       docker-compose # This is needed by tilt
       jq
+
+      # Tezos tooling
+      ligo
 
       # formatters
       nixfmt

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -5,9 +5,8 @@ pkgs.mkShell {
     export PATH=${npmPackages}/node_modules/.bin:_build/install/default/bin:$PATH
 
     # This is a flag picked up by our sandbox.sh that's used
-    # to know when to use esy instead of nix.
-    # You can turn this off with the command 'unset USE_NIX'.
-    export USE_NIX=y
+    # to know when to rebuild the binaries.
+    export REBUILD=y
   '';
   inputsFrom = [ deku ];
   packages = with pkgs;

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -25,10 +25,6 @@ tezos-client() {
   docker exec -t deku_flextesa tezos-client "$@"
 }
 
-ligo() {
-  docker run --rm -v "$PWD":"$PWD" -w "$PWD" ligolang/ligo:0.28.0 "$@"
-}
-
 if [ $mode  = "docker" ]
 then
   RPC_NODE=http://flextesa:20000

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -12,14 +12,7 @@ fi
 
 data_directory="data"
 
-# shellcheck disable=SC2016
-[ "$USE_NIX" ] || LD_LIBRARY_PATH=$(esy x sh -c 'echo $LD_LIBRARY_PATH')
-export LD_LIBRARY_PATH
-# shellcheck disable=SC2016
-[ "$USE_NIX" ] || PATH=$(esy x sh -c 'echo $PATH')
-export PATH
-
-[ "$USE_NIX" ] && dune build @install
+[ "$REBUILD" ] && dune build @install
 
 tezos-client() {
   docker exec -t deku_flextesa tezos-client "$@"


### PR DESCRIPTION
Created in draft mode until we transition the whole team to Nix.

## Depends

- [x] #554

## Problem

If we remove esy from our sandbox script, this yields:
- simpler scripts - no branching based on package manager
- a lot of leverage in packaging the script for clients. This has been really useful to me for parametric deku.

## Solution

Remove esy from the scripts.

 