### PR TITLE
add global ticket_table 

### DIFF
--- a/src/core/contract_ffi.ml
+++ b/src/core/contract_ffi.ml
@@ -1,0 +1,55 @@
+(* type _ syscall =
+     | FAILWITH         : int -> bytes syscall
+     | EXAMPLE          : int -> (int * string) syscall
+     | SENDER           : int -> (Address.t -> unit) syscall
+     | SOURCE           : int -> (Address.t -> unit) syscall
+     | SELF             : int -> (Address.t -> unit) syscall
+     | OWN_TICKET       :
+         int
+         -> (Ticket_handle.t * (Ticket_handle.t -> unit)) option syscall
+     | READ_TICKET      :
+         int
+         -> (Ticket_handle.t
+            * (Ticket_handle.t -> Amount.t -> Ticket_handle.t -> unit))
+            option
+            syscall
+     | JOIN_TICKETS     :
+         int
+         -> (Ticket_handle.t * Ticket_handle.t * (Ticket_handle.t -> unit)) option
+            syscall
+     | SPLIT_TICKET     :
+         int
+         -> (Ticket_id.t * (Ticket_handle.t -> Ticket_handle.t -> unit)) option
+            syscall
+     | GET_CONTRACT_OPT :
+         int
+         -> (Address.t * (Address.t option -> unit)) option syscall
+     | TRANSACTION      :
+         int
+         -> (bytes * Ticket_handle.t -> Address.t * (unit -> unit)) option syscall
+
+   (* THIS IS AN OVERKILL *)
+   let load : type a. a syscall -> a = function
+     | FAILWITH _ -> "tyest" |> String.to_bytes
+     | SENDER _ -> fun _ -> ()
+     | _ -> failwith "est"
+
+   module type CTX = sig
+     val failwith : bytes -> unit
+     val sender : (Address.t -> unit) -> unit
+   end
+
+   let syscall (type a) mem (module S : CTX) =
+     let module T = S in
+     fun x ->
+       match Array.get mem x with
+       | 0 -> load (FAILWITH 0) |> T.failwith
+       | 1 -> load (SENDER 1) |> T.sender
+       | _ -> failwith "test"
+
+   module S : CTX = struct
+     let sender = Address.of_string "test" |> Option.get
+     let failwith _ = ()
+     let sender f = f sender
+   end
+   let res = syscall [|0|] (module S) 1 *)

--- a/src/core/ledger.ml
+++ b/src/core/ledger.ml
@@ -1,19 +1,6 @@
 open Helpers
 open Crypto
-module Address_and_ticket_map = struct
-  type key = {
-    address : Key_hash.t;
-    ticket : Ticket_id.t;
-  }
-  [@@deriving ord, yojson]
-  module Map = Map.Make_with_yojson (struct
-    type t = key [@@deriving ord, yojson]
-  end)
-  type t = Amount.t Map.t [@@deriving yojson]
-  let empty = Map.empty
-  let find_opt address ticket = Map.find_opt { address; ticket }
-  let add address ticket = Map.add { address; ticket }
-end
+
 module Withdrawal_handle = struct
   type t = {
     hash : BLAKE2B.t;
@@ -34,66 +21,48 @@ module Withdrawal_handle_tree = Incremental_patricia.Make (struct
   let hash t = t.Withdrawal_handle.hash
 end)
 type t = {
-  ledger : Address_and_ticket_map.t;
+  ledger : Ticket_table.t;
   withdrawal_handles : Withdrawal_handle_tree.t;
 }
 [@@deriving yojson]
 let empty =
   {
-    ledger = Address_and_ticket_map.empty;
+    ledger = Ticket_table.empty;
     withdrawal_handles = Withdrawal_handle_tree.empty;
   }
 let balance address ticket t =
-  Address_and_ticket_map.find_opt address ticket t.ledger
+  Ticket_table.amount t.ledger (Address.of_key_hash address) ticket
   |> Option.value ~default:Amount.zero
-let assert_available ~sender ~(amount : Amount.t) =
-  if sender >= amount then
-    Ok ()
-  else
-    Error `Not_enough_funds
+
 let transfer ~sender ~destination amount ticket t =
-  let open Amount in
-  let sender_balance = balance sender ticket t in
-  let%ok () = assert_available ~sender:sender_balance ~amount in
-  let destination_balance = balance destination ticket t in
-  Ok
-    {
-      ledger =
-        t.ledger
-        |> Address_and_ticket_map.add sender ticket (sender_balance - amount)
-        |> Address_and_ticket_map.add destination ticket
-             (destination_balance + amount);
-      withdrawal_handles = t.withdrawal_handles;
-    }
+  let%ok ledger =
+    Ticket_table.transfer t.ledger
+      ~sender:(Address.of_key_hash sender)
+      ~destination:(Address.of_key_hash destination)
+      ~amount ~ticket
+    |> Result.map_error (fun _ -> `Insufficient_funds) in
+  Ok { ledger; withdrawal_handles = t.withdrawal_handles }
 let deposit destination amount ticket t =
-  let open Amount in
-  let destination_balance = balance destination ticket t in
-  {
-    ledger =
-      t.ledger
-      |> Address_and_ticket_map.add destination ticket
-           (destination_balance + amount);
-    withdrawal_handles = t.withdrawal_handles;
-  }
+  let ledger =
+    Ticket_table.unsafe_deposit_ticket t.ledger ~ticket
+      ~destination:(Address.of_key_hash destination)
+      ~amount in
+  { ledger; withdrawal_handles = t.withdrawal_handles }
 
 let withdraw ~sender ~destination amount ticket t =
-  let open Amount in
-  let owner = destination in
-  let sender_balance = balance sender ticket t in
-  let%ok () = assert_available ~sender:sender_balance ~amount in
+  let%ok ledger =
+    Ticket_table.unsafe_withdraw t.ledger
+      ~sender:(Address.of_key_hash sender)
+      ~amount ~ticket
+    |> Result.map_error (function _ -> `Insufficient_funds) in
   let withdrawal_handles, handle =
     Withdrawal_handle_tree.add
       (fun id ->
-        let hash = Withdrawal_handle.hash ~id ~owner ~amount ~ticket in
-        { id; hash; owner; amount; ticket })
+        let hash =
+          Withdrawal_handle.hash ~id ~owner:destination ~amount ~ticket in
+        { id; hash; owner = destination; amount; ticket })
       t.withdrawal_handles in
-  let t =
-    {
-      ledger =
-        t.ledger
-        |> Address_and_ticket_map.add sender ticket (sender_balance - amount);
-      withdrawal_handles;
-    } in
+  let t = { ledger; withdrawal_handles } in
   Ok (t, handle)
 let withdrawal_handles_find_proof handle t =
   match

--- a/src/core/ledger.mli
+++ b/src/core/ledger.mli
@@ -18,7 +18,7 @@ val transfer :
   Amount.t ->
   Ticket_id.t ->
   t ->
-  (t, [> `Not_enough_funds]) result
+  (t, [> `Insufficient_funds]) result
 val deposit : Key_hash.t -> Amount.t -> Ticket_id.t -> t -> t
 val withdraw :
   sender:Key_hash.t ->
@@ -26,7 +26,7 @@ val withdraw :
   Amount.t ->
   Ticket_id.t ->
   t ->
-  (t * Withdrawal_handle.t, [> `Not_enough_funds]) result
+  (t * Withdrawal_handle.t, [> `Insufficient_funds]) result
 val withdrawal_handles_find_proof :
   Withdrawal_handle.t -> t -> (BLAKE2B.t * BLAKE2B.t) list
 val withdrawal_handles_find_proof_by_id :

--- a/src/core/state.ml
+++ b/src/core/state.ml
@@ -94,4 +94,4 @@ let apply_user_operation t user_operation =
   | Ok (t, receipt) -> (t, receipt)
   (* TODO: use this erros for something *)
   | Error (`Origination_error _ | `Invocation_error _) -> (t, None)
-  | Error `Not_enough_funds -> (t, None)
+  | Error `Insufficient_funds -> (t, None)

--- a/src/core/ticket_handle.ml
+++ b/src/core/ticket_handle.ml
@@ -1,0 +1,32 @@
+open Crypto
+
+include BLAKE2B_20
+
+(* TODO: STOP STRINGIFYING EVERYWHERE TO GET HASH WHEN HASH ALREADY EXISTS *)
+let make owner ticket =
+  BLAKE2B_20.hash_v [Address.to_string owner; Tezos.Ticket_id.to_string ticket]
+let make_temp owner ticket amount =
+  BLAKE2B_20.hash_v
+    [
+      Address.to_string owner;
+      Tezos.Ticket_id.to_string ticket;
+      Amount.to_int amount |> string_of_int;
+    ]
+
+let to_bytes t = BLAKE2B_20.to_raw_string t |> Bytes.of_string
+let of_bytes t = Bytes.to_string t |> BLAKE2B_20.of_raw_string
+
+module Map = Helpers.Map.Make_with_yojson (struct
+  type nonrec t = t
+
+  let to_yojson = to_yojson
+  let of_yojson = of_yojson
+  let compare = compare
+end)
+module Set = Helpers.Set.Make_with_yojson (struct
+  type nonrec t = t
+
+  let to_yojson = to_yojson
+  let of_yojson = of_yojson
+  let compare = compare
+end)

--- a/src/core/ticket_handle.mli
+++ b/src/core/ticket_handle.mli
@@ -1,0 +1,22 @@
+type t [@@deriving yojson, ord, eq]
+val to_string : t -> string
+val of_string : string -> t option
+
+val make : Address.t -> Tezos.Ticket_id.t -> t
+val make_temp : Address.t -> Tezos.Ticket_id.t -> Amount.t -> t
+val to_bytes : t -> bytes
+val of_bytes : bytes -> t option
+
+module Map : sig
+  include Map.S with type key := t
+  val to_yojson : ('a -> Yojson.Safe.t) -> 'a t -> Yojson.Safe.t
+  val of_yojson :
+    (Yojson.Safe.t -> ('a, string) result) ->
+    Yojson.Safe.t ->
+    ('a t, string) result
+end
+module Set : sig
+  include Set.S with type elt := t
+  val to_yojson : t -> Yojson.Safe.t
+  val of_yojson : Yojson.Safe.t -> (t, string) result
+end

--- a/src/core/ticket_table.ml
+++ b/src/core/ticket_table.ml
@@ -1,0 +1,160 @@
+open Helpers
+module Map = Ticket_handle.Map
+module Set = Ticket_handle.Set
+module Errors = struct
+  let doesnt_exist = Error `Ticket_doesnt_exist
+  let insufficient_funds = Error `Insufficient_funds
+
+  let ownership_violation = Error `Ticket_ownership_violation
+  let different_tickets = Error `Attempted_to_merge_different_tickets
+
+  let ticket_split_error = Error `Ticket_split_invalid_amount
+end
+
+open struct
+  open struct
+    let ok = Ok ()
+  end
+  let assert_ownership sender ~ticket ~ticket_handle =
+    let checked_handle = Ticket_handle.make sender ticket in
+    if Ticket_handle.equal checked_handle ticket_handle then
+      ok
+    else
+      Errors.ownership_violation
+
+  let assert_enough_funds ~ticket_total ~amount =
+    if Amount.(compare ticket_total amount = -1) then
+      Errors.insufficient_funds
+    else
+      ok
+  let assert_same_amount ticket_total amount =
+    if Amount.(equal ticket_total amount) then
+      Ok ()
+    else
+      Errors.ticket_split_error
+
+  let assert_same_tickets t1 t2 =
+    if Ticket_id.equal t1 t2 then ok else Errors.different_tickets
+end
+
+module Ticket_repr = struct
+  type t = {
+    ticket : Ticket_id.t;
+    amount : Amount.t;
+  }
+  [@@deriving yojson, eq, ord]
+  let[@inline] ticket t = t.ticket
+
+  let make ticket amount = { ticket; amount }
+  let join t1 t2 =
+    let%ok () = assert_same_tickets t1.ticket t2.ticket in
+    Ok { t1 with amount = Amount.(t1.amount + t2.amount) }
+
+  let split ticket ~ticket_total ~amounts:(first, second) =
+    let total_amount = Amount.(first + second) in
+    let%ok () = assert_same_amount ticket_total total_amount in
+    let%ok () = assert_enough_funds ~ticket_total ~amount:total_amount in
+    let ticket1 = { ticket; amount = first } in
+    let ticket2 = { ticket; amount = second } in
+    Ok (ticket1, ticket2)
+end
+type t = {
+  global : Ticket_repr.t Ticket_handle.Map.t;
+  temp : Ticket_handle.Set.t;
+      (* we use temp during execution to drop tickets that are no longer owned by anyone *)
+}
+[@@deriving yojson]
+
+let empty = { global = Ticket_handle.Map.empty; temp = Ticket_handle.Set.empty }
+let validate (t : t) : t =
+  let global =
+    Ticket_handle.Set.fold (fun x acc -> Map.remove x acc) t.temp t.global in
+  { global; temp = Ticket_handle.Set.empty }
+
+let amount t address ticket =
+  let handle = Ticket_handle.make address ticket in
+  Map.find_opt handle t.global |> Option.map (fun x -> x.Ticket_repr.amount)
+
+let unsafe_read t ~handle =
+  Map.find_opt handle t |> Option.map (fun x -> (x, Map.remove handle t))
+
+let unsafe_deposit_ticket { global; temp } ~ticket ~destination ~amount =
+  let handle = Ticket_handle.make destination ticket in
+  let new_ticket = Ticket_repr.make ticket amount in
+  let state = unsafe_read global ~handle in
+  {
+    global =
+      (match state with
+      | Some (existing_ticket, t) ->
+        let joined =
+          Ticket_repr.join existing_ticket new_ticket |> Result.get_ok in
+        (* error stemming from Result.get_ok should never occur  *)
+        Map.add handle joined t
+      | None -> Map.add handle new_ticket global);
+    temp;
+  }
+let own t sender ticket_handle =
+  let%assert () = (`Ticket_ownership_violation, Set.mem ticket_handle t.temp) in
+  let%ok ticket, global =
+    match unsafe_read t.global ~handle:ticket_handle with
+    | Some (ticket, global) -> Ok (ticket, global)
+    | None -> Errors.doesnt_exist in
+  let temp = Set.remove ticket_handle t.temp in
+  Ok
+    (unsafe_deposit_ticket { global; temp } ~ticket:ticket.ticket
+       ~amount:ticket.amount ~destination:sender)
+
+let read_ticket t ~sender ~ticket_handle =
+  Map.find_opt ticket_handle t.global
+  |> Option.fold
+       ~some:(fun Ticket_repr.{ ticket; amount } ->
+         let%ok () = assert_ownership sender ~ticket ~ticket_handle in
+         let global = Map.remove ticket_handle t.global in
+         let to_return = ((ticket, amount), { global; temp = t.temp }) in
+         Ok to_return)
+       ~none:Errors.doesnt_exist
+
+let disown t sender ticket_handle =
+  let%ok (ticket_id, amount), t = read_ticket t ~sender ~ticket_handle in
+  let handle = Ticket_handle.make_temp sender ticket_id amount in
+  let temp = Set.add handle t.temp in
+  let global = Map.add handle (Ticket_repr.make ticket_id amount) t.global in
+  Ok { global; temp }
+
+let split_ticket t ~sender ~ticket_handle ~amounts =
+  let%ok (ticket, amount), t = read_ticket t ~sender ~ticket_handle in
+  let%ok handle, handle2 =
+    Ticket_repr.split ticket ~ticket_total:amount ~amounts in
+  Ok ((handle, handle2), t)
+
+let transfer t ~sender ~ticket ~destination ~amount =
+  let ticket_handle = Ticket_handle.make sender ticket in
+  let%ok (ticket, ticket_total), t = read_ticket t ~sender ~ticket_handle in
+  let%ok () = assert_enough_funds ~ticket_total ~amount in
+  let%ok to_send, to_hold =
+    Ticket_repr.split ticket ~ticket_total
+      ~amounts:Amount.(amount, ticket_total - amount) in
+  let t =
+    unsafe_deposit_ticket t ~ticket:to_send.ticket ~amount:to_send.amount
+      ~destination in
+  if Amount.(equal ticket_total amount) then
+    Ok t
+  else
+    Ok
+      (unsafe_deposit_ticket t ~ticket:to_hold.ticket ~amount:to_hold.amount
+         ~destination:sender)
+
+let unsafe_withdraw t ~ticket ~sender ~amount =
+  let handle = Ticket_handle.make sender ticket in
+  let%ok (ticket_id, total_amount), t =
+    read_ticket t ~sender ~ticket_handle:handle in
+  let%ok () = assert_enough_funds ~ticket_total:total_amount ~amount in
+  let%ok _, handle2 =
+    Ticket_repr.split ticket_id ~ticket_total:total_amount
+      ~amounts:Amount.(amount, total_amount - amount) in
+  Ok
+    (unsafe_deposit_ticket t ~ticket:handle2.ticket ~destination:sender
+       ~amount:handle2.amount)
+
+(* tickets field with mapping of ticket -> handle *)
+(* cli: create a function that returns a future handle for the ticket to be used by the contract *)

--- a/src/core/ticket_table.mli
+++ b/src/core/ticket_table.mli
@@ -1,0 +1,76 @@
+module Ticket_repr : sig
+  type t = {
+    ticket : Ticket_id.t;
+    amount : Amount.t;
+  }
+  [@@deriving yojson, eq, ord]
+
+  val ticket : t -> Ticket_id.t
+  val make : Ticket_id.t -> Amount.t -> t
+end
+type t [@@deriving yojson]
+
+val empty : t
+val validate : t -> t
+
+val amount : t -> Address.t -> Ticket_id.t -> Amount.t option
+
+val unsafe_deposit_ticket :
+  t -> ticket:Ticket_id.t -> destination:Address.t -> amount:Amount.t -> t
+
+val own :
+  t ->
+  Address.t ->
+  Ticket_handle.t ->
+  (t, [> `Ticket_doesnt_exist | `Ticket_ownership_violation]) result
+
+val read_ticket :
+  t ->
+  sender:Address.t ->
+  ticket_handle:Ticket_handle.t ->
+  ( (Ticket_id.t * Amount.t) * t,
+    [> `Ticket_doesnt_exist | `Ticket_ownership_violation] )
+  result
+
+val disown :
+  t ->
+  Address.t ->
+  Ticket_handle.t ->
+  (t, [> `Ticket_doesnt_exist | `Ticket_ownership_violation]) result
+
+val split_ticket :
+  t ->
+  sender:Address.t ->
+  ticket_handle:Ticket_handle.t ->
+  amounts:Amount.t * Amount.t ->
+  ( (Ticket_repr.t * Ticket_repr.t) * t,
+    [> `Insufficient_funds
+    | `Ticket_doesnt_exist
+    | `Ticket_ownership_violation
+    | `Ticket_split_invalid_amount ] )
+  result
+
+val transfer :
+  t ->
+  sender:Address.t ->
+  ticket:Ticket_id.t ->
+  destination:Address.t ->
+  amount:Amount.t ->
+  ( t,
+    [> `Insufficient_funds
+    | `Ticket_doesnt_exist
+    | `Ticket_ownership_violation
+    | `Ticket_split_invalid_amount ] )
+  result
+
+val unsafe_withdraw :
+  t ->
+  ticket:Ticket_id.t ->
+  sender:Address.t ->
+  amount:Amount.t ->
+  ( t,
+    [> `Insufficient_funds
+    | `Ticket_doesnt_exist
+    | `Ticket_ownership_violation
+    | `Ticket_split_invalid_amount ] )
+  result

--- a/src/crypto/BLAKE2B.ml
+++ b/src/crypto/BLAKE2B.ml
@@ -10,6 +10,7 @@ end) : sig
   val equal : t -> t -> bool
   val compare : t -> t -> int
   val hash : string -> t
+  val hash_v : string list -> t
   val verify : hash:t -> string -> bool
   val both : t -> t -> t
   val size : int
@@ -35,7 +36,9 @@ end = struct
   let equal = equal
   let compare = unsafe_compare
   let hash data = digest_string data
-  let verify ~hash:expected_hash data = expected_hash = hash data
+  let hash_v lst = digestv_string lst
+
+  let verify ~hash:expected_hash data = equal expected_hash (hash data)
   let both a b = hash (to_raw_string a ^ to_raw_string b)
   module Map = Map.Make (struct
     type nonrec t = t

--- a/tests/test_ledger.ml
+++ b/tests/test_ledger.ml
@@ -110,15 +110,15 @@ let () =
           expect_balance c t2 5 t;
           (let t = transfer ~sender:b ~destination:c (Amount.of_int 202) t1 t in
            (expect.result t).toBeError ();
-           expect.equal (Result.get_error t) `Not_enough_funds);
+           expect.equal (Result.get_error t) `Insufficient_funds);
           (let d = make_address () in
            let t = transfer ~sender:d ~destination:c (Amount.of_int 1) t2 t in
            (expect.result t).toBeError ();
-           expect.equal (Result.get_error t) `Not_enough_funds);
+           expect.equal (Result.get_error t) `Insufficient_funds);
           (let t3 = make_ticket () in
            let t = transfer ~sender:a ~destination:b (Amount.of_int 1) t3 t in
            (expect.result t).toBeError ();
-           expect.equal (Result.get_error t) `Not_enough_funds);
+           expect.equal (Result.get_error t) `Insufficient_funds);
           ());
       test "deposit" (fun _ expect_balance ->
           let t, (t1, t2), (a, b) = setup_two () in
@@ -178,9 +178,9 @@ let () =
           (let t1' = make_ticket ~data:t1.data () in
            let t = transfer ~sender:a ~destination:b (Amount.of_int 1) t1' t in
            (expect.result t).toBeError ();
-           expect.equal (Result.get_error t) `Not_enough_funds);
+           expect.equal (Result.get_error t) `Insufficient_funds);
           (let t1' = make_ticket ~ticketer:t1.ticketer () in
            let t = transfer ~sender:a ~destination:b (Amount.of_int 1) t1' t in
            (expect.result t).toBeError ();
-           expect.equal (Result.get_error t) `Not_enough_funds);
+           expect.equal (Result.get_error t) `Insufficient_funds);
           ()))


### PR DESCRIPTION
## Problem

We're going to start moving tickets between implicit and originated accounts  (e.g. putting ticket handles in contract storage, putting them as parameters, dropping from table, etc(as in "End of Thinking Capacity".)

## Solution
Create a global ticket table, with api that in theory shouldn't allow you to do manipulations with ticket that is already droppped or doesnt belong to you.

 