### PR TITLE
chore: Split tilt to allow both docker and local workflow

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -30,28 +30,21 @@ jobs:
         run: nix develop -c dune runtest --force --no-buffer
       - name: "Build deku via flakes"
         run: nix build --verbose .#deku
-  e2e_test:
+  # Includes all our e2e tests
+  tilt_ci:
     runs-on: ubuntu-latest
     needs: build
     steps:
       - uses: actions/checkout@v2
+      
       - uses: cachix/install-nix-action@v16
       - uses: cachix/cachix-action@v10
         with:
           name: deku
           authToken: "${{ secrets.CACHIX_SIGNING_KEY }}"
-      - name: "Run flextesa"
-        run: nix develop -c docker-compose up -d flextesa
-      - name: "Set up sandbox before smoke test"
-        run: nix run .#sandbox setup
-      - name: "Run smoke test"
-        run: nix run .#sandbox smoke-test
-      # We want fresh nodes before the next test to be sure there
-      # is no spooky interaction
-      - name: "Set up sandbox before deposit withdraw test"
-        run: nix run .#sandbox tear-down && nix run .#sandbox setup
-      - name: "Run deposit-withdraw test"
-        run: nix run .#sandbox deposit-withdraw-test
+
+      - name: "tilt ci"
+        run: "nix develop -c tilt ci -- --mode=local"
 
   # Static and docker are linked because we're using the static build in docker
   static:

--- a/.gitignore
+++ b/.gitignore
@@ -13,11 +13,13 @@ result
 # nix-direnv cache
 .direnv
 
-# Deku nodes folder
+# Deku-specific
 data/
+wallet.json
 
 # Others
 node_modules
 *.install
 *.bundle.js
 *.bundle.js.LICENSE.txt
+

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,28 +1,23 @@
+# Setup configurations
 config.define_string("nodes", False, "specify number of deku nodes to run")
+config.define_string("mode", False, "specify what mode to run in, 'docker' (default) or 'local'")
+
 cfg = config.parse()
+
 no_of_deku_nodes = int(cfg.get('nodes', "3"))
+mode = cfg.get('mode', 'docker')
 
-def get_services(compose):
-    return compose.get("services").keys()
+def load_config ():
+  if mode == "docker" :
+    return load_dynamic('./tilt/Tiltfile.docker')
+  else:
+    return load_dynamic('./tilt/Tiltfile.local')
 
-def make_deku_yaml(n):
-  services = []
+symbols = load_config()
 
-  for i in range(n + 1):
-    deku_node_name = "deku-node-%s" % i
-    services.append((deku_node_name, {
-    'container_name': deku_node_name,
-    'restart': 'always',
-    'image': 'ghcr.io/marigold-dev/deku',
-    'expose': [ 4040 ],
-    'volumes': [ ("./data/%s:/app/data" % i) ],
-    }))
-
-  services = {k: v for k, v in services}
-  return encode_yaml({
-    'version': '3.8',
-    'services': services
-  })
+add_sandbox = symbols['add_sandbox']
+load_deku_services = symbols['load_deku_services']
+make_deku_yaml = symbols['make_deku_yaml']
 
 deku_yaml = make_deku_yaml(no_of_deku_nodes)
 
@@ -40,48 +35,9 @@ dc_resource("metrics", labels=["infra"], trigger_mode=TRIGGER_MODE_MANUAL, auto_
 dc_resource("indexer", labels=["infra"], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
 dc_resource("prometheus", labels=["infra"], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
 
-for deku_service in get_services(decode_yaml(deku_yaml)):
-    dc_resource(deku_service, labels=["deku"], resource_deps=["deku-setup"])
+load_deku_services(deku_yaml)
 
-custom_build(
-  'ghcr.io/marigold-dev/deku', # image name, should match with what's in docker-compose
-  'nix build .#docker && docker load < ./result',
-  ["./src", "./ppx_lambda_vm", "./ppx_let_binding", "./nix"], # folders to watch f or changes
-  skips_local_docker=False,
-  tag = "latest")
-
-# since everyone won't have dune available in their environment these are removed for now
-# run dune build and tests on changes
-# local_resource(
-#   "build",
-#   "dune build @install --force",
-#   deps=["src", "nix", "ppx_lambda_vm", "ppx_let_binding"],
-#   labels=["deku"],
-#   )
-# local_resource(
-#   "tests",
-#   "dune runtest --force",
-#   deps=["src", "tests"],
-#   labels=["deku"],
-#   )
-
-# run setup when we build
-local_resource(
-  "deku-setup",
-  "sleep 10 && ./sandbox.sh setup docker %s" % no_of_deku_nodes,
-  resource_deps=["flextesa"],
-  labels=["scripts"],
-  )
-
-# bootstrap the deku network, it will be run after deku-setup and the nodes have started
-local_resource(
-  "deku-net",
-  "./sandbox.sh start docker %s" % no_of_deku_nodes,
-  resource_deps=["deku-setup", "deku-node-0", "deku-node-1", "deku-node-2"],
-  labels=["scripts"],
-  auto_init=True, # trigger once at start
-  trigger_mode=TRIGGER_MODE_MANUAL,
-  )
+add_sandbox(no_of_deku_nodes)
 
 # action to manually trigger a teardown, this should almost never be needed
 local_resource(

--- a/Tiltfile
+++ b/Tiltfile
@@ -2,6 +2,9 @@
 config.define_string("nodes", False, "specify number of deku nodes to run")
 config.define_string("mode", False, "specify what mode to run in, 'docker' (default) or 'local'")
 
+if config.tilt_subcommand == "down":
+  local("nix run .#sandbox tear-down")
+
 cfg = config.parse()
 
 no_of_deku_nodes = int(cfg.get('nodes', "3"))
@@ -42,7 +45,7 @@ add_sandbox(no_of_deku_nodes)
 # action to manually trigger a teardown, this should almost never be needed
 local_resource(
   "deku-tear-down",
-  "./sandbox.sh tear-down",
+  "nix run .#sandbox tear-down",
   auto_init=False,
   trigger_mode=TRIGGER_MODE_MANUAL,
   labels=["scripts"],

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1648332543,
-        "narHash": "sha256-9FWmFNLCOp4y0I8Yb4GvgGXxtDq3nBDSTI9qyCi2LJ4=",
+        "lastModified": 1652972885,
+        "narHash": "sha256-OKTV5Mi0WyDGsF6GcTwWkgJPNRkskD5yqCZZmghZYHI=",
         "owner": "kamadorueda",
         "repo": "alejandra",
-        "rev": "5cbb3486c7959646f452830c0a223edc5db5b951",
+        "rev": "69d2075e432c562099965829d8bc4da701b10d20",
         "type": "github"
       },
       "original": {
@@ -53,11 +53,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1652854916,
-        "narHash": "sha256-kHKVBY/NCExBNyqCP51P7IClaA5CQsHZW+29ZmzBreQ=",
+        "lastModified": 1653135531,
+        "narHash": "sha256-pYwJrEQrG8BgeVcI+lveK3KbOBDx9MT28HxV09v+jgI=",
         "owner": "nix-community",
         "repo": "dream2nix",
-        "rev": "2fd96e44e9c86892fb0dfedd50e33eeb5726415b",
+        "rev": "4b3dfb101fd2fdbe25bd128072f138276aa4bc82",
         "type": "github"
       },
       "original": {
@@ -186,11 +186,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652659998,
-        "narHash": "sha256-FqNrXC1EE6U2RACwXBlsAvg1lqQGLYpuYb6+W3DL9vA=",
+        "lastModified": 1653060744,
+        "narHash": "sha256-kfRusllRumpt33J1hPV+CeCCylCXEU7e0gn2/cIM7cY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1d7db1b9e4cf1ee075a9f52e5c36f7b9f4207502",
+        "rev": "dfd82985c273aac6eced03625f454b334daae2e8",
         "type": "github"
       },
       "original": {
@@ -226,11 +226,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1652801670,
-        "narHash": "sha256-EQvqsWeLMGRdjDjqYv5jX1rxmOhrQY7TNKP5HSz6uWQ=",
+        "lastModified": 1653401415,
+        "narHash": "sha256-yugn7ODU/dLpn7Bqv3wozcKJsByOd6vvOIGgSGOJbJU=",
         "owner": "anmonteiro",
         "repo": "nix-overlays",
-        "rev": "47167199bea23a35969c907fa4fd252e50e63edb",
+        "rev": "afa9af9f6525ddeb8868816e4bd71b631cdb1193",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -63,15 +63,12 @@
         ligo = (import nixpkgs { inherit system; }).ligo.overrideAttrs
           (_: { meta = { platforms = pkgs.ocaml.meta.platforms; }; });
 
-        pkgs = ocaml-overlays.makePkgs {
-          inherit system;
-          extraOverlays = [
-            (import ./nix/overlay.nix)
-            prometheus-web.overlays.default
-            tezos.overlays.default
-            json-logs-reporter.overlays.default
-          ];
-        };
+        pkgs = (ocaml-overlays.makePkgs { inherit system; }).appendOverlays [
+          (import ./nix/overlay.nix)
+          prometheus-web.overlays.default
+          tezos.overlays.default
+          json-logs-reporter.overlays.default
+        ];
 
         pkgs_static = pkgs.pkgsCross.musl64;
 
@@ -96,7 +93,7 @@
           pkgs = import nixpkgs { inherit system; };
         };
       in {
-        devShell = import ./nix/shell.nix { inherit pkgs deku ligo; };
+        devShell = import ./nix/shell.nix { inherit pkgs system deku ligo; };
         packages = {
           inherit deku deku-static;
           docker = import ./nix/docker.nix {

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs, deku, ligo, nodejs ? pkgs.nodejs }:
+{ pkgs, system, deku, ligo, nodejs ? pkgs.nodejs }:
 pkgs.mkShell {
   shellHook = ''
     export PATH=_build/install/default/bin:$PATH
@@ -18,7 +18,7 @@ pkgs.mkShell {
       docker
       nodejs
       shellcheck
-      tilt
+
       docker-compose # This is needed by tilt
       jq
 
@@ -29,7 +29,8 @@ pkgs.mkShell {
       nixfmt
       nodePackages.prettier
       ocamlformat
-    ] ++ (with pkgs.ocaml-ng.ocamlPackages_5_00; [
+    ] ++ (pkgs.lib.optional (system != "x86_64-darwin") tilt)
+    ++ (with pkgs.ocaml-ng.ocamlPackages_5_00; [
       # OCaml developer tooling
       ocaml
       findlib

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -311,7 +311,7 @@ wait_for_servers() {
 # Steps for the command: ./sandbox.sh smoke-test
 # - deku_height()
 # - start_deku_cluster()
-# - killall deku-node
+# - pkill -x deku-node
 # - assert_deku_state()
 deku_storage() {
   local contract
@@ -427,7 +427,7 @@ deposit_withdraw_test() {
   WITHDRAW_PROOF=$(deku-cli withdraw-proof data/0 "$OPERATION_HASH" "$DUMMY_TICKET%burn_callback" | tr -d '\t\n\r')
   if [ -z "$WITHDRAW_PROOF" ]; then
     echo Withdraw failed!
-    killall deku-node
+    pkill -x deku-node
     exit 1
   fi
   sleep 10
@@ -486,7 +486,7 @@ smoke-test)
   start_deku_cluster
   seconds=35
   sleep $seconds
-  killall deku-node
+  pkill -x deku-node
   assert_deku_state "$starting_height" $seconds
   ;;
 tear-down)
@@ -497,7 +497,7 @@ deposit-withdraw-test)
   sleep 5
   deploy_dummy_ticket
   deposit_withdraw_test
-  killall deku-node
+  pkill -x deku-node
   ;;
 deploy-dummy-ticket)
   deploy_dummy_ticket

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -278,7 +278,7 @@ start_deku_cluster() {
   # See deku-cli produce-block --help
   echo "Producing a block"
   if [ "$mode" = "docker" ]; then
-    HASH=$(docker exec -t deku-node-0 /app/deku_cli.exe produce-block /app/data | awk '{ print $2 }' | tail -n1 | tr -d " \t\n\r")
+    HASH=$(docker exec -t deku-node-0 /bin/deku-cli produce-block /app/data | awk '{ print $2 }' | tail -n1 | tr -d " \t\n\r")
   else
     HASH=$(deku-cli produce-block "$DATA_DIRECTORY/0" | awk '{ print $2 }')
   fi

--- a/tilt/Tiltfile.docker
+++ b/tilt/Tiltfile.docker
@@ -72,17 +72,29 @@ def add_sandbox (no_of_deku_nodes):
   # run setup when we build
   local_resource(
     "deku-setup",
-    "sleep 5 && ./sandbox.sh setup docker %s" % no_of_deku_nodes,
+    "sleep 5 && nix run .#sandbox setup docker %s" % no_of_deku_nodes,
     resource_deps=["flextesa"],
     labels=["scripts"],
     )
 
-  # bootstrap the deku network, it will be run after deku-setup and the nodes have started
-  local_resource(
-    "deku-net",
-    "./sandbox.sh start docker %s" % no_of_deku_nodes,
-    resource_deps=["deku-setup", "deku-node-0", "deku-node-1", "deku-node-2"],
-    labels=["scripts"],
-    auto_init=True, # trigger once at start
-    trigger_mode=TRIGGER_MODE_MANUAL,
-    )
+  if config.tilt_subcommand == "ci":
+    # bootstrap the deku network and run some tests
+    local_resource(
+      "smoke-test",
+      "sleep 5 && nix run .#sandbox smoke-test docker %s" % no_of_deku_nodes,
+      resource_deps=["deku-setup", "deku-node-0", "deku-node-1", "deku-node-2"],
+      labels=["scripts"],
+      auto_init=True, # trigger once at start
+      trigger_mode=TRIGGER_MODE_MANUAL,
+      )
+  else:
+    # bootstrap the deku network, it will be run after deku-setup and the nodes have started
+    local_resource(
+      "deku-net",
+      "nix run .#sandbox start docker %s" % no_of_deku_nodes,
+      resource_deps=["deku-setup", "deku-node-0", "deku-node-1", "deku-node-2"],
+      labels=["scripts"],
+      auto_init=True, # trigger once at start
+      trigger_mode=TRIGGER_MODE_MANUAL,
+      )
+    

--- a/tilt/Tiltfile.docker
+++ b/tilt/Tiltfile.docker
@@ -1,0 +1,88 @@
+# If `USE_NIX` is not set to 'y' we won't build the image
+if os.environ.get('USE_NIX', 'n') == 'y':
+  custom_build(
+    'ghcr.io/marigold-dev/deku', # image name, should match with what's in docker-compose
+    'nix build .#docker && docker load < ./result',
+    ["./src", "./ppx_lambda_vm", "./ppx_let_binding", "./nix"], # folders to watch f or changes
+    skips_local_docker=False,
+    tag = "latest")
+
+def get_services(compose):
+    return compose.get("services").keys()
+
+def make_deku_yaml(n):
+  services = []
+
+  for i in range(n + 1):
+    deku_node_name = "deku-node-%s" % i
+    services.append((deku_node_name, {
+    'container_name': deku_node_name,
+    'restart': 'always',
+    'image': 'ghcr.io/marigold-dev/deku',
+    'expose': [ 4040, 9000 ],
+    'ports': [ "444%s:4040" % i ],
+    'volumes': [ ("./data/%s:/app/data" % i) ],
+    'command': [ "/app/data", "--listen-prometheus=9000" ]
+    }))
+
+
+  prometheus_config = {
+    'scrape_configs': [
+      {
+        'job_name': 'deku',
+        'scrape_interval': '1s',
+        'metrics_path': '/',
+        'static_configs': [
+          {
+            'targets': [ s[0] + ":9000" for s in services]
+          }
+        ]
+      }
+    ]
+  }
+
+
+  prometheus_config_yaml = encode_yaml(prometheus_config)
+  output_path = "/tmp/prometheus_config.yaml"
+
+  # Print prometheus_config_yaml into tmp
+  local('cat > {}'.format(output_path), stdin=prometheus_config_yaml, echo_off=True, quiet=True)
+
+  # override prometheus with one that works in docker
+  services.append(("prometheus", {
+    'container_name': 'deku_prometheus',
+    'restart': 'always',
+    'image': 'prom/prometheus',
+    'ports': ['9090:9090'],
+    'expose': [ 9090 ],
+    'volumes': [ output_path + ':/etc/prometheus/prometheus.yml' ],
+  }))
+
+  services = {k: v for k, v in services}
+  return encode_yaml({
+    'version': '3.8',
+    'services': services
+  })
+
+def load_deku_services (deku_yaml):
+  for deku_service in get_services(decode_yaml(deku_yaml)):
+      dc_resource(deku_service, labels=["deku"], resource_deps=["deku-setup"])
+
+def add_sandbox (no_of_deku_nodes):
+  # run setup when we build
+  local_resource(
+    "deku-setup",
+    "sleep 5 && ./sandbox.sh setup docker %s" % no_of_deku_nodes,
+    resource_deps=["flextesa"],
+    labels=["scripts"],
+    )
+
+  # bootstrap the deku network, it will be run after deku-setup and the nodes have started
+  local_resource(
+    "deku-net",
+    "./sandbox.sh start docker %s" % no_of_deku_nodes,
+    resource_deps=["deku-setup", "deku-node-0", "deku-node-1", "deku-node-2"],
+    labels=["scripts"],
+    auto_init=True, # trigger once at start
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    )

--- a/tilt/Tiltfile.local
+++ b/tilt/Tiltfile.local
@@ -2,20 +2,42 @@ def add_sandbox (no_of_deku_nodes):
   # run setup when we build
   local_resource(
     "deku-setup",
-    "sleep 5 && ./sandbox.sh setup local %s" % no_of_deku_nodes,
+    "sleep 5 && nix run .#sandbox setup local %s" % no_of_deku_nodes,
     resource_deps=["flextesa"],
     labels=["scripts"],
     )
 
-  # bootstrap the deku network, it will be run after deku-setup and the nodes have started
-  local_resource(
-    "deku-net",
-    serve_cmd= "./sandbox.sh start local %s" % no_of_deku_nodes,
-    resource_deps=["deku-setup"],
-    labels=["scripts"],
-    auto_init=True, # trigger once at start
-    trigger_mode=TRIGGER_MODE_MANUAL,
-    )
+  if config.tilt_subcommand == "ci":
+    # bootstrap the deku network and run some tests
+    local_resource(
+      "smoke-test",
+      "sleep 5 && nix run .#sandbox smoke-test local %s" % no_of_deku_nodes,
+      resource_deps=["deku-setup"],
+      labels=["scripts"],
+      auto_init=True, # trigger once at start
+      trigger_mode=TRIGGER_MODE_MANUAL,
+      allow_parallel=True,
+      )
+
+    local_resource(
+      "deposit-withdraw-test",
+      "sleep 5 && nix run .#sandbox deposit-withdraw-test",
+      resource_deps=["smoke-test"],
+      labels=["scripts"],
+      auto_init=True, # trigger once at start
+      trigger_mode=TRIGGER_MODE_MANUAL,
+      allow_parallel=True,
+      )
+  else:
+    # bootstrap the deku network, it will be run after deku-setup and the nodes have started
+    local_resource(
+      "deku-net",
+      serve_cmd="nix run .#sandbox start local %s" % no_of_deku_nodes,
+      resource_deps=["deku-setup"],
+      labels=["scripts"],
+      auto_init=True, # trigger once at start
+      trigger_mode=TRIGGER_MODE_MANUAL,
+      )
 
 def load_deku_services (_):
   print('no-op')

--- a/tilt/Tiltfile.local
+++ b/tilt/Tiltfile.local
@@ -1,0 +1,26 @@
+def add_sandbox (no_of_deku_nodes):
+  # run setup when we build
+  local_resource(
+    "deku-setup",
+    "sleep 5 && ./sandbox.sh setup local %s" % no_of_deku_nodes,
+    resource_deps=["flextesa"],
+    labels=["scripts"],
+    )
+
+  # bootstrap the deku network, it will be run after deku-setup and the nodes have started
+  local_resource(
+    "deku-net",
+    serve_cmd= "./sandbox.sh start local %s" % no_of_deku_nodes,
+    resource_deps=["deku-setup"],
+    labels=["scripts"],
+    auto_init=True, # trigger once at start
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    )
+
+def load_deku_services (_):
+  print('no-op')
+
+def make_deku_yaml (_):
+  print('no-op')
+  # We must return a valid (but empty) docker-compose configuration
+  return encode_yaml({'version': '3.8', 'services': {}})


### PR DESCRIPTION
## Problem

<!--- Restate the problem addressed by the PR here --->

`Tilt` currently only runs with nodes in docker, we often want to run them locally

## Solution

<!--- Restate the basic ideas behind your solution --->
<!--- Here it is also a good space to put details of your implementation --->

Moved the current (docker based) deku nodes configuration into a separate file.
Created a file for the local workflow with the same API but calls `sandbox.sh` with local settings.

Added a `mode` argument that can be used like `tilt up -- --mode=local`, it will default to `docker` when omitted.

When running in tilt we also override the prometheus service with a special configuration that reads the nodes running in docker.
If `USE_NIX` is unset we will not try to build the docker image with `nix`