### PR TITLE
[d4hines] add gh-stack variable

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,3 +5,4 @@ use_flake() {
 }
 
 use_flake
+export GHSTACK_TARGET_REPOSITORY='marigold-dev/deku'


### PR DESCRIPTION
## Problem

I spend a lot of time recursivley rebasing a DAG of branches. This is tedious and error prone. Instead I'm going to try automating this with a tool.

I'm testing gh-stack first. This PR automates some configuration of the tool using our direnv file.

See https://github.com/luqven/gh-stack#usage

## Solution

direnv ftw



<!---GHSTACKOPEN-->
### Stacked PR Chain: d4hines
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#559|👉add gh-stack variable|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/559?label=Pending)|-|
|#558|Simplify Sandbox.sh|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/558?label=Pending)|#559|
|#527|Dummy-ticket|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/527?label=Approved)|#558|
|#536|feat: add block-by-level rpc|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/536?label=Approved)|#527|
|#537|Add block rate and operation rate metrics|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/537?label=Approved)|#536|
|#539|Benchmarking: ticket transfers|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/539?label=Pending)|#537|
|#540|*(Draft)POC: Parametric Deku*|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/540?label=Pending)|#539|
<!---GHSTACKCLOSE-->



