### PR TITLE
Nix: add missing folder direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,5 @@
+mkdir -p .direnv
+
 use_flake() {
   watch_file flake.nix
   watch_file flake.lock


### PR DESCRIPTION
When using `direnv` in Nix, it is missing the folder `.direnv` to execute the command.