### PR TITLE
chore: Add trusted public keys for nix cache

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,10 @@
   nixConfig = {
     trusted-substituters =
       [ "https://cache.nixos.org/" "https://deku.cachix.org" ];
+    trusted-public-keys = [
+      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+      "deku.cachix.org-1:9zYY9BUBDV9xiXj8C0uCy+hkgjyDVRdH932KHmqVwYg="
+    ];
   };
 
   inputs = {


### PR DESCRIPTION
## Problem

<!--- Restate the problem addressed by the PR here --->
We don't specify the public keys which means that someone could do a "man in the middle attack" on our cache.

## Solution

<!--- Restate the basic ideas behind your solution --->
<!--- Here it is also a good space to put details of your implementation --->

Add `cache.nixos.org` and `deku.cachix.org` public keys