### PR TITLE
chore: use nix-direnv instead of hand-rolled .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,10 +1,3 @@
-mkdir -p .direnv
-
-use_flake() {
-  watch_file flake.nix
-  watch_file flake.lock
-  eval "$(nix print-dev-env --profile "$(direnv_layout_dir)/flake-profile")"
-}
-
+# To use direnv with nix flakes, first install https://github.com/nix-community/nix-direnv
 use_flake
 export GHSTACK_TARGET_REPOSITORY='marigold-dev/deku'


### PR DESCRIPTION
## Problem

Our hand-rolled .envrc has relatively poor caching. We can improve it by switching to https://github.com/nix-community/nix-direnv
 