### PR TITLE
Add get-balance features to run test scenario

### DIFF
--- a/sandbox.sh
+++ b/sandbox.sh
@@ -422,7 +422,7 @@ deposit_withdraw_test() {
 
   # Check that the ticket has been deposited on deku
   BALANCE=$(deku-cli get-balance data/0 $DEKU_ADDRESS "(Pair \"$DUMMY_TICKET\" 0x)" | sed -n "s/Balance: \([0-9]*\)/\1/p")
-  if (($BALANCE == 0))
+  if ((BALANCE == 0))
   then
     echo "error: Balance for ticket $DUMMY_TICKET is \"$BALANCE\"! Did the deposit fail?"
     pkill -x deku-node

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -420,6 +420,15 @@ deposit_withdraw_test() {
 
   DUMMY_TICKET=$(tezos-client show known contract dummy_ticket | tr -d '\t\n\r')
 
+  # Check that the ticket has been deposited on deku
+  BALANCE=$(deku-cli get-balance data/0 $DEKU_ADDRESS "(Pair \"$DUMMY_TICKET\" 0x)" | sed -n "s/Balance: \([0-9]*\)/\1/p")
+  if (($BALANCE == 0))
+  then
+    echo "error: Balance for ticket $DUMMY_TICKET is \"$BALANCE\"! Did the deposit fail?"
+    pkill -x deku-node
+    exit 1
+  fi
+
   # # We can withdraw 10 tickets from deku
   OPERATION_HASH=$(deku-cli withdraw data/0 ./wallet.json "$DUMMY_TICKET" 10 "Pair \"$DUMMY_TICKET\" 0x" | awk '{ print $2 }' | tr -d '\t\n\r')
   sleep 10

--- a/src/bin/deku_cli.ml
+++ b/src/bin/deku_cli.ml
@@ -525,6 +525,36 @@ let withdraw_proof =
   lwt_ret
     (const withdraw_proof $ folder_node $ operation_hash $ contract_callback)
 
+let info_get_ticket_balance =
+  let doc = "Get balance of a ticket for an account." in
+  Cmd.info "get-balance" ~version:"%\226\128\140%VERSION%%" ~doc ~exits ~man
+
+let get_ticket_balance node_folder address ticket =
+  let open Network in
+  let%await identity = read_identity ~node_folder in
+  let%await result = request_ticket_balance { address; ticket } identity.uri in
+  Format.printf "Balance: %i\n%!" (Amount.to_int result.amount);
+  await (`Ok ())
+
+let get_ticket_balance =
+  let open Term in
+  let folder_node =
+    let docv = "folder_node" in
+    let doc = "The folder where the node lives." in
+    let open Arg in
+    required & pos 0 (some string) None & info [] ~doc ~docv in
+  let address =
+    let docv = "address" in
+    let doc = "The account address to get the balance." in
+    let open Arg in
+    required & pos 1 (some address_implicit) None & info [] ~docv ~doc in
+  let ticket =
+    let docv = "ticket" in
+    let doc = "The ticket to get the balance." in
+    let open Arg in
+    required & pos 2 (some ticket) None & info [] ~docv ~doc in
+  lwt_ret (const get_ticket_balance $ folder_node $ address $ ticket)
+
 let info_sign_block =
   let doc =
     "Sign a block hash and broadcast to the network manually, useful when the \
@@ -797,5 +827,6 @@ let _ =
          Cmd.v info_setup_tezos setup_tezos;
          Cmd.v info_add_trusted_validator add_trusted_validator;
          Cmd.v info_remove_trusted_validator remove_trusted_validator;
+         Cmd.v info_get_ticket_balance get_ticket_balance;
          Cmd.v info_self self;
        ]

--- a/src/network/network.ml
+++ b/src/network/network.ml
@@ -30,3 +30,5 @@ let request_consensus_operation = request (module Consensus_operation_gossip)
 
 let request_trusted_validator_membership =
   request (module Trusted_validators_membership_change)
+
+let request_ticket_balance = request (module Ticket_balance)


### PR DESCRIPTION
<!---
  if some of the following sections doesn't apply,
  delete the section.

  Also feel free to delete the comments.
--->

## Depends

<!--- All PR or issues that are required to be closed / merged before this can be merged --->


## Problem

<!--- Restate the problem addressed by the PR here --->
We want to easily run a test scenario where:
- one start a sandbox

```bash
docker compose up -d
./sandbox setup
```

**Note deku contract address**

- start deku
```bash
./sandbox start
```

- orignate a dummy ticket contract

dummy_ticket.mligo
```mligo
type storage = bytes ticket list

type return = operation list * storage

type vault_ticket = bytes ticket
type vault_deposit = {
  ticket: vault_ticket;
  address: address
}

type parameter =
| Deposit of {
  deku_consensus : address;
  deku_recipient : address;
  bytes : bytes;
}
| Withdraw of bytes ticket

let main (param, stored_tickets : parameter * storage) : return =
 match param with
 | Deposit {deku_consensus; deku_recipient; bytes} ->
   (match (Tezos.get_entrypoint_opt "%deposit" deku_consensus : vault_deposit contract option)  with 
   | Some contract ->
    (* Content of ticket is just a packed int *)
    let ticket = Tezos.create_ticket bytes 1000000n in 
    let param  = { ticket = ticket; address = deku_recipient } in
    let op = Tezos.transaction param 0mutez contract in
    (* We increment the counter to add some variety to the data *)
    [op], stored_tickets
   | None -> failwith "Entrypoint doesn't exist")
  | Withdraw ticket ->
    let ops : operation list = [] in
    ops , ticket :: stored_tickets
```

```bash
tezos-client --endpoint http://localhost:20000 originate contract "dummy_ticket" \
    transferring 0 from myWallet \
    running "$(ligo compile contract ./dummy_ticket.mligo)" \
    --init "{}" \
    --burn-cap 2 \
    --force
```
Note dummy contract address

- deposit a ticket from tezos to a deku address (node 0 address)

```bash
tezos-client --endpoint $RPC_NODE transfer 0 from myWallet to $DUMMY_CONTRACT \
  --entrypoint deposit --arg "Pair (Pair 0x10 \"$CONSENSUS_CONTRACT\") $(cat ./data/0/identity.json | jq .t)" \
  --burn-cap 2
```

- check that deposit works

```bash
esy x deku-cli get-balance ./data/0 $(cat ./data/0/identity.json | jq -r .t) "(Pair \"$DUMMY_CONTRACT\" 0x10)"
```
- do a transfert in deku (node 0 address -> node 1 address)

```bash
cat ./data/0/identity.json | jq '{ priv_key: .secret, address: .t }' > me.json && esy x deku-cli create-transaction ./data/0 me.json $(cat ./data/1/identity.json | jq -r .t) 42 "(Pair \"$DUMMY_CONTRACT\" 0x10)"
```

- check that transfert works

node 0 balance:
```bash
esy x deku-cli get-balance ./data/0 $(cat ./data/0/identity.json | jq -r .t) "(Pair \"$DUMMY_CONTRACT\" 0x10)"
```

node 1 balance:
```bash
esy x deku-cli get-balance ./data/0 $(cat ./data/1/identity.json | jq -r .t) "(Pair \"$DUMMY_CONTRACT\" 0x10)"
```

- withdraw a ticket in deku (7 tickets unit from node 0 to myWallet)

```bash
 esy x deku-cli withdraw ./data/0 me.json tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb 7 "(Pair \"$DUMMY_CONTRACT\" 0x10)"
 ```
**note operation hash**

- check node 0 balance

```bash
esy x deku-cli get-balance ./data/0 $(cat ./data/0/identity.json | jq -r .t) "(Pair \"$DUMMY_CONTRACT\" 0x10)"
```

- generate a withdraw_proof in deku

```bash
esy x deku-cli withdraw-proof ./data/0 "$WITHDRAW_HASH" "${DUMMY_CONTRACT}%withdraw"
```
Note the proof
_looks like_
```
(Pair (Pair "KT1TZiwWz63LLMZ2fC1gsQpocbFWUXjqjcwm%withdraw"
            (Pair (Pair 7 0x10) 0 "tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb")
            "KT1TZiwWz63LLMZ2fC1gsQpocbFWUXjqjcwm")
      0x7c4a56f9e72a0982543b9c9884b2491a75d0ff28f099aabe3e0247b76d89f0c1
      {  })
```

- withdraw in tezos with the withdraw proof

THINK TO ESCAPE CORRECTLY!!!
Looks like for the proof above

```bash
tezos-client --endpoint $RPC_NODE transfer 0 from myWallet to $CONSENSUS_CONTRACT \
  --entrypoint withdraw --arg "(Pair (Pair \"KT1TZiwWz63LLMZ2fC1gsQpocbFWUXjqjcwm%withdraw\" \
  (Pair (Pair 7 0x10) 0 \"tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb\") \
  \"KT1TZiwWz63LLMZ2fC1gsQpocbFWUXjqjcwm\") \
  0x7c4a56f9e72a0982543b9c9884b2491a75d0ff28f099aabe3e0247b76d89f0c1 \
  {  })" \
  --burn-cap 2
  ```

## Solution

<!--- Restate the basic ideas behind your solution --->
<!--- Here it is also a good space to put details of your implementation --->
- document the workflow
- add missing commands in deku-cli

## Related

<!--- add here all the related issues to your PR --->
- #570
 