### PR TITLE
chore: use dream2nix for a better npm experience

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,71 @@
 {
   "nodes": {
+    "alejandra": {
+      "inputs": {
+        "flakeCompat": "flakeCompat",
+        "nixpkgs": [
+          "dream2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1648332543,
+        "narHash": "sha256-9FWmFNLCOp4y0I8Yb4GvgGXxtDq3nBDSTI9qyCi2LJ4=",
+        "owner": "kamadorueda",
+        "repo": "alejandra",
+        "rev": "5cbb3486c7959646f452830c0a223edc5db5b951",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kamadorueda",
+        "repo": "alejandra",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1644785799,
+        "narHash": "sha256-VpAJO1L0XeBvtCuNGK4IDKp6ENHIpTrlaZT7yfBCvwo=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "fc7a94f841347c88f2cb44217b2a3faa93e2a0b2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "dream2nix": {
+      "inputs": {
+        "alejandra": "alejandra",
+        "crane": "crane",
+        "flake-utils-pre-commit": "flake-utils-pre-commit",
+        "gomod2nix": "gomod2nix",
+        "mach-nix": "mach-nix",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "node2nix": "node2nix",
+        "poetry2nix": "poetry2nix",
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 1651844867,
+        "narHash": "sha256-a+bAmmeIudRVY23ZkEB5W5xJumBY3ydsiDIGN/56NmQ=",
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "rev": "e5d0e9cdb00695b0b63d1f52ff3b39c0e3035fe3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1649676176,
@@ -15,18 +81,80 @@
         "type": "github"
       }
     },
-    "nix-npm-buildpackage": {
+    "flake-utils-pre-commit": {
       "locked": {
-        "lastModified": 1648040270,
-        "narHash": "sha256-HZU4h2J5gre5ASHynlln+KoK7wgtFjsqkzVVG2XsFXM=",
-        "owner": "serokell",
-        "repo": "nix-npm-buildpackage",
-        "rev": "881f4bfa68e33cd0fb69e6b739fb92f8d0bbe37e",
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
-        "owner": "serokell",
-        "repo": "nix-npm-buildpackage",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flakeCompat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1648199409,
+        "narHash": "sha256-JwPKdC2PoVBkG6E+eWw3j6BMR6sL3COpYWfif7RVb8Y=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "64a525ee38886ab9028e6f61790de0832aa3ef03",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "gomod2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627572165,
+        "narHash": "sha256-MFpwnkvQpauj799b4QTBJQFEddbD02+Ln5k92QyHOSk=",
+        "owner": "tweag",
+        "repo": "gomod2nix",
+        "rev": "67f22dd738d092c6ba88e420350ada0ed4992ae8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "mach-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1634711045,
+        "narHash": "sha256-m5A2Ty88NChLyFhXucECj6+AuiMZPHXNbw+9Kcs7F6Y=",
+        "owner": "DavHau",
+        "repo": "mach-nix",
+        "rev": "4433f74a97b94b596fa6cd9b9c0402104aceef5d",
+        "type": "github"
+      },
+      "original": {
+        "id": "mach-nix",
+        "type": "indirect"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1649838635,
+        "narHash": "sha256-P1h48+l9vUvMz4JwHBgkTXiX6mE8oYR75vBVUbe6Cuc=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "40a58baa248a8b335e2d66ca258a74248af9d834",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
         "type": "github"
       }
     },
@@ -43,6 +171,22 @@
         "owner": "nixos",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "node2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1634916276,
+        "narHash": "sha256-lov2b/8ydYjq+MhKQugmWV2lFnq35AU5RTRBTfLq7B4=",
+        "owner": "svanderburg",
+        "repo": "node2nix",
+        "rev": "644e90c0304038a446ed53efc97e9eb1e2831e71",
+        "type": "github"
+      },
+      "original": {
+        "owner": "svanderburg",
+        "repo": "node2nix",
         "type": "github"
       }
     },
@@ -66,6 +210,48 @@
       "original": {
         "owner": "anmonteiro",
         "repo": "nix-overlays",
+        "type": "github"
+      }
+    },
+    "poetry2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1632969109,
+        "narHash": "sha256-jPDclkkiAy5m2gGLBlKgH+lQtbF7tL4XxBrbSzw+Ioc=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "aee8f04296c39d88155e05d25cfc59dfdd41cc77",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "1.21.0",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-utils": [
+          "dream2nix",
+          "flake-utils-pre-commit"
+        ],
+        "nixpkgs": [
+          "dream2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646153636,
+        "narHash": "sha256-AlWHMzK+xJ1mG267FdT8dCq/HvLCA6jwmx2ZUy5O8tY=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "b6bc0b21e1617e2b07d8205e7fae7224036dfa4b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
         "type": "github"
       }
     },
@@ -97,8 +283,9 @@
     },
     "root": {
       "inputs": {
+        "dream2nix": "dream2nix",
         "flake-utils": "flake-utils",
-        "nix-npm-buildpackage": "nix-npm-buildpackage",
+        "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs",
         "ocaml-overlays": "ocaml-overlays",
         "prometheus-web": "prometheus-web",

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,10 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    nix-npm-buildpackage.url = "github:serokell/nix-npm-buildpackage";
+    nix-filter.url = "github:numtide/nix-filter";
+
+    dream2nix.url = "github:nix-community/dream2nix";
+    dream2nix.inputs.nixpkgs.follows = "nixpkgs";
 
     ocaml-overlays.url = "github:anmonteiro/nix-overlays";
     ocaml-overlays.inputs = {
@@ -32,11 +35,21 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, nix-npm-buildpackage, ocaml-overlays
+  outputs = { self, nixpkgs, flake-utils, nix-filter, dream2nix, ocaml-overlays
     , prometheus-web, tezos }:
-    with flake-utils.lib;
-    eachSystem defaultSystems (system:
+    let
+      supportedSystems =
+        [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+
+      dream2nix-lib = dream2nix.lib2.init {
+        systems = supportedSystems;
+        config.projectRoot = ./.;
+      };
+    in with flake-utils.lib;
+    eachSystem supportedSystems (system:
       let
+        nodejs = pkgs.nodejs-16_x;
+
         ligo = (import nixpkgs { inherit system; }).ligo.overrideAttrs
           (_: { meta = { platforms = pkgs.ocaml.meta.platforms; }; });
 
@@ -51,25 +64,20 @@
 
         pkgs_static = pkgs.pkgsCross.musl64;
 
-        bp =
-          pkgs.callPackage nix-npm-buildpackage { nodejs = pkgs.nodejs-14_x; };
-        npmPackages = bp.buildNpmPackage {
-          src = ./.;
-          npmBuild = "echo ok";
+        npmPackages = import ./nix/npm.nix {
+          inherit system dream2nix-lib nix-filter nodejs;
         };
 
         deku = pkgs.callPackage ./nix/deku.nix {
           doCheck = true;
-          nodejs = pkgs.nodejs-16_x;
-          inherit npmPackages;
+          inherit nodejs npmPackages;
         };
 
         deku-static = pkgs_static.callPackage ./nix/deku.nix {
           pkgs = pkgs_static;
           doCheck = true;
           static = true;
-          nodejs = pkgs.nodejs-16_x;
-          inherit npmPackages;
+          inherit nodejs npmPackages;
         };
 
         sandbox = pkgs.callPackage ./nix/sandbox.nix {
@@ -77,15 +85,17 @@
           pkgs = import nixpkgs { inherit system; };
         };
       in {
-        devShell =
-          import ./nix/shell.nix { inherit pkgs deku ligo npmPackages; };
+        devShell = import ./nix/shell.nix { inherit pkgs deku ligo; };
         packages = {
-          inherit deku deku-static npmPackages;
+          inherit deku deku-static;
           docker = import ./nix/docker.nix {
             inherit pkgs;
             deku = deku-static;
           };
-        };
+        } // (builtins.listToAttrs (builtins.map (p: {
+          name = p.pname;
+          value = p;
+        }) npmPackages));
 
         apps = {
           deku-cli = {

--- a/flake.nix
+++ b/flake.nix
@@ -92,10 +92,12 @@
             inherit pkgs;
             deku = deku-static;
           };
-        } // (builtins.listToAttrs (builtins.map (p: {
-          name = p.pname;
-          value = p;
-        }) npmPackages));
+        }
+        # Add npm packages as exposed packages
+          // (builtins.listToAttrs (builtins.map (p: {
+            name = p.pname;
+            value = p;
+          }) npmPackages));
 
         apps = {
           deku-cli = {
@@ -114,10 +116,11 @@
       }) // {
         hydraJobs = {
           x86_64-linux = self.packages.x86_64-linux;
-          aarch64-darwin = {
-            # darwin doesn't support static builds and docker
-            inherit (self.packages.aarch64-darwin) deku npmPackages;
-          };
+          # darwin doesn't support static builds and docker
+          aarch64-darwin = builtins.removeAttrs self.packages.aarch64-darwin [
+            "deku-static"
+            "docker"
+          ];
         };
       };
 }

--- a/nix/deku.nix
+++ b/nix/deku.nix
@@ -1,5 +1,5 @@
-{ pkgs, stdenv, lib, removeReferencesTo, doCheck ? true, cacert, npmPackages
-, nodejs ? pkgs.nodejs, static ? false }:
+{ pkgs, stdenv, lib, system, removeReferencesTo, doCheck ? true, cacert
+, npmPackages, nodejs ? pkgs.nodejs, static ? false }:
 
 let ocamlPackages = pkgs.ocaml-ng.ocamlPackages_5_00;
 
@@ -55,12 +55,13 @@ in ocamlPackages.buildDunePackage rec {
       cacert
       core_bench
       memtrace
-      landmarks
       benchmark
     ]
     # checkInputs are here because when cross compiling dune needs test dependencies
     # but they are not available for the build phase. The issue can be seen by adding strictDeps = true;.
-    ++ checkInputs;
+    ++ checkInputs
+    # some benchmarking libraries are broken om m1, so we make them optional
+    ++ (if system != "aarch64-darwin" then [ landmarks ] else [ ]);
 
   checkInputs = with ocamlPackages; [ alcotest qcheck qcheck-alcotest rely ];
 

--- a/nix/deku.nix
+++ b/nix/deku.nix
@@ -14,15 +14,10 @@ in ocamlPackages.buildDunePackage rec {
       [ "dune-project" "sidechain.opam" "package.json" "package-lock.json" ];
   };
 
-  configurePhase = ''
-    export PATH=${npmPackages}/node_modules/.bin:$PATH
-    export NODE_PATH=${npmPackages}/node_modules
-
-    ln -s ${npmPackages}/node_modules ./node_modules
-  '';
-
   # This is the same as standard dune build but with static support
   buildPhase = ''
+    echo NODE_PATH
+    echo $NODE_PATH
     runHook preBuild
     echo "running ${if static then "static" else "release"} build"
     dune build -p ${pname} --profile=${if static then "static" else "release"}
@@ -31,7 +26,7 @@ in ocamlPackages.buildDunePackage rec {
 
   inherit doCheck;
 
-  nativeBuildInputs = [ nodejs npmPackages removeReferencesTo ]
+  nativeBuildInputs = [ nodejs removeReferencesTo ] ++ npmPackages
     ++ (with ocamlPackages; [ utop reason ]);
 
   propagatedBuildInputs = with ocamlPackages;
@@ -65,7 +60,7 @@ in ocamlPackages.buildDunePackage rec {
     ]
     # checkInputs are here because when cross compiling dune needs test dependencies
     # but they are not available for the build phase. The issue can be seen by adding strictDeps = true;.
-    ++ checkInputs ++ [ npmPackages ];
+    ++ checkInputs;
 
   checkInputs = with ocamlPackages; [ alcotest qcheck qcheck-alcotest rely ];
 

--- a/nix/npm.nix
+++ b/nix/npm.nix
@@ -15,6 +15,7 @@ let
       };
     };
 
+    # TODO: If we remove this Webpack will fail, not sure why
     inject = { acorn-import-assertions."1.8.0" = [[ "acorn" "8.7.1" ]]; };
 
     settings =

--- a/nix/npm.nix
+++ b/nix/npm.nix
@@ -1,0 +1,38 @@
+{ system, dream2nix-lib, nix-filter, nodejs }:
+
+let
+  outputs = (dream2nix-lib.makeFlakeOutputs {
+    source = nix-filter.lib.filter {
+      root = ../.;
+      include = [ ../package-lock.json ../package.json ];
+    };
+
+    packageOverrides = {
+      webpack-cli = {
+        remove-webpack-check = {
+          patches = [ ./patches/remove-webpack-check.patch ];
+        };
+      };
+    };
+
+    inject = { acorn-import-assertions."1.8.0" = [[ "acorn" "8.7.1" ]]; };
+
+    settings =
+      [{ subsystemInfo.nodejs = (builtins.substring 0 2 nodejs.version); }];
+  });
+  npmPackages = outputs.packages."${system}".sidechain;
+
+  node_modules' = builtins.attrValues
+    (builtins.removeAttrs npmPackages.dependencies [ "webpack" ]);
+  webpack = npmPackages.dependencies.webpack.overrideAttrs (_: {
+    postFixup = ''
+      wrapProgram $out/bin/webpack \
+      --set NODE_PATH=${npmPackages}/lib/node_modules/sidechain/node_modules:${
+        builtins.foldl' (prev: curr: prev + ":" + curr) "$NODE_PATH"
+        node_modules'
+      }
+    '';
+  });
+  node_modules = node_modules' ++ [ webpack ];
+
+in node_modules

--- a/nix/patches/remove-webpack-check.patch
+++ b/nix/patches/remove-webpack-check.patch
@@ -1,0 +1,12 @@
+diff --git a/packages/webpack-cli/src/webpack-cli.ts b/packages/webpack-cli/src/webpack-cli.ts
+--- a/lib/webpack-cli.js
++++ b/lib/webpack-cli.js
+@@ -342,7 +342,7 @@
+           continue;
+         }
+ 
+-        let skipInstallation = false;
++        let skipInstallation = true;
+ 
+         // Allow to use `./path/to/webpack.js` outside `node_modules`
+         if (dependency === WEBPACK_PACKAGE && fs.existsSync(WEBPACK_PACKAGE)) {

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,9 +1,7 @@
-{ pkgs, deku, ligo, npmPackages }:
+{ pkgs, deku, ligo, nodejs ? pkgs.nodejs }:
 pkgs.mkShell {
   shellHook = ''
-    export NODE_PATH=${npmPackages}/node_modules
-    export PATH=${npmPackages}/node_modules/.bin:_build/install/default/bin:$PATH
-
+    export PATH=_build/install/default/bin:$PATH
     # This is a flag picked up by our sandbox.sh that's used
     # to know when to use esy instead of nix.
     # You can turn this off with the command 'unset USE_NIX'.
@@ -18,7 +16,7 @@ pkgs.mkShell {
       # Make developer life easier
       ## General tooling
       docker
-      nodejs-16_x
+      nodejs
       shellcheck
       tilt
       docker-compose # This is needed by tilt


### PR DESCRIPTION
## Problem

<!--- Restate the problem addressed by the PR here --->

The current npm solution for nix doesn't work too well

## Solution

<!--- Restate the basic ideas behind your solution --->
<!--- Here it is also a good space to put details of your implementation --->

Use dream2nix that seems to work better with newer versions of npm.
This is a simplified/refactored version of #579

Also removed landmarks on `aarch64-darwin` since it's not compatible with the m1

As you can see here it unblocks m1: https://hydra.strid.ninja/jobset/deku/deku-m1

## Related

<!--- add here all the related issues to your PR --->
- #579 This is heavily inspired by the work in this PR so I'm adding co-author
 