### PR TITLE
networking: optimize broadcasting

### DIFF
--- a/src/node/networking.ml
+++ b/src/node/networking.ml
@@ -9,10 +9,11 @@ module type Request_endpoint = sig
   val path : string
 end
 exception Error_status
-let request request_to_yojson path data uri =
+
+let raw_request path raw_data uri =
   let open Piaf in
   let uri = Uri.with_path uri path in
-  let body = request_to_yojson data |> Yojson.Safe.to_string |> Body.of_string in
+  let body = Body.of_string raw_data in
   let%await response = Client.Oneshot.post ~body uri in
   match response with
   | Ok response -> (
@@ -21,10 +22,20 @@ let request request_to_yojson path data uri =
     | Ok body -> await body
     | Error _err -> Lwt.fail Error_status)
   | Error _err -> Lwt.fail Error_status
+
+let request request_to_yojson path data uri =
+  let raw_data = request_to_yojson data |> Yojson.Safe.to_string in
+  raw_request path raw_data uri
+
+let raw_post path raw_data uri =
+  let%await _body = raw_request path raw_data uri in
+  await ()
+
 let post (type req) (module E : Request_endpoint with type request = req) data
     uri =
   let%await _body = request E.request_to_yojson E.path data uri in
   await ()
+
 let request (type req res)
     (module E : Request_endpoint with type request = req and type response = res)
     data uri =
@@ -32,11 +43,16 @@ let request (type req res)
   let response =
     Yojson.Safe.from_string body |> E.response_of_yojson |> Result.get_ok in
   await response
-let broadcast_to_list endpoint uris data =
+
+let broadcast_to_list (type req res)
+    (module E : Request_endpoint with type request = req and type response = res)
+    uris data =
+  let data = E.request_to_yojson data |> Yojson.Safe.to_string in
   uris
   (* TODO: limit concurrency here *)
   |> Lwt_list.iter_p (fun uri ->
-         Lwt.catch (fun () -> post endpoint data uri) (fun _exn -> await ()))
+         Lwt.catch (fun () -> raw_post E.path data uri) (fun _exn -> await ()))
+
 let broadcast_to_validators endpoint state data =
   Validators.to_list state.protocol.validators
   |> List.filter_map (fun Validators.{ address; _ } ->

--- a/src/node/networking.ml
+++ b/src/node/networking.ml
@@ -34,7 +34,8 @@ let request (type req res)
   await response
 let broadcast_to_list endpoint uris data =
   uris
-  |> Lwt_list.iter_s (fun uri ->
+  (* TODO: limit concurrency here *)
+  |> Lwt_list.iter_p (fun uri ->
          Lwt.catch (fun () -> post endpoint data uri) (fun _exn -> await ()))
 let broadcast_to_validators endpoint state data =
   Validators.to_list state.protocol.validators


### PR DESCRIPTION
## Problem

Currently Deku TPS is quite low, this is due to the block producer waiting the other nodes to parse each block, but currently this is done in serial, which makes so that our pipeline is empty most of the time.

Also we're serializing the same message many times for each validator.

## Solution

Sends the messages in parallel and serialize only once.