### PR TITLE
Add the tx hash 

### DIFF
--- a/examples/go-counter/README.md
+++ b/examples/go-counter/README.md
@@ -15,5 +15,5 @@ the Deku CLI. For example:
 alias deku-cli='nix run github:marigold-dev/deku/parametric#deku-cli --'
 action='{"Action": "Increment"}'
 db='[["counter", 41]]'
-echo "$db" | deku-cli create-mock-transaction ./wallet.json ./vm $action
+echo "$db" | deku-cli create-mock-transaction ./wallet.json $action ./vm
 ```

--- a/examples/go-counter/main.go
+++ b/examples/go-counter/main.go
@@ -25,9 +25,13 @@ func log(message string) {
 }
 
 func main() {
-	state_transition := func(sender_address string, input []byte) (return_err error) {
+	state_transition := func(sender_address string, tx_hash string, input []byte) (return_err error) {
 		var message message
-		log(fmt.Sprintf("State transition received. Sender: %s, Payload: %s", sender_address, string(input)))
+		log(fmt.Sprintf(
+				"State transition received. Sender: %s, Tx hash: %s, Payload: %s,",
+				sender_address,
+				tx_hash,
+				string(input)))
 		err := json.Unmarshal(input, &message)
 		check(err)
 		counter_bytes := deku_go_interop.Get("counter")

--- a/examples/js-counter/example.js
+++ b/examples/js-counter/example.js
@@ -1,6 +1,7 @@
 const { main, set, get } = require("deku_js_interop");
 
-const transition = (_sender, action_buffer) => {
+const transition = (sender, tx_hash, action_buffer) => {
+  console.log(`sender: ${sender}, tx_hash: ${tx_hash}`)
   const action = JSON.parse(action_buffer.toString());
   let counter = get("counter");
   counter = Number.parseFloat(counter);

--- a/sdks/deku_go_interop/interop.go
+++ b/sdks/deku_go_interop/interop.go
@@ -3,10 +3,8 @@ package deku_go_interop
 import (
 	"encoding/binary"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 )
 
@@ -71,7 +69,7 @@ func Set(key string, value interface{}) {
 	write(message)
 }
 
-func Main(state_transition func(sender string, input []byte) (err error)) {
+func Main(state_transition func(sender string, tx_hash string, input []byte) (err error)) {
 	log("Opening read")
 	fifo_path := os.Args[1]
 	log(fmt.Sprintf("fifo path: %s", fifo_path))
@@ -86,9 +84,10 @@ func Main(state_transition func(sender string, input []byte) (err error)) {
 			break
 		}
 		sender := strings.Trim(string(read()), "\"")
+		tx_hash := strings.Trim(string(read()), "\"")
 		input := read()
 		log(fmt.Sprintf("Read start message: %s", string(input)))
-		err := state_transition(sender, input)
+		err := state_transition(sender, tx_hash, input)
 		var end_message []byte
 		if err != nil {
 			end_message = []byte(fmt.Sprintf("[\"Error\", \"%s\"]", err.Error()))

--- a/sdks/deku_js_interop/package-lock.json
+++ b/sdks/deku_js_interop/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "deku-typescript-interop",
+  "name": "deku_js_interop",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "deku_js_interop",
       "devDependencies": {
         "@types/node": "^17.0.29",
         "@typescript-eslint/eslint-plugin": "^5.21.0",

--- a/sdks/deku_js_interop/src/interop.ts
+++ b/sdks/deku_js_interop/src/interop.ts
@@ -1,6 +1,5 @@
-import * as fs from 'fs';
-import * as child_process from 'child_process';
-
+import * as fs from "fs";
+import * as child_process from "child_process";
 
 let machineToChain: number | undefined;
 let chainToMachine: number | undefined;
@@ -14,10 +13,10 @@ const init_fifo = () => {
 
   console.log(`fifo path: ${fifo_path}`);
   console.log("opening read");
-  machineToChain = fs.openSync(`${fifo_path}_read`, 'a');
+  machineToChain = fs.openSync(`${fifo_path}_read`, "a");
   console.log("opening write");
-  chainToMachine = fs.openSync(`${fifo_path}_write`, 'r');
-}
+  chainToMachine = fs.openSync(`${fifo_path}_write`, "r");
+};
 
 /**
  * Reads the fifo and returns the result
@@ -26,11 +25,11 @@ const init_fifo = () => {
 const read = (): Buffer => {
   const buffer = Buffer.alloc(8);
   fs.readSync(chainToMachine, buffer);
-  const n = buffer.readUInt16LE()
+  const n = buffer.readUInt16LE();
   const valueBuffer = Buffer.alloc(n);
   fs.readSync(chainToMachine, valueBuffer);
   return valueBuffer;
-}
+};
 
 // Write the given buffer to machineToChain fifo
 // It will perform 2 writes, one for the size of the buffer, another one for the buffer itself
@@ -45,7 +44,7 @@ const write = (value: Buffer) => {
   buffer.writeUInt16LE(value.length);
   fs.writeFileSync(machineToChain, buffer);
   fs.writeFileSync(machineToChain, value);
-}
+};
 
 /**
  * Returns the value of a given key from the deku state
@@ -56,7 +55,7 @@ const get = (key: string): Buffer | undefined => {
   const message = `["Get", "${key}"]`;
   write(Buffer.from(message));
   return read();
-}
+};
 
 /**
  * Set a value in the deku state for a given key
@@ -64,30 +63,31 @@ const get = (key: string): Buffer | undefined => {
  * @param {string} value a string encoded in json
  */
 const set = (key: string, value: string) => {
-  const message = `["Set",{"key":"${key}","value":${value}}]`
+  const message = `["Set",{"key":"${key}","value":${value}}]`;
   return write(Buffer.from(message));
-}
+};
 
 /**
  * The main function
- * @param state_transition the function called when there is an new input 
+ * @param state_transition the function called when there is an new input
  */
-const main = (state_transition: ((address: string, input: Buffer) => string)) => {
+const main = (
+  state_transition: (address: string, tx_hash: string, input: Buffer) => string
+) => {
   init_fifo();
 
-  for (; ;) {
+  for (;;) {
     const control = read().toString();
-    if (control === "\"close\"") {
+    if (control === '"close"') {
       break;
     }
     const sender = read().toString().slice(1, -1);
+    const tx_hash = read().toString().slice(1, -1);
     const input = read();
-    const error = state_transition(sender, input);
-    const end_message = error
-      ? `["Error", "${error}"]`
-      : '["Stop"]'
+    const error = state_transition(sender, tx_hash, input);
+    const end_message = error ? `["Error", "${error}"]` : '["Stop"]';
     write(Buffer.from(end_message));
   }
-}
+};
 
-export { main, get, set }
+export { main, get, set };

--- a/src/bin/deku_cli.ml
+++ b/src/bin/deku_cli.ml
@@ -228,7 +228,10 @@ let create_mock_transaction sender_wallet_file payload vm_binary_path vm_args =
       ~data:
         (Core.User_operation.make ~source:wallet.address
            (Vm_transaction { payload })) in
-  let named_pipe_path = "/tmp/deku/named_pipe" in
+  let suffix =
+    Stdlib.Random.bits () |> string_of_int |> BLAKE2B.hash |> BLAKE2B.to_string
+  in
+  let named_pipe_path = "/tmp/deku_named_pipe_" ^ suffix in
   let stdin, _ = Unix.pipe () in
   let args =
     Array.concat

--- a/src/bin/deku_cli.ml
+++ b/src/bin/deku_cli.ml
@@ -221,7 +221,7 @@ let create_mock_transaction sender_wallet_file payload vm_binary_path vm_args =
   let payload = Yojson.Safe.from_string payload in
   (* We sign the payload just to make sure the wallet is an actual wallet.
      This adds to the realism of the test. *)
-  let _transaction =
+  let transaction =
     Protocol.Operation.Core_user.sign ~secret:wallet.priv_key
       ~nonce:(Crypto.Random.int32 Int32.max_int)
       ~block_height:0L
@@ -239,7 +239,8 @@ let create_mock_transaction sender_wallet_file payload vm_binary_path vm_args =
   let _pid =
     Unix.create_process vm_binary_path args stdin Unix.stdout Unix.stderr in
   External_vm.start_vm_ipc ~named_pipe_path;
-  External_vm.apply_vm_operation ~state ~source:wallet.address payload
+  External_vm.apply_vm_operation ~state ~source:wallet.address
+    ~tx_hash:transaction.hash payload
   |> External_vm.to_yojson
   |> Yojson.Safe.to_string
   |> print_endline;

--- a/src/core/state.ml
+++ b/src/core/state.ml
@@ -99,7 +99,8 @@ let apply_user_operation t user_operation =
     Ok ({ ledger; contract_storage; vm_state }, None)
   | Vm_transaction { payload } ->
     let vm_state =
-      External_vm.apply_vm_operation ~state:t.vm_state ~source payload in
+      External_vm.apply_vm_operation ~state:t.vm_state ~source ~tx_hash:hash
+        payload in
     Ok ({ contract_storage; ledger; vm_state }, None)
 let apply_user_operation t user_operation =
   match apply_user_operation t user_operation with

--- a/src/external_vm/external_vm.ml
+++ b/src/external_vm/external_vm.ml
@@ -21,7 +21,7 @@ let start_vm_ipc ~named_pipe_path =
       (External_process.open_pipes ~named_pipe_path ~to_yojson:Fun.id
          ~of_yojson:vm_message_of_yojson)
 
-let apply_vm_operation ~state ~source operation =
+let apply_vm_operation ~state ~source ~tx_hash operation =
   match !vm with
   | Some vm ->
     (* TODO: I'm using the first message as a control, but we should have a dedicated control pipe.
@@ -30,6 +30,7 @@ let apply_vm_operation ~state ~source operation =
     (* TODO: this is a dumb way to do things. We should have a better protocol than JSON. *)
     let source = `String (Key_hash.to_string source) in
     vm.send source;
+    vm.send (`String (BLAKE2B.to_string tx_hash));
     vm.send operation;
     let finished = ref false in
     let state = ref state in

--- a/src/external_vm/external_vm.mli
+++ b/src/external_vm/external_vm.mli
@@ -5,5 +5,6 @@ val of_yojson : Yojson.Safe.t -> (t, string) result
 val to_yojson : t -> Yojson.Safe.t
 val empty : t
 val start_vm_ipc : named_pipe_path:string -> unit
-val apply_vm_operation : state:t -> source:Key_hash.t -> Yojson.Safe.t -> t
+val apply_vm_operation :
+  state:t -> source:Key_hash.t -> tx_hash:BLAKE2B.t -> Yojson.Safe.t -> t
 val close_vm_ipc : unit -> unit


### PR DESCRIPTION
## Problem

We don't currently post the transaction hash to the vm. 

Additionally, we have a potential foot gun in that the cli uses an absolute path for the fifo in `/tmp`. I fixed this along the way.

## Solution

post tx hash.