### PR TITLE
chore: Add docker login action for nix build

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -46,6 +46,13 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       
       - uses: cachix/install-nix-action@v16
       - uses: cachix/cachix-action@v10


### PR DESCRIPTION
## Problem

<!--- Restate the problem addressed by the PR here --->

CI is failing now with `denied: unauthenticated: User cannot be authenticated with the token provided.`

## Solution

<!--- Restate the basic ideas behind your solution --->
<!--- Here it is also a good space to put details of your implementation --->

Add login action in the nix docker workflow

## Related

<!--- add here all the related issues to your PR --->
- #556
 