### PR TITLE
node: optimize pending_operations a map

### DIFF
--- a/src/node/building_blocks.ml
+++ b/src/node/building_blocks.ml
@@ -67,9 +67,7 @@ let is_signable state block =
   let is_trusted_operation operation =
     match operation with
     | Protocol.Operation.Core_tezos _ ->
-      List.exists
-        (fun op -> Protocol.Operation.equal op.Node.operation operation)
-        state.pending_operations
+      Node.Operation_map.mem operation state.pending_operations
     | Core_user _ -> true
     | Consensus consensus_operation -> (
       current_time > next_allowed_membership_change_timestamp
@@ -109,9 +107,8 @@ let should_start_new_epoch last_state_root_update current_time =
     \    block with an updated state root hash.\n"]
 
 (** Can only included a tezos operation if enough time has already elapsed *)
-let can_include_tezos_operation ~current_time pending_operation =
-  current_time -. pending_operation.Node.requested_at
-  > minimum_waiting_period_for_tezos_operation
+let can_include_tezos_operation ~current_time ~requested_at =
+  current_time -. requested_at > minimum_waiting_period_for_tezos_operation
 
 let produce_block state =
   let current_time = Unix.time () in
@@ -125,19 +122,19 @@ let produce_block state =
     else
       None in
   let operations =
-    List.filter_map
-      (fun pending_operation ->
-        let operation = pending_operation.Node.operation in
+    (* TODO: fold into list on Helpers *)
+    Node.Operation_map.fold
+      (fun operation requested_at operations ->
         match operation with
         | Operation.Core_tezos _ ->
-          if can_include_tezos_operation ~current_time pending_operation then
-            Some operation
+          if can_include_tezos_operation ~current_time ~requested_at then
+            operation :: operations
           else
-            None
+            operations
         | Core_user _
         | Consensus _ ->
-          Some operation)
-      state.pending_operations in
+          operation :: operations)
+      state.pending_operations [] in
   Block.produce ~state:state.Node.protocol ~author:state.identity.t
     ~next_state_root_hash ~operations
 let is_valid_block_height state block_height =
@@ -159,14 +156,11 @@ let apply_block state update_state block =
   let%ok state = Node.apply_block state block in
   Ok (update_state state)
 let clean state update_state block =
-  let operation_is_in_block operation =
-    List.exists (fun op -> Operation.equal op operation) block.Block.operations
-  in
   let pending_operations =
-    List.find_all
-      (fun pending_operation ->
-        not (operation_is_in_block pending_operation.Node.operation))
-      state.State.pending_operations in
+    List.fold_left
+      (fun pending_operations operation ->
+        Node.Operation_map.remove operation pending_operations)
+      state.State.pending_operations block.Block.operations in
   let trusted_validator_membership_change =
     List.fold_left
       (fun trusted_validator_membership_change operation ->

--- a/src/node/state.ml
+++ b/src/node/state.ml
@@ -11,18 +11,17 @@ type identity = {
 module Address_map = Map.Make (Key_hash)
 module Uri_map = Map.Make (Uri)
 
-type pending_operation = {
-  (* TODO: proper type for timestamps *)
-  requested_at : float;
-  operation : Protocol.Operation.t;
-}
+module Operation_map = Map.Make (Operation)
+
+(* TODO: proper type for timestamps *)
+type timestamp = float
 type t = {
   identity : identity;
   trusted_validator_membership_change :
     Trusted_validators_membership_change.Set.t;
   interop_context : Tezos_interop.t;
   data_folder : string;
-  pending_operations : pending_operation list;
+  pending_operations : timestamp Operation_map.t;
   block_pool : Block_pool.t;
   protocol : Protocol.t;
   snapshots : Snapshots.t;
@@ -53,7 +52,7 @@ let make ~identity ~trusted_validator_membership_change
     trusted_validator_membership_change;
     interop_context;
     data_folder;
-    pending_operations = [];
+    pending_operations = Operation_map.empty;
     block_pool = initial_block_pool;
     protocol = initial_protocol;
     snapshots = initial_snapshots;

--- a/src/node/state.mli
+++ b/src/node/state.mli
@@ -9,19 +9,15 @@ type identity = {
 [@@deriving yojson]
 module Address_map : Map.S with type key = Key_hash.t
 module Uri_map : Map.S with type key = Uri.t
+module Operation_map : Map.S with type key = Protocol.Operation.t
 
-type pending_operation = {
-  (* TODO: proper type for timestamps *)
-  requested_at : float;
-  operation : Protocol.Operation.t;
-}
 type t = {
   identity : identity;
   trusted_validator_membership_change :
     Trusted_validators_membership_change.Set.t;
   interop_context : Tezos_interop.t;
   data_folder : string;
-  pending_operations : pending_operation list;
+  pending_operations : float Operation_map.t;
   block_pool : Block_pool.t;
   protocol : Protocol.t;
   snapshots : Snapshots.t;


### PR DESCRIPTION
## Problem

Currently pending_operations is a list, but in almost all the usages of it we first need to search on it to avoid duplicates, this makes so that any linear operation on pending operations is actually O(n^2).

## Solution

Because the order doesn't matter for us right now, I changed from a list to a map which in OCaml is a binary search tree, making so that all the O(n^2) operations are now O(n log n).

## **Warning**

This code is not ideal, but it's not a big regression, so I would ask for a bit of patience.