### PR TITLE
chore: Add odoc dependency in nix

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -47,6 +47,16 @@ in {
           sha256 = "13c53b1cxkq2nj444655skw5a1mcxzbaqwqsqjf7jbwradb3hmxa";
         };
       });
+      odoc = osuper.odoc.overrideAttrs (o: {
+        patches = [
+          (prev.fetchpatch {
+            name = "ocaml5-compat.patch";
+            url =
+              "https://patch-diff.githubusercontent.com/raw/ocaml/odoc/pull/831.patch";
+            sha256 = "sha256-vTzbMwa2WA/3xTzCP6SGX+BZSroOwUG5w/FLQIYIkB0=";
+          })
+        ];
+      });
       odoc-parser = osuper.odoc-parser.overrideAttrs (o: {
         propagatedBuildInputs = o.propagatedBuildInputs
           ++ (with oself; [ camlp-streams result astring ]);

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -32,5 +32,6 @@ pkgs.mkShell {
       dune_2
       ocaml-lsp
       ocamlformat-rpc
+      odoc
     ]);
 }


### PR DESCRIPTION
## Problem

<!--- Restate the problem addressed by the PR here --->

We want to generate docs for the code we write

## Solution

<!--- Restate the basic ideas behind your solution --->
<!--- Here it is also a good space to put details of your implementation --->

Add odoc as a dev dependency in nix so that we can run `dune build @doc`