### PR TITLE
load_test type error

### DIFF
--- a/tests/e2e/load_test.ml
+++ b/tests/e2e/load_test.ml
@@ -58,7 +58,7 @@ let do_transaction ~validator_uri ~block_level ~ticket ~sender ~recipient
       ~block_height:block_level
       ~data:
         (Core.User_operation.make
-           ~sender:(Core.Address.of_key_hash sender.key_hash)
+           ~source:(sender.key_hash)
            (Transaction { destination = recipient.key_hash; amount; ticket }))
   in
   Lwt.async (fun () ->


### PR DESCRIPTION
Currently, running dune build in this branch yields 
```
61 |            ~sender:(Core.Address.of_key_hash sender.key_hash)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: The function applied to this argument has type
         source:Crypto.Key_hash.t -> Core__User_operation.t
This argument cannot be applied with label ~sender
```
This change fixes said error.
