### PR TITLE
deps: move to nodejs 14 as nodejs 12 is EOL

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -32,11 +32,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1651558728,
-        "narHash": "sha256-8HzyRnWlgZluUrVFNOfZAOlA1fghpOSezXvxhalGMUo=",
+        "lastModified": 1652231724,
+        "narHash": "sha256-MjalcXFZgcgchp4QqnF05JTkFBBGad5hbksA1EKoP98=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cbe587c735b734405f56803e267820ee1559e6c1",
+        "rev": "41ff747f882914c1f8c233207ce280ac9d0c867f",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1651742952,
-        "narHash": "sha256-rphbWT3vPKdDv/z6CvylxDyjlQjzYVvN8VMe96yc1i0=",
+        "lastModified": 1652354587,
+        "narHash": "sha256-4wAlDsnfdAzOEM8WGVs1HDDqB8x2tJWQd0Z/86V3q1Y=",
         "owner": "anmonteiro",
         "repo": "nix-overlays",
-        "rev": "a6807f0800b901393167b19138628729d69efc5d",
+        "rev": "a5d810ae91095586c18d2cafde80381936a445ad",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
         pkgs_static = pkgs.pkgsCross.musl64;
 
         bp =
-          pkgs.callPackage nix-npm-buildpackage { nodejs = pkgs.nodejs-12_x; };
+          pkgs.callPackage nix-npm-buildpackage { nodejs = pkgs.nodejs-14_x; };
         npmPackages = bp.buildNpmPackage {
           src = ./.;
           npmBuild = "echo ok";


### PR DESCRIPTION
## Problem

NodeJS 12 is now EOL and nix complaints about that when updating.

## Solution

Just move to NodeJS 14.