### PR TITLE
add breakline at the end of function

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -23,4 +23,4 @@ if-then-else = fit-or-vertical
 let-and = sparse
 type-decl = sparse
 sequence-blank-line=preserve-one
-module-item-spacing=preserve
+module-item-spacing=sparse

--- a/src/bin/deku_node.ml
+++ b/src/bin/deku_node.ml
@@ -2,12 +2,15 @@ open Cmdliner
 open Helpers
 open Node
 open Bin_common
+
 let ignore_some_errors = function
   | Error #Flows.ignore -> Ok ()
   | v -> v
+
 let update_state state =
   Server.set_state state;
   state
+
 let handle_request (type req res)
     (module E : Network.Request_endpoint
       with type request = req
@@ -154,6 +157,7 @@ let handle_ticket_balance =
       let state = Server.get_state () in
       let amount = Flows.request_ticket_balance state ~ticket ~address in
       Ok { amount })
+
 let node folder prometheus_port =
   let node = Node_state.get_initial_state ~folder |> Lwt_main.run in
   Tezos_interop.Consensus.listen_operations node.Node.State.interop_context
@@ -206,4 +210,5 @@ let node =
     required & pos 0 (some string) None & info [] ~doc ~docv in
   let open Term in
   const node $ folder_node $ Prometheus_dream.opts
+
 let _ = Cmd.eval @@ Cmd.v (Cmd.info "deku-node") node

--- a/src/bin/files.ml
+++ b/src/bin/files.ml
@@ -1,38 +1,50 @@
 open Helpers
 open Node
 open State
+
 exception Invalid_json of string
+
 let read_json of_yojson ~file =
   let%await string = Lwt_io.with_file ~mode:Input file Lwt_io.read in
   let json = Yojson.Safe.from_string string in
   match of_yojson json with
   | Ok data -> await data
   | Error error -> raise (Invalid_json error)
+
 let write_json to_yojson data ~file =
   Lwt_io.with_file ~mode:Output file (fun oc ->
       Lwt_io.write oc (Yojson.Safe.pretty_to_string (to_yojson data)))
+
 module Identity = struct
   let read = read_json identity_of_yojson
+
   let write = write_json identity_to_yojson
 end
+
 module Wallet = struct
   type t = {
     address : Crypto.Key_hash.t;
     priv_key : Crypto.Secret.t;
   }
   [@@deriving yojson]
+
   let read = read_json of_yojson
+
   let write = write_json to_yojson
 end
+
 module Interop_context = struct
   module Secret = struct
     include Crypto.Secret
+
     let of_yojson = function
       | `String string ->
         of_string string |> Option.to_result ~none:"invalid secret"
       | _ -> Error "expected a string"
+
     let to_yojson t = `String (to_string t)
   end
+
   type t = {
     rpc_node : Uri.t;
     secret : Secret.t;
@@ -41,17 +53,24 @@ module Interop_context = struct
     required_confirmations : int;
   }
   [@@deriving yojson]
+
   let read = read_json of_yojson
+
   let write = write_json to_yojson
 end
+
 module State_bin = struct
   let read ~file = Lwt_io.with_file ~mode:Input file Lwt_io.read_value
+
   let write protocol ~file =
     Lwt_io.with_file ~mode:Output file (fun __x ->
         Lwt_io.write_value __x protocol)
 end
+
 module Trusted_validators_membership_change = struct
   type t = Trusted_validators_membership_change.t [@@deriving yojson]
+
   let read = read_json [%of_yojson: t list]
+
   let write = write_json [%to_yojson: t list]
 end

--- a/src/bin/files.mli
+++ b/src/bin/files.mli
@@ -1,18 +1,25 @@
 open Node
 open State
+
 exception Invalid_json of string
+
 module Identity : sig
   val read : file:string -> identity Lwt.t
+
   val write : identity -> file:string -> unit Lwt.t
 end
+
 module Wallet : sig
   type t = {
     address : Crypto.Key_hash.t;
     priv_key : Crypto.Secret.t;
   }
+
   val read : file:string -> t Lwt.t
+
   val write : t -> file:string -> unit Lwt.t
 end
+
 module Interop_context : sig
   type t = {
     rpc_node : Uri.t;
@@ -21,15 +28,22 @@ module Interop_context : sig
     discovery_contract : Tezos.Address.t;
     required_confirmations : int;
   }
+
   val read : file:string -> t Lwt.t
+
   val write : t -> file:string -> unit Lwt.t
 end
+
 module State_bin : sig
   val read : file:string -> Protocol.t Lwt.t
+
   val write : Protocol.t -> file:string -> unit Lwt.t
 end
+
 module Trusted_validators_membership_change : sig
   type t = Trusted_validators_membership_change.t [@@deriving yojson]
+
   val read : file:string -> t list Lwt.t
+
   val write : t list -> file:string -> unit Lwt.t
 end

--- a/src/bin/node_state.ml
+++ b/src/bin/node_state.ml
@@ -1,6 +1,7 @@
 open Helpers
 open Protocol
 open Node
+
 let get_initial_state ~folder =
   let%await identity = Files.Identity.read ~file:(folder ^ "/identity.json") in
   let trusted_validator_membership_change_file =

--- a/src/core_deku/address.ml
+++ b/src/core_deku/address.ml
@@ -1,10 +1,13 @@
 open Crypto
 open Helpers
+
 type t =
   | Implicit   of Key_hash.t
   | Originated of Contract_address.t
 [@@deriving eq, ord, yojson]
+
 let of_key_hash implicit = Implicit implicit
+
 let to_key_hash t =
   match t with
   | Implicit implicit -> Some implicit
@@ -14,10 +17,13 @@ let to_contract_hash t =
   match t with
   | Implicit _key_hash -> None
   | Originated contract_hash -> Some contract_hash
+
 let of_contract_hash contract_hash = Originated contract_hash
+
 let to_string = function
   | Implicit implicit -> Key_hash.to_string implicit
   | Originated contract_hash -> Contract_address.to_string contract_hash
+
 let of_string =
   let implicit string =
     let%some key_hash = Key_hash.of_string string in

--- a/src/core_deku/address.mli
+++ b/src/core_deku/address.mli
@@ -1,8 +1,15 @@
 open Crypto
+
 type t [@@deriving eq, ord, yojson]
+
 val of_key_hash : Key_hash.t -> t
+
 val to_key_hash : t -> Key_hash.t option
+
 val of_contract_hash : Contract_address.t -> t
+
 val to_contract_hash : t -> Contract_address.t option
+
 val to_string : t -> string
+
 val of_string : string -> t option

--- a/src/core_deku/amount.ml
+++ b/src/core_deku/amount.ml
@@ -1,15 +1,22 @@
 type t = int [@@deriving eq, ord]
+
 let zero = 0
+
 let ( + ) = ( + )
+
 let ( - ) a b =
   let t = a - b in
   if t < 0 then
     raise (Invalid_argument "Negative amount");
   t
+
 let of_int t =
   if t < 0 then
     raise (Invalid_argument "Negative amount");
   t
+
 let to_int t = t
+
 let of_yojson json = json |> [%of_yojson: int] |> Result.map of_int
+
 let to_yojson t = `Int t

--- a/src/core_deku/amount.mli
+++ b/src/core_deku/amount.mli
@@ -1,6 +1,11 @@
 type t [@@deriving eq, ord, yojson]
+
 val zero : t
+
 val ( + ) : t -> t -> t
+
 val ( - ) : t -> t -> t
+
 val of_int : int -> t
+
 val to_int : t -> int

--- a/src/core_deku/contract_address.ml
+++ b/src/core_deku/contract_address.ml
@@ -2,14 +2,22 @@ open Helpers
 open Crypto
 
 type t = BLAKE2B_20.t [@@deriving eq, ord]
+
 let of_user_operation_hash t = BLAKE2B.to_raw_string t |> BLAKE2B_20.hash
+
 include Encoding_helpers.Make_b58 (struct
   type nonrec t = t
+
   let name = "Deku_contract_hash"
+
   let title = "A Deku contract ID"
+
   let size = BLAKE2B_20.size
+
   let prefix = Base58.Prefix.deku_contract_hash
+
   let to_raw = BLAKE2B_20.to_raw_string
+
   let of_raw = BLAKE2B_20.of_raw_string
 end)
 

--- a/src/core_deku/contract_address.mli
+++ b/src/core_deku/contract_address.mli
@@ -1,7 +1,9 @@
 open Crypto
+
 type t [@@deriving ord, eq, yojson]
 
 val of_user_operation_hash : BLAKE2B.t -> t
 
 val to_string : t -> string
+
 val of_string : string -> t option

--- a/src/core_deku/contract_storage.ml
+++ b/src/core_deku/contract_storage.ml
@@ -1,6 +1,5 @@
 open Helpers
 open Contract_vm
-
 module Map = Map.Make_with_yojson (Contract_address)
 
 type t = Contract.t Map.t [@@deriving yojson, eq]

--- a/src/core_deku/contract_storage.mli
+++ b/src/core_deku/contract_storage.mli
@@ -3,8 +3,11 @@ open Contract_vm
 type t [@@deriving yojson, eq]
 
 val empty : t
+
 val originate_contract :
   t -> address:Contract_address.t -> contract:Contract.t -> t
+
 val update_contract_storage :
   t -> address:Contract_address.t -> updated_contract:Contract.t -> t
+
 val get_contract : t -> address:Contract_address.t -> Contract.t option

--- a/src/core_deku/contract_vm.ml
+++ b/src/core_deku/contract_vm.ml
@@ -13,6 +13,7 @@ module Lambda = struct
 
   module Raw_repr = struct
     open Lambda_vm
+
     module Errors = struct
       type t =
         [ `Out_of_gas
@@ -20,6 +21,7 @@ module Lambda = struct
         | `Invalid_contract
         | `Invalid_contract_argument ]
     end
+
     let wrap_error x =
       Result.map_error
         (function
@@ -31,12 +33,14 @@ module Lambda = struct
 
     module Script = struct
       type t = Ast.script [@@deriving yojson]
+
       let to_code ~gas script = wrap_error (Compiler.compile gas script)
     end
 
     (** TODO: conversion from micheline *)
     module Value = struct
       type t = Ast.value [@@deriving yojson]
+
       let to_value ~gas value = wrap_error (Compiler.compile_value gas value)
     end
   end
@@ -48,12 +52,14 @@ module Lambda = struct
     }
     [@@deriving yojson]
   end
+
   module Compiler = struct
     let error_to_string : Raw_repr.Errors.t -> string = function
       | `Out_of_gas -> "Out of gas"
       | `Out_of_stack -> "Out of stack"
       | `Invalid_contract -> "Invalid contract"
       | `Invalid_contract_argument -> "Invalid contract argument"
+
     let compile ({ code; storage } : Origination_payload.t) ~gas =
       let open Lambda_vm in
       let gas = Gas.make ~initial_gas:gas in
@@ -65,9 +71,11 @@ module Lambda = struct
       in
       Ok (Contract.make ~code ~storage)
   end
+
   module Invocation_payload = struct
     type t = Raw_repr.Value.t [@@deriving yojson]
   end
+
   module Interpreter = struct
     let error_to_string : Lambda_vm.Interpreter.error -> string = function
       | Runtime_limits_error Out_of_gas -> "Out of gas"
@@ -99,19 +107,24 @@ module Lambda = struct
       Ok (updated_contract, ())
   end
 end
+
 module Dummy = struct
   module Contract = struct
     type t = int [@@deriving yojson, eq]
   end
+
   module Origination_payload = struct
     type t = int [@@deriving yojson]
   end
+
   module Compiler = struct
     let compile payload ~gas:_ = Ok payload
   end
+
   module Invocation_payload = struct
     type t = int * int [@@deriving yojson]
   end
+
   module Interpreter = struct
     let invoke storage ~arg ~gas:_ =
       let result =
@@ -130,11 +143,13 @@ module External_vm = struct
       | Dummy  of Dummy.Contract.t
     [@@deriving yojson, eq]
   end
+
   module Origination_payload = struct
     type t =
       | Dummy  of int
       | Lambda of Lambda.Origination_payload.t
     [@@deriving yojson]
+
     let lambda_of_yojson ~code ~storage =
       let%ok code = Lambda.Raw_repr.Script.of_yojson code in
       let%ok storage = Lambda.Raw_repr.Value.of_yojson storage in
@@ -142,6 +157,7 @@ module External_vm = struct
 
     let dummy_of_yojson ~storage = Dummy storage
   end
+
   module Compiler = struct
     let compile payload ~gas =
       match payload with
@@ -152,6 +168,7 @@ module External_vm = struct
         let%ok contract = Lambda.Compiler.compile contract ~gas in
         Ok (Contract.Lambda contract)
   end
+
   module Invocation_payload = struct
     type t =
       | Lambda of Lambda.Invocation_payload.t
@@ -166,6 +183,7 @@ module External_vm = struct
       let%ok arg = Dummy.Invocation_payload.of_yojson arg in
       Ok (Dummy arg)
   end
+
   module Interpreter = struct
     let invoke code ~source ~arg ~gas =
       match (code, arg) with
@@ -180,4 +198,5 @@ module External_vm = struct
       | _, _ -> Error "Invocation failure"
   end
 end
+
 include External_vm

--- a/src/core_deku/contract_vm.mli
+++ b/src/core_deku/contract_vm.mli
@@ -1,13 +1,16 @@
 module Contract : sig
   type t [@@deriving yojson, eq]
 end
+
 module Origination_payload : sig
   type t [@@deriving yojson]
 
   val lambda_of_yojson :
     code:Yojson.Safe.t -> storage:Yojson.Safe.t -> (t, string) result
+
   val dummy_of_yojson : storage:int -> t
 end
+
 module Compiler : sig
   val compile : Origination_payload.t -> gas:int -> (Contract.t, string) result
 end
@@ -16,6 +19,7 @@ module Invocation_payload : sig
   type t [@@deriving yojson]
 
   val lambda_of_yojson : arg:Yojson.Safe.t -> (t, string) result
+
   val dummy_of_yojson : arg:Yojson.Safe.t -> (t, string) result
 end
 

--- a/src/core_deku/ledger.ml
+++ b/src/core_deku/ledger.ml
@@ -1,19 +1,26 @@
 open Helpers
 open Crypto
+
 module Address_and_ticket_map = struct
   type key = {
     address : Key_hash.t;
     ticket : Ticket_id.t;
   }
   [@@deriving ord, yojson]
+
   module Map = Map.Make_with_yojson (struct
     type t = key [@@deriving ord, yojson]
   end)
+
   type t = Amount.t Map.t [@@deriving yojson]
+
   let empty = Map.empty
+
   let find_opt address ticket = Map.find_opt { address; ticket }
+
   let add address ticket = Map.add { address; ticket }
 end
+
 module Withdrawal_handle = struct
   type t = {
     hash : BLAKE2B.t;
@@ -23,34 +30,42 @@ module Withdrawal_handle = struct
     ticket : Ticket_id.t;
   }
   [@@deriving yojson]
+
   let hash ~id ~owner ~amount ~ticket =
     let Ticket_id.{ ticketer; data } = ticket in
     Tezos.Deku.Consensus.hash_withdraw_handle ~id:(Z.of_int id) ~owner
       ~amount:(Z.of_int (Amount.to_int amount))
       ~ticketer ~data
 end
+
 module Withdrawal_handle_tree = Incremental_patricia.Make (struct
   type t = Withdrawal_handle.t [@@deriving yojson]
+
   let hash t = t.Withdrawal_handle.hash
 end)
+
 type t = {
   ledger : Address_and_ticket_map.t;
   withdrawal_handles : Withdrawal_handle_tree.t;
 }
 [@@deriving yojson]
+
 let empty =
   {
     ledger = Address_and_ticket_map.empty;
     withdrawal_handles = Withdrawal_handle_tree.empty;
   }
+
 let balance address ticket t =
   Address_and_ticket_map.find_opt address ticket t.ledger
   |> Option.value ~default:Amount.zero
+
 let assert_available ~sender ~(amount : Amount.t) =
   if sender >= amount then
     Ok ()
   else
     Error `Not_enough_funds
+
 let transfer ~sender ~destination amount ticket t =
   let open Amount in
   let sender_balance = balance sender ticket t in
@@ -65,6 +80,7 @@ let transfer ~sender ~destination amount ticket t =
              (destination_balance + amount);
       withdrawal_handles = t.withdrawal_handles;
     }
+
 let deposit destination amount ticket t =
   let open Amount in
   let destination_balance = balance destination ticket t in
@@ -95,13 +111,16 @@ let withdraw ~sender ~destination amount ticket t =
       withdrawal_handles;
     } in
   Ok (t, handle)
+
 let withdrawal_handles_find_proof handle t =
   match
     Withdrawal_handle_tree.find handle.Withdrawal_handle.id t.withdrawal_handles
   with
   | None -> assert false
   | Some (proof, _) -> proof
+
 let withdrawal_handles_find_proof_by_id key t =
   Withdrawal_handle_tree.find key t.withdrawal_handles
+
 let withdrawal_handles_root_hash t =
   Withdrawal_handle_tree.hash t.withdrawal_handles

--- a/src/core_deku/ledger.mli
+++ b/src/core_deku/ledger.mli
@@ -1,4 +1,5 @@
 open Crypto
+
 module Withdrawal_handle : sig
   type t = private {
     hash : BLAKE2B.t;
@@ -9,9 +10,13 @@ module Withdrawal_handle : sig
   }
   [@@deriving yojson]
 end
+
 type t [@@deriving yojson]
+
 val empty : t
+
 val balance : Key_hash.t -> Ticket_id.t -> t -> Amount.t
+
 val transfer :
   sender:Key_hash.t ->
   destination:Key_hash.t ->
@@ -19,7 +24,9 @@ val transfer :
   Ticket_id.t ->
   t ->
   (t, [> `Not_enough_funds]) result
+
 val deposit : Key_hash.t -> Amount.t -> Ticket_id.t -> t -> t
+
 val withdraw :
   sender:Key_hash.t ->
   destination:Tezos.Address.t ->
@@ -27,8 +34,11 @@ val withdraw :
   Ticket_id.t ->
   t ->
   (t * Withdrawal_handle.t, [> `Not_enough_funds]) result
+
 val withdrawal_handles_find_proof :
   Withdrawal_handle.t -> t -> (BLAKE2B.t * BLAKE2B.t) list
+
 val withdrawal_handles_find_proof_by_id :
   int -> t -> ((BLAKE2B.t * BLAKE2B.t) list * Withdrawal_handle.t) option
+
 val withdrawal_handles_root_hash : t -> BLAKE2B.t

--- a/src/core_deku/state.ml
+++ b/src/core_deku/state.ml
@@ -1,16 +1,23 @@
 open Helpers
 open Crypto
+
 type t = {
   ledger : Ledger.t;
   contract_storage : Contract_storage.t;
 }
 [@@deriving yojson]
+
 type receipt = Receipt_tezos_withdraw of Ledger.Withdrawal_handle.t
 [@@deriving yojson]
+
 let empty = { ledger = Ledger.empty; contract_storage = Contract_storage.empty }
+
 let ledger t = t.ledger
+
 let contract_storage t = t.contract_storage
+
 let hash t = to_yojson t |> Yojson.Safe.to_string |> BLAKE2B.hash
+
 let apply_tezos_operation t tezos_operation =
   let open Tezos_operation in
   let apply_internal_operation t internal_operation =
@@ -89,6 +96,7 @@ let apply_user_operation t user_operation =
       Contract_storage.update_contract_storage contract_storage
         ~address:to_invoke ~updated_contract:contract in
     Ok ({ ledger; contract_storage }, None)
+
 let apply_user_operation t user_operation =
   match apply_user_operation t user_operation with
   | Ok (t, receipt) -> (t, receipt)

--- a/src/core_deku/state.mli
+++ b/src/core_deku/state.mli
@@ -1,10 +1,18 @@
 open Crypto
+
 type t [@@deriving yojson]
+
 type receipt = Receipt_tezos_withdraw of Ledger.Withdrawal_handle.t
 [@@deriving yojson]
+
 val empty : t
+
 val ledger : t -> Ledger.t
+
 val contract_storage : t -> Contract_storage.t
+
 val hash : t -> BLAKE2B.t
+
 val apply_user_operation : t -> User_operation.t -> t * receipt option
+
 val apply_tezos_operation : t -> Tezos_operation.t -> t

--- a/src/core_deku/tezos_operation.ml
+++ b/src/core_deku/tezos_operation.ml
@@ -1,5 +1,6 @@
 open Helpers
 open Crypto
+
 type internal_operation =
   | Tezos_deposit of {
       destination : Tezos.Address.t;
@@ -7,29 +8,37 @@ type internal_operation =
       ticket : Tezos.Ticket_id.t;
     }
 [@@deriving yojson]
+
 type payload = {
   tezos_operation_hash : Tezos.Operation_hash.t;
   internal_operations : internal_operation list;
 }
 [@@deriving yojson]
+
 type t = {
   hash : BLAKE2B.t;
   payload : payload;
 }
 [@@deriving yojson]
+
 let equal a b = BLAKE2B.equal a.hash b.hash
+
 let compare a b = BLAKE2B.compare a.hash b.hash
+
 let hash, verify =
   let to_yojson payload = payload_to_yojson payload |> Yojson.Safe.to_string in
   let hash payload = to_yojson payload |> BLAKE2B.hash in
   let verify hash payload = to_yojson payload |> BLAKE2B.verify ~hash in
   (hash, verify)
+
 let make payload =
   let hash = hash payload in
   { hash; payload }
+
 let verify hash payload =
   let%assert () = ("Invalid_tezos_operation_hash", verify hash payload) in
   Ok { hash; payload }
+
 let of_yojson json =
   let%ok t = of_yojson json in
   let%ok t = verify t.hash t.payload in

--- a/src/core_deku/tezos_operation.mli
+++ b/src/core_deku/tezos_operation.mli
@@ -6,13 +6,16 @@ type internal_operation =
       amount : Amount.t;
       ticket : Tezos.Ticket_id.t;
     }
+
 type payload = {
   tezos_operation_hash : Tezos.Operation_hash.t;
   internal_operations : internal_operation list;
 }
+
 type t = private {
   hash : BLAKE2B.t;
   payload : payload;
 }
 [@@deriving eq, ord, yojson]
+
 val make : payload -> t

--- a/src/core_deku/user_operation.ml
+++ b/src/core_deku/user_operation.ml
@@ -18,14 +18,18 @@ type initial_operation =
       ticket : Ticket_id.t;
     }
 [@@deriving yojson]
+
 type t = {
   hash : BLAKE2B.t;
   source : Key_hash.t;
   initial_operation : initial_operation;
 }
 [@@deriving yojson]
+
 let equal a b = BLAKE2B.equal a.hash b.hash
+
 let compare a b = BLAKE2B.compare a.hash b.hash
+
 let hash, verify =
   let to_yojson sender initial_operation =
     [%to_yojson: Key_hash.t * initial_operation] (sender, initial_operation)
@@ -39,10 +43,12 @@ let hash, verify =
 let make ~source initial_operation =
   let hash = hash source initial_operation in
   { hash; source; initial_operation }
+
 let verify hash source initial_operation =
   let%assert () =
     ("Invalid_user_operation_hash", verify hash source initial_operation) in
   Ok { hash; source; initial_operation }
+
 let of_yojson json =
   let%ok t = of_yojson json in
   let%ok t = verify t.hash t.source t.initial_operation in

--- a/src/core_deku/user_operation.mli
+++ b/src/core_deku/user_operation.mli
@@ -16,10 +16,12 @@ type initial_operation =
       amount : Amount.t;
       ticket : Ticket_id.t;
     }
+
 type t = private {
   hash : BLAKE2B.t;
   source : Key_hash.t;
   initial_operation : initial_operation;
 }
 [@@deriving eq, ord, yojson]
+
 val make : source:Key_hash.t -> initial_operation -> t

--- a/src/crypto/BLAKE2B.ml
+++ b/src/crypto/BLAKE2B.ml
@@ -1,46 +1,73 @@
 open Helpers
+
 module Make (P : sig
   val size : int
 end) : sig
   type t [@@deriving yojson]
+
   val to_string : t -> string
+
   val of_string : string -> t option
+
   val of_raw_string : string -> t option
+
   val to_raw_string : t -> string
+
   val equal : t -> t -> bool
+
   val compare : t -> t -> int
+
   val hash : string -> t
+
   val verify : hash:t -> string -> bool
+
   val both : t -> t -> t
+
   val size : int
+
   module Map : Map.S with type key = t
+
   val encoding : t Data_encoding.t
 end = struct
   include P
+
   include Digestif.Make_BLAKE2B (struct
     let digest_size = P.size
   end)
+
   let of_raw_string = of_raw_string_opt
+
   let to_string = to_hex
+
   let of_string string =
     let%some () =
       match String.length string = size * 2 with
       | true -> Some ()
       | false -> None in
     of_hex_opt string
+
   let to_yojson str = `String (to_hex str)
+
   let of_yojson json =
     let%ok hex = [%of_yojson: string] json in
     of_string hex |> Option.to_result ~none:"Invalid hex"
+
   let equal = equal
+
   let compare = unsafe_compare
+
   let hash data = digest_string data
+
   let verify ~hash:expected_hash data = expected_hash = hash data
+
   let both a b = hash (to_raw_string a ^ to_raw_string b)
+
   module Map = Map.Make (struct
     type nonrec t = t
+
     let compare = compare
   end)
+
   let encoding =
     let open Data_encoding in
     conv
@@ -48,9 +75,11 @@ end = struct
       (fun string -> string |> of_raw_string |> Option.get)
       (Fixed.string size)
 end
+
 module BLAKE2B_20 = Make (struct
   let size = 20
 end)
+
 include Make (struct
   let size = 32
 end)

--- a/src/crypto/base58.mli
+++ b/src/crypto/base58.mli
@@ -28,27 +28,37 @@
 
 module Prefix : sig
   val contract_hash : string
+
   val deku_contract_hash : string
 
   val block_hash : string
+
   val operation_hash : string
+
   val protocol_hash : string
 
   val ed25519_public_key_hash : string
+
   val secp256k1_public_key_hash : string
+
   val p256_public_key_hash : string
 
   val ed25519_public_key : string
+
   val secp256k1_public_key : string
+
   val p256_public_key : string
 
   val ed25519_seed : string
 
   val secp256k1_secret_key : string
+
   val p256_secret_key : string
 
   val ed25519_signature : string
+
   val secp256k1_signature : string
+
   val p256_signature : string
 
   val chain_id : string

--- a/src/crypto/crypto.mli
+++ b/src/crypto/crypto.mli
@@ -1,13 +1,25 @@
 module Base58 : module type of Base58
+
 module Encoding_helpers : module type of Encoding_helpers
+
 module Random : module type of Random
+
 module Secp256k1 : module type of Secp256k1
+
 module Ed25519 : module type of Ed25519
+
 module P256 : module type of P256
+
 module Incremental_patricia : module type of Incremental_patricia
+
 module BLAKE2B : module type of BLAKE2B
+
 module BLAKE2B_20 : module type of BLAKE2B_20
+
 module Secret : module type of Secret
+
 module Key : module type of Key
+
 module Key_hash : module type of Key_hash
+
 module Signature : module type of Signature

--- a/src/crypto/crypto_intf.mli
+++ b/src/crypto/crypto_intf.mli
@@ -1,42 +1,73 @@
 module type S = sig
   module Secret : sig
     type t
+
     val encoding : t Data_encoding.t
+
     val equal : t -> t -> bool
+
     val compare : t -> t -> int
+
     val to_string : t -> string
+
     val of_string : string -> t option
   end
+
   module Key : sig
     type t
+
     val of_secret : Secret.t -> t
+
     val encoding : t Data_encoding.t
+
     val equal : t -> t -> bool
+
     val compare : t -> t -> int
+
     val to_string : t -> string
+
     val of_string : string -> t option
   end
+
   module Key_hash : sig
     type t
+
     val of_key : Key.t -> t
+
     val encoding : t Data_encoding.t
+
     val equal : t -> t -> bool
+
     val compare : t -> t -> int
+
     val to_string : t -> string
+
     val of_string : string -> t option
   end
+
   module Signature : sig
     type t
+
     val size : int
+
     val zero : t
+
     val encoding : t Data_encoding.t
+
     val equal : t -> t -> bool
+
     val compare : t -> t -> int
+
     val to_raw : t -> string
+
     val to_string : t -> string
+
     val of_string : string -> t option
   end
+
   val sign : Secret.t -> BLAKE2B.t -> Signature.t
+
   val verify : Key.t -> Signature.t -> BLAKE2B.t -> bool
+
   val generate : unit -> Secret.t * Key.t
 end

--- a/src/crypto/ed25519.ml
+++ b/src/crypto/ed25519.ml
@@ -1,76 +1,118 @@
 open Mirage_crypto_ec
 open Ed25519
 open Helpers
+
 module Secret = struct
   type t = priv
+
   let equal a b =
     let a, b = (priv_to_cstruct a, priv_to_cstruct b) in
     Cstruct.equal a b
+
   let compare a b = Cstruct.compare (priv_to_cstruct a) (priv_to_cstruct b)
+
   include Encoding_helpers.Make_b58 (struct
     type nonrec t = t
+
     let name = "Ed25519.Secret_key"
+
     let title = "An Ed25519 secret key"
+
     let size = 32
+
     let prefix = Base58.Prefix.ed25519_seed
+
     let to_raw t = Cstruct.to_string (Ed25519.priv_to_cstruct t)
+
     let of_raw string =
       Ed25519.priv_of_cstruct (Cstruct.of_string string) |> Result.to_option
   end)
 end
+
 module Key = struct
   type t = pub
+
   let of_secret = Ed25519.pub_of_priv
+
   let equal a b =
     let a, b = (pub_to_cstruct a, pub_to_cstruct b) in
     Cstruct.equal a b
+
   let compare a b = Cstruct.compare (pub_to_cstruct a) (pub_to_cstruct b)
+
   include Encoding_helpers.Make_b58 (struct
     type nonrec t = t
+
     let name = "Ed25519.Public_key"
+
     let title = "Ed25519 public key"
+
     let size = 32
+
     let prefix = Base58.Prefix.ed25519_public_key
+
     let to_raw t = Cstruct.to_string (Ed25519.pub_to_cstruct t)
+
     let of_raw string =
       Ed25519.pub_of_cstruct (Cstruct.of_string string) |> Result.to_option
   end)
 end
+
 module Key_hash = struct
   type t = BLAKE2B_20.t [@@deriving ord, eq]
+
   let of_key t = BLAKE2B_20.hash (Ed25519.pub_to_cstruct t |> Cstruct.to_string)
+
   include Encoding_helpers.Make_b58 (struct
     type nonrec t = t
+
     let name = "Ed25519.Public_key_hash"
+
     let title = "An Ed25519 public key hash"
+
     let size = BLAKE2B_20.size
+
     let prefix = Base58.Prefix.ed25519_public_key_hash
+
     let to_raw = BLAKE2B_20.to_raw_string
+
     let of_raw = BLAKE2B_20.of_raw_string
   end)
 end
+
 module Signature = struct
   type t = string [@@deriving ord, eq]
+
   include Encoding_helpers.Make_b58 (struct
     type nonrec t = t
+
     let name = "Ed25519"
+
     let title = "An Ed25519 signature"
+
     let size = 64
+
     let prefix = Base58.Prefix.ed25519_signature
+
     let to_raw = Fun.id
+
     let of_raw string =
       match String.length string = size with
       | true -> Some string
       | false -> None
   end)
+
   let zero = String.make size '\x00'
 end
+
 let sign secret hash =
   Cstruct.of_string (BLAKE2B.to_raw_string hash)
   |> Ed25519.sign ~key:secret
   |> Cstruct.to_string
+
 let verify public signature hash =
   verify ~key:public
     ~msg:(Cstruct.of_string (BLAKE2B.to_raw_string hash))
     (Cstruct.of_string signature)
+
 let generate () = Ed25519.generate ()

--- a/src/crypto/encoding_helpers.ml
+++ b/src/crypto/encoding_helpers.ml
@@ -1,5 +1,6 @@
 let unexpected_data ~name =
   Format.kasprintf invalid_arg "Unexpected data (%s)" name
+
 let make_encoding ~name ~title ~to_string ~of_string ~raw_encoding =
   let open Data_encoding in
   let of_string_exn string =
@@ -10,6 +11,7 @@ let make_encoding ~name ~title ~to_string ~of_string ~raw_encoding =
   splitted
     ~binary:(obj1 (req name raw_encoding))
     ~json:(def name ~title:(title ^ " (Base58Check-encoded)") json_encoding)
+
 let rec parse_string_variant l string =
   match l with
   | of_string :: l -> (
@@ -17,26 +19,38 @@ let rec parse_string_variant l string =
     | Some v -> Some v
     | None -> parse_string_variant l string)
   | [] -> None
+
 module Make_b58 (H : sig
   type t
+
   val name : string
+
   val title : string
+
   val prefix : string
+
   val size : int
+
   val to_raw : t -> string
+
   val of_raw : string -> t option
 end) =
 struct
   open H
+
   let size = size
+
   let to_raw = H.to_raw
 
   let to_string t = Base58.simple_encode ~prefix ~to_raw t
+
   let of_string string = Base58.simple_decode ~prefix ~of_raw string
+
   let of_raw_exn string =
     match of_raw string with
     | Some t -> t
     | None -> unexpected_data ~name
+
   let encoding =
     make_encoding ~name ~title ~to_string ~of_string
       ~raw_encoding:

--- a/src/crypto/encoding_helpers.mli
+++ b/src/crypto/encoding_helpers.mli
@@ -14,11 +14,17 @@ val parse_string_variant : (string -> 'a option) list -> string -> 'a option
 module Make_b58 : functor
   (H : sig
      type t
+
      val name : string
+
      val title : string
+
      val prefix : string
+
      val size : int
+
      val to_raw : t -> string
+
      val of_raw : string -> t option
    end)
   -> sig

--- a/src/crypto/incremental_patricia.ml
+++ b/src/crypto/incremental_patricia.ml
@@ -1,11 +1,15 @@
 open Helpers
+
 module Make (V : sig
   type t [@@deriving yojson]
+
   val hash : t -> BLAKE2B.t
 end) =
 struct
   type value = V.t [@@deriving yojson]
+
   type key = int [@@deriving yojson]
+
   type tree =
     | Empty
     | Leaf  of {
@@ -18,19 +22,24 @@ struct
         right : tree;
       }
   [@@deriving yojson]
+
   type t = {
     tree : tree;
     top_bit : key;
     last_key : key;
   }
   [@@deriving yojson]
+
   let is_set bit number = (1 lsl bit) land number <> 0
+
   let empty_hash = BLAKE2B.hash ""
+
   let hash_of_t = function
     | Empty -> empty_hash
     | Leaf { hash; _ }
     | Node { hash; _ } ->
       hash
+
   let rec find bit proofs key t =
     match t with
     | Empty -> None
@@ -41,20 +50,24 @@ struct
         | true -> right
         | false -> left in
       find (bit - 1) ((hash_of_t left, hash_of_t right) :: proofs) key t
+
   let find key t =
     if key >= 0 && key <= t.last_key then
       find (t.top_bit - 1) [] key t.tree
     else
       None
+
   let node left right =
     let hash = BLAKE2B.both (hash_of_t left) (hash_of_t right) in
     Node { left; hash; right }
+
   let rec empty n =
     if n = 0 then
       Empty
     else
       let tree = empty (n - 1) in
       node tree tree
+
   let add f t =
     let rec add bit key value t =
       match (bit, t) with
@@ -76,6 +89,8 @@ struct
         t.tree in
     let tree = add (top_bit - 1) key value tree in
     ({ tree; top_bit; last_key = key }, value)
+
   let empty = { top_bit = 0; tree = Empty; last_key = -1 }
+
   let hash t = hash_of_t t.tree
 end

--- a/src/crypto/incremental_patricia.mli
+++ b/src/crypto/incremental_patricia.mli
@@ -1,14 +1,21 @@
 module Make : functor
   (V : sig
      type t [@@deriving yojson]
+
      val hash : t -> BLAKE2B.t
    end)
   -> sig
   type value = V.t
+
   type key = int
+
   type t [@@deriving yojson]
+
   val empty : t
+
   val hash : t -> BLAKE2B.t
+
   val add : (key -> value) -> t -> t * value
+
   val find : key -> t -> ((BLAKE2B.t * BLAKE2B.t) list * value) option
 end

--- a/src/crypto/key.ml
+++ b/src/crypto/key.ml
@@ -1,17 +1,21 @@
 open Helpers
+
 type t =
   | Ed25519   of Ed25519.Key.t
   | Secp256k1 of Secp256k1.Key.t
   | P256      of P256.Key.t
 [@@deriving ord, eq]
+
 let of_secret = function
   | Secret.Ed25519 secret -> Ed25519 (Ed25519.Key.of_secret secret)
   | Secret.Secp256k1 secret -> Secp256k1 (Secp256k1.Key.of_secret secret)
   | Secret.P256 secret -> P256 (P256.Key.of_secret secret)
+
 let to_string = function
   | Ed25519 key -> Ed25519.Key.to_string key
   | Secp256k1 key -> Secp256k1.Key.to_string key
   | P256 key -> P256.Key.to_string key
+
 let of_string =
   let ed25519 string =
     let%some key = Ed25519.Key.of_string string in
@@ -23,6 +27,7 @@ let of_string =
     let%some key = P256.Key.of_string string in
     Some (P256 key) in
   Encoding_helpers.parse_string_variant [ed25519; secp256k1; p256]
+
 let encoding =
   let open Data_encoding in
   let name = "Signature.Public_key" in
@@ -49,5 +54,6 @@ let encoding =
          ] in
   Encoding_helpers.make_encoding ~name ~title ~to_string ~of_string
     ~raw_encoding
+
 let to_yojson, of_yojson =
   Yojson_ext.with_yojson_string "key" to_string of_string

--- a/src/crypto/key.mli
+++ b/src/crypto/key.mli
@@ -3,9 +3,15 @@ type t =
   | Secp256k1 of Secp256k1.Key.t
   | P256      of P256.Key.t
 [@@deriving ord, eq]
+
 val of_secret : Secret.t -> t
+
 val encoding : t Data_encoding.t
+
 val to_string : t -> string
+
 val of_string : string -> t option
+
 val to_yojson : t -> Yojson.Safe.t
+
 val of_yojson : Yojson.Safe.t -> (t, string) result

--- a/src/crypto/key_hash.ml
+++ b/src/crypto/key_hash.ml
@@ -1,22 +1,28 @@
 open Helpers
+
 type t =
   | Ed25519   of Ed25519.Key_hash.t
   | Secp256k1 of Secp256k1.Key_hash.t
   | P256      of P256.Key_hash.t
 [@@deriving ord, eq]
+
 let of_key = function
   | Key.Ed25519 key -> Ed25519 (Ed25519.Key_hash.of_key key)
   | Key.Secp256k1 key -> Secp256k1 (Secp256k1.Key_hash.of_key key)
   | Key.P256 key -> P256 (P256.Key_hash.of_key key)
+
 let matches_key key t = equal (of_key key) t
+
 let make_ed25519 () =
   let secret, key = Ed25519.generate () in
   let key_hash = Ed25519.Key_hash.of_key key in
   (Secret.Ed25519 secret, Key.Ed25519 key, Ed25519 key_hash)
+
 let to_string = function
   | Ed25519 key_hash -> Ed25519.Key_hash.to_string key_hash
   | Secp256k1 key_hash -> Secp256k1.Key_hash.to_string key_hash
   | P256 key_hash -> P256.Key_hash.to_string key_hash
+
 let of_string =
   let ed25519 string =
     let%some key_hash = Ed25519.Key_hash.of_string string in
@@ -28,6 +34,7 @@ let of_string =
     let%some key = P256.Key_hash.of_string string in
     Some (P256 key) in
   Encoding_helpers.parse_string_variant [ed25519; secp256k1; p256]
+
 let encoding =
   let open Data_encoding in
   let name = "Signature.Public_key_hash" in
@@ -54,5 +61,6 @@ let encoding =
          ] in
   Encoding_helpers.make_encoding ~name ~title ~to_string ~of_string
     ~raw_encoding
+
 let to_yojson, of_yojson =
   Yojson_ext.with_yojson_string "key_hash" to_string of_string

--- a/src/crypto/key_hash.mli
+++ b/src/crypto/key_hash.mli
@@ -3,11 +3,19 @@ type t =
   | Secp256k1 of Secp256k1.Key_hash.t
   | P256      of P256.Key_hash.t
 [@@deriving ord, eq]
+
 val of_key : Key.t -> t
+
 val matches_key : Key.t -> t -> bool
+
 val make_ed25519 : unit -> Secret.t * Key.t * t
+
 val encoding : t Data_encoding.t
+
 val to_string : t -> string
+
 val of_string : string -> t option
+
 val to_yojson : t -> Yojson.Safe.t
+
 val of_yojson : Yojson.Safe.t -> (t, string) result

--- a/src/crypto/p256.ml
+++ b/src/crypto/p256.ml
@@ -2,78 +2,120 @@ open Mirage_crypto_ec
 open P256
 open Helpers
 open P256.Dsa
+
 module Secret = struct
   type t = Dsa.priv
+
   let equal a b =
     let a, b = (priv_to_cstruct a, priv_to_cstruct b) in
     Cstruct.equal a b
+
   let compare a b = Cstruct.compare (priv_to_cstruct a) (priv_to_cstruct b)
+
   include Encoding_helpers.Make_b58 (struct
     type nonrec t = t
+
     let name = "P256.Secret_key"
+
     let title = "A P256 secret key"
+
     let size = 32
+
     let prefix = Base58.Prefix.p256_secret_key
+
     let to_raw t = Cstruct.to_string (priv_to_cstruct t)
+
     let of_raw string =
       priv_of_cstruct (Cstruct.of_string string) |> Result.to_option
   end)
 end
+
 module Key = struct
   type t = pub
+
   let of_secret = pub_of_priv
+
   let equal a b =
     let a, b = (pub_to_cstruct a, pub_to_cstruct b) in
     Cstruct.equal a b
+
   let compare a b = Cstruct.compare (pub_to_cstruct a) (pub_to_cstruct b)
+
   include Encoding_helpers.Make_b58 (struct
     type nonrec t = t
+
     let name = "P256.Public_key"
+
     let title = "P256 public key"
+
     let size = 33
+
     let prefix = Base58.Prefix.p256_public_key
+
     let to_raw t = Cstruct.to_string (pub_to_cstruct ~compress:true t)
+
     let of_raw string =
       pub_of_cstruct (Cstruct.of_string string) |> Result.to_option
   end)
 end
+
 module Key_hash = struct
   type t = BLAKE2B_20.t [@@deriving ord, eq]
+
   let of_key t =
     BLAKE2B_20.hash (pub_to_cstruct ~compress:true t |> Cstruct.to_string)
+
   include Encoding_helpers.Make_b58 (struct
     type nonrec t = t
+
     let name = "P256.Public_key_hash"
+
     let title = "An P256 public key hash"
+
     let size = BLAKE2B_20.size
+
     let prefix = Base58.Prefix.p256_public_key_hash
+
     let to_raw = BLAKE2B_20.to_raw_string
+
     let of_raw = BLAKE2B_20.of_raw_string
   end)
 end
+
 module Signature = struct
   type t = string [@@deriving ord, eq]
+
   include Encoding_helpers.Make_b58 (struct
     type nonrec t = t
+
     let name = "P256"
+
     let title = "An P256 signature"
+
     let size = 64
+
     let prefix = Base58.Prefix.p256_signature
+
     let to_raw = Fun.id
+
     let of_raw string =
       match String.length string = size with
       | true -> Some string
       | false -> None
   end)
+
   let zero = String.make size '\x00'
 end
+
 let sign secret hash =
   let r, s =
     Cstruct.of_string (BLAKE2B.to_raw_string hash) |> sign ~key:secret in
   [r; s] |> Cstruct.concat |> Cstruct.to_string
+
 let verify public signature hash =
   let r, s = (String.sub signature 0 32, String.sub signature 32 32) in
   verify ~key:public
     (Cstruct.of_string r, Cstruct.of_string s)
     (Cstruct.of_string (BLAKE2B.to_raw_string hash))
+
 let generate () = Dsa.generate ()

--- a/src/crypto/random.ml
+++ b/src/crypto/random.ml
@@ -1,5 +1,9 @@
 Stdlib.Random.self_init ()
+
 let () = Mirage_crypto_rng_unix.initialize ()
+
 open Mirage_crypto_rng
+
 let generate bits = generate bits
+
 let int32 = Stdlib.Random.int32

--- a/src/crypto/secp256k1.ml
+++ b/src/crypto/secp256k1.ml
@@ -1,5 +1,6 @@
 module Libsecp256k1 = Libsecp256k1.External
 open Libsecp256k1
+
 let context =
   let c = Context.create () in
   let rand_value =
@@ -9,20 +10,32 @@ let context =
     c
   else
     failwith "Secp256k1 context randomization failed. Aborting."
+
 module Key = struct
   type t = Libsecp256k1.Key.public Libsecp256k1.Key.t
+
   let equal = Libsecp256k1.Key.equal
+
   let compare a b =
     Bigstring.compare (Libsecp256k1.Key.buffer a) (Libsecp256k1.Key.buffer b)
+
   let of_secret sk = Libsecp256k1.Key.neuterize_exn context sk
+
   let to_raw t = Libsecp256k1.Key.to_bytes context t |> Bigstring.to_string
+
   include Encoding_helpers.Make_b58 (struct
     type nonrec t = t
+
     let name = "Secp256k1.Public_key"
+
     let title = "A Secp256k1 public key"
+
     let size = Libsecp256k1.Key.compressed_pk_bytes
+
     let prefix = Base58.Prefix.secp256k1_public_key
+
     let to_raw = to_raw
+
     let of_raw string =
       string
       |> Bigstring.of_string
@@ -30,62 +43,96 @@ module Key = struct
       |> Result.to_option
   end)
 end
+
 module Key_hash = struct
   type t = BLAKE2B_20.t [@@deriving ord, eq]
+
   let of_key t = BLAKE2B_20.hash (Key.to_raw t)
+
   include Encoding_helpers.Make_b58 (struct
     type nonrec t = t
+
     let name = "Secp256k1.Public_key_hash"
+
     let title = "A Secp256k1 public key hash"
+
     let size = BLAKE2B_20.size
+
     let prefix = Base58.Prefix.secp256k1_public_key_hash
+
     let to_raw = BLAKE2B_20.to_raw_string
+
     let of_raw = BLAKE2B_20.of_raw_string
   end)
 end
+
 module Secret = struct
   type t = Libsecp256k1.Key.secret Libsecp256k1.Key.t
+
   let equal = Libsecp256k1.Key.equal
+
   let compare a b =
     Bigstring.compare (Libsecp256k1.Key.buffer a) (Libsecp256k1.Key.buffer b)
+
   include Encoding_helpers.Make_b58 (struct
     type nonrec t = t
+
     let name = "Secp256k1.Secret_key"
+
     let title = "A Secp256k1 secret key"
+
     let size = Libsecp256k1.Key.secret_bytes
+
     let prefix = Base58.Prefix.secp256k1_secret_key
+
     let to_raw t = Libsecp256k1.Key.to_bytes context t |> Bigstring.to_string
+
     let of_raw string =
       Libsecp256k1.Key.read_sk context (string |> Bigstring.of_string)
       |> Result.to_option
   end)
 end
+
 module Signature = struct
   type t = Sign.plain Sign.t
+
   let equal = Sign.equal
+
   let compare a b = Bigstring.compare (Sign.buffer a) (Sign.buffer b)
+
   let of_raw string =
     string |> Bigstring.of_string |> Sign.read context |> Result.to_option
+
   include Encoding_helpers.Make_b58 (struct
     type nonrec t = t
+
     let name = "Secp256k1"
+
     let title = "A Secp256k1 signature"
+
     let size = Sign.plain_bytes
+
     let prefix = Base58.Prefix.secp256k1_signature
+
     let to_raw t = Sign.to_bytes ~der:false context t |> Bigstring.to_string
+
     let of_raw = of_raw
   end)
+
   let zero = of_raw (String.make size '\x00') |> Option.get
 end
+
 let generate () =
   let seed = Random.generate 32 |> Cstruct.to_bytes in
   let sk = Libsecp256k1.Key.read_sk_exn context (Bigstring.of_bytes seed) in
   let pk = Libsecp256k1.Key.neuterize_exn context sk in
   (sk, pk)
+
 let sign secret hash =
   BLAKE2B.to_raw_string hash
   |> Bigstring.of_string
   |> Sign.sign_exn context ~sk:secret
+
 let verify public signature hash =
   Sign.verify_exn context ~pk:public
     ~msg:(Bigstring.of_string (BLAKE2B.to_raw_string hash))

--- a/src/crypto/secret.ml
+++ b/src/crypto/secret.ml
@@ -1,13 +1,16 @@
 open Helpers
+
 type t =
   | Ed25519   of Ed25519.Secret.t
   | Secp256k1 of Secp256k1.Secret.t
   | P256      of P256.Secret.t
 [@@deriving ord, eq]
+
 let to_string = function
   | Ed25519 secret -> Ed25519.Secret.to_string secret
   | Secp256k1 secret -> Secp256k1.Secret.to_string secret
   | P256 secret -> P256.Secret.to_string secret
+
 let of_string =
   let ed25519 string =
     let%some secret = Ed25519.Secret.of_string string in
@@ -19,6 +22,7 @@ let of_string =
     let%some secret = P256.Secret.of_string string in
     Some (P256 secret) in
   Encoding_helpers.parse_string_variant [ed25519; secp256k1; p256]
+
 let encoding =
   let open Data_encoding in
   let name = "Signature.Secret_key" in
@@ -45,5 +49,6 @@ let encoding =
          ] in
   Encoding_helpers.make_encoding ~name ~title ~to_string ~of_string
     ~raw_encoding
+
 let to_yojson, of_yojson =
   Yojson_ext.with_yojson_string "secret" to_string of_string

--- a/src/crypto/secret.mli
+++ b/src/crypto/secret.mli
@@ -3,8 +3,13 @@ type t =
   | Secp256k1 of Secp256k1.Secret.t
   | P256      of P256.Secret.t
 [@@deriving ord, eq]
+
 val encoding : t Data_encoding.t
+
 val to_string : t -> string
+
 val of_string : string -> t option
+
 val to_yojson : t -> Yojson.Safe.t
+
 val of_yojson : Yojson.Safe.t -> (t, string) result

--- a/src/crypto/signature.ml
+++ b/src/crypto/signature.ml
@@ -1,4 +1,5 @@
 open Helpers
+
 type t =
   | Ed25519   of Ed25519.Signature.t
   | Secp256k1 of Secp256k1.Signature.t
@@ -6,6 +7,7 @@ type t =
 [@@deriving ord, eq]
 
 let zero = Ed25519 Ed25519.Signature.zero
+
 let size =
   assert (
     Ed25519.Signature.size = Secp256k1.Signature.size
@@ -17,6 +19,7 @@ let sign secret hash =
   | Secret.Ed25519 secret -> Ed25519 (Ed25519.sign secret hash)
   | Secret.Secp256k1 secret -> Secp256k1 (Secp256k1.sign secret hash)
   | Secret.P256 secret -> P256 (P256.sign secret hash)
+
 let verify key signature hash =
   match (key, signature) with
   | Key.Ed25519 key, Ed25519 signature -> Ed25519.verify key signature hash
@@ -36,6 +39,7 @@ let to_string = function
   | Ed25519 signature -> Ed25519.Signature.to_string signature
   | Secp256k1 signature -> Secp256k1.Signature.to_string signature
   | P256 signature -> P256.Signature.to_string signature
+
 let of_string =
   let ed25519 string =
     let%some signature = Ed25519.Signature.of_string string in
@@ -47,5 +51,6 @@ let of_string =
     let%some signature = P256.Signature.of_string string in
     Some (P256 signature) in
   Encoding_helpers.parse_string_variant [ed25519; secp256k1; p256]
+
 let to_yojson, of_yojson =
   Yojson_ext.with_yojson_string "signature" to_string of_string

--- a/src/crypto/signature.mli
+++ b/src/crypto/signature.mli
@@ -9,8 +9,11 @@ val size : int
 val zero : t
 
 val sign : Secret.t -> BLAKE2B.t -> t
+
 val verify : Key.t -> t -> BLAKE2B.t -> bool
 
 val to_raw : t -> string
+
 val to_string : t -> string
+
 val of_string : string -> t option

--- a/src/helpers/helpers.ml
+++ b/src/helpers/helpers.ml
@@ -6,18 +6,25 @@ module Option = Option_ext
 module Yojson_ext = Yojson_ext
 module Map = Map_ext
 module Set = Set_ext
+
 module String_map = Map.Make_with_yojson (struct
   type t = string [@@deriving yojson]
+
   let compare = String.compare
 end)
+
 module String_set = Set.Make_with_yojson (struct
   type t = string [@@deriving yojson]
+
   let compare = String.compare
 end)
+
 module Int64_map = Map.Make_with_yojson (struct
   type t = int64 [@@deriving yojson]
+
   let compare = Int64.compare
 end)
+
 module Parallel = Parallel
 include Lwt_ext.Let_syntax
 include Result.Let_syntax

--- a/src/helpers/list_ext.ml
+++ b/src/helpers/list_ext.ml
@@ -1,4 +1,5 @@
 include List
+
 let find_index f l =
   let rec go idx = function
     | [] -> None
@@ -8,9 +9,11 @@ let find_index f l =
       else
         go (idx + 1) xs in
   go 0 l
+
 let in_order_uniq (type a) compare l =
   let module S = Set.Make (struct
     type t = a
+
     let compare = compare
   end) in
   let rec go acc seen_set lst =
@@ -22,12 +25,14 @@ let in_order_uniq (type a) compare l =
       else
         go (x :: acc) (S.add x seen_set) xs in
   go [] S.empty l
+
 let rec fold_left_ok f state = function
   | [] -> Ok state
   | head :: tl ->
   match f state head with
   | Ok state -> fold_left_ok f state tl
   | Error error -> Error error
+
 let somes l = List.filter_map (fun x -> x) l
 
 (* NOT TCO *)
@@ -38,4 +43,5 @@ let rec kmap_ok k f l =
   match f el with
   | Ok el -> kmap_ok (fun tl -> k (el :: tl)) f tl
   | Error error -> Error error
+
 let map_ok f l = kmap_ok (fun x -> x) f l

--- a/src/helpers/list_ext.mli
+++ b/src/helpers/list_ext.mli
@@ -1,7 +1,12 @@
 include module type of List
+
 val find_index : ('a -> bool) -> 'a t -> int option
+
 val in_order_uniq : ('a -> 'a -> int) -> 'a t -> 'a t
+
 val fold_left_ok :
   ('a -> 'b -> ('a, 'c) result) -> 'a -> 'b list -> ('a, 'c) result
+
 val somes : 'a option list -> 'a list
+
 val map_ok : ('a -> ('b, 'c) result) -> 'a t -> ('b t, 'c) result

--- a/src/helpers/lwt_ext.ml
+++ b/src/helpers/lwt_ext.ml
@@ -1,4 +1,5 @@
 module Let_syntax = struct
   let await = Lwt.return
+
   [%%let "let.await", Lwt.bind]
 end

--- a/src/helpers/lwt_ext.mli
+++ b/src/helpers/lwt_ext.mli
@@ -1,4 +1,5 @@
 module Let_syntax : sig
   val await : 'a -> 'a Lwt.t
+
   [%%let ("let.await" : 'a Lwt.t -> ('a -> 'b Lwt.t) -> 'b Lwt.t)]
 end

--- a/src/helpers/map_ext.ml
+++ b/src/helpers/map_ext.ml
@@ -1,12 +1,17 @@
 include Map
+
 module Make_with_yojson (K : sig
   include Map.OrderedType
+
   val to_yojson : t -> Yojson.Safe.t
+
   val of_yojson : Yojson.Safe.t -> (t, string) result
 end) =
 struct
   include Map.Make (K)
+
   let to_yojson f t = t |> bindings |> [%to_yojson: (K.t * 'a) list] f
+
   let of_yojson f json =
     json
     |> [%of_yojson: (K.t * 'a) list] f

--- a/src/helpers/map_ext.mli
+++ b/src/helpers/map_ext.mli
@@ -1,14 +1,20 @@
 include module type of Map
+
 module Make_with_yojson : functor
   (K : sig
      type t
+
      val compare : t -> t -> int
+
      val to_yojson : t -> Yojson.Safe.t
+
      val of_yojson : Yojson.Safe.t -> (t, string) result
    end)
   -> sig
   include module type of Map.Make (K)
+
   val to_yojson : ('a -> Yojson.Safe.t) -> 'a t -> Yojson.Safe.t
+
   val of_yojson :
     (Yojson.Safe.t -> ('a, string) result) ->
     Yojson.Safe.t ->

--- a/src/helpers/option_ext.ml
+++ b/src/helpers/option_ext.ml
@@ -1,12 +1,16 @@
 include Option
+
 module Let_syntax = struct
   let some = Option.some
+
   [%%let
   "let.none",
     fun v f ->
       match v with
       | None -> f ()
       | Some v -> Some v]
+
   [%%let "let.some", Option.bind]
+
   [%%let "let.default", fun v f -> Option.value (f ()) ~default:v]
 end

--- a/src/helpers/option_ext.mli
+++ b/src/helpers/option_ext.mli
@@ -1,7 +1,11 @@
 include module type of Option
+
 module Let_syntax : sig
   val some : 'a -> 'a option
+
   [%%let ("let.none" : 'a option -> (unit -> 'a option) -> 'a option)]
+
   [%%let ("let.some" : 'a option -> ('a -> 'b option) -> 'b option)]
+
   [%%let ("let.default" : 'a -> (unit -> 'a option) -> 'a)]
 end

--- a/src/helpers/parallel.ml
+++ b/src/helpers/parallel.ml
@@ -4,11 +4,13 @@ open Lwt_ext.Let_syntax
 (* TODO: proper number of domains *)
 (* THIS IS GLOBAL STATE OUTSIDE OF src/node/server.ml. CAUTION *)
 let pool = lazy (Lwt_domain.setup_pool 8)
+
 let pool () = Lazy.force_val pool
 
 let encode to_yojson data =
   let json = to_yojson data in
   Yojson.Safe.to_string json
+
 let encode to_yojson data =
   Lwt_domain.detach (pool ()) (fun () -> encode to_yojson data) ()
 
@@ -18,6 +20,7 @@ let decode of_yojson data =
     Ok (of_yojson json)
   with
   | exn -> Error exn
+
 let decode of_yojson data =
   let%await data =
     Lwt_domain.detach (pool ()) (fun () -> decode of_yojson data) () in

--- a/src/helpers/parallel.mli
+++ b/src/helpers/parallel.mli
@@ -1,2 +1,3 @@
 val encode : ('a -> Yojson.Safe.t) -> 'a -> string Lwt.t
+
 val decode : (Yojson.Safe.t -> 'a) -> string -> 'a Lwt.t

--- a/src/helpers/result_ext.ml
+++ b/src/helpers/result_ext.ml
@@ -1,7 +1,10 @@
 include Result
+
 module Let_syntax = struct
   let ok = Result.ok
+
   [%%let "let.ok", Result.bind]
+
   [%%let
   "let.assert",
     fun (message, bool) f ->

--- a/src/helpers/result_ext.mli
+++ b/src/helpers/result_ext.mli
@@ -1,10 +1,13 @@
 include module type of struct
   include Result
 end
+
 module Let_syntax : sig
   val ok : 'a -> ('a, 'b) result
+
   [%%let
   ("let.ok" : ('a, 'b) result -> ('a -> ('c, 'b) result) -> ('c, 'b) result)]
+
   [%%let
   ("let.assert" : 'a * bool -> (unit -> ('b, 'a) result) -> ('b, 'a) result)]
 end

--- a/src/helpers/set_ext.ml
+++ b/src/helpers/set_ext.ml
@@ -1,11 +1,16 @@
 include Set
+
 module Make_with_yojson (V : sig
   include Set.OrderedType
+
   val to_yojson : t -> Yojson.Safe.t
+
   val of_yojson : Yojson.Safe.t -> (t, string) result
 end) =
 struct
   include Set.Make (V)
+
   let to_yojson t = t |> to_seq |> List.of_seq |> [%to_yojson: V.t list]
+
   let of_yojson json = json |> [%of_yojson: V.t list] |> Result.map of_list
 end

--- a/src/helpers/set_ext.mli
+++ b/src/helpers/set_ext.mli
@@ -1,13 +1,19 @@
 include module type of Set
+
 module Make_with_yojson : functor
   (K : sig
      type t
+
      val compare : t -> t -> int
+
      val to_yojson : t -> Yojson.Safe.t
+
      val of_yojson : Yojson.Safe.t -> (t, string) result
    end)
   -> sig
   include module type of Set.Make (K)
+
   val to_yojson : t -> Yojson.Safe.t
+
   val of_yojson : Yojson.Safe.t -> (t, string) result
 end

--- a/src/helpers/uri_ext.ml
+++ b/src/helpers/uri_ext.ml
@@ -1,3 +1,5 @@
 include Uri
+
 let to_yojson t = `String (to_string t)
+
 let of_yojson json = json |> [%of_yojson: string] |> Result.map of_string

--- a/src/helpers/uri_ext.mli
+++ b/src/helpers/uri_ext.mli
@@ -1,5 +1,7 @@
 include module type of struct
   include Uri
 end
+
 val to_yojson : t -> Yojson.Safe.t
+
 val of_yojson : Yojson.Safe.t -> (t, string) result

--- a/src/helpers/yojson_ext.ml
+++ b/src/helpers/yojson_ext.ml
@@ -1,4 +1,5 @@
 open Result_ext.Let_syntax
+
 let with_yojson_string name to_string of_string =
   let to_yojson t = `String (to_string t) in
   let of_yojson json =
@@ -38,6 +39,7 @@ let rec to_data_encoding_json (json : Yojson.Basic.t) : Data_encoding.Json.t =
   | `Null -> `Null
   | `String string -> `String string
   | `Int int -> `Float (float_of_int int)
+
 let to_data_encoding_json json =
   json |> Yojson.Safe.to_basic |> to_data_encoding_json
 

--- a/src/helpers/zarith_ext.ml
+++ b/src/helpers/zarith_ext.ml
@@ -1,5 +1,7 @@
 include Z
+
 let to_yojson z = `String (Z.to_string z)
+
 let of_yojson = function
   | `String string -> (
     try Ok (Z.of_string string) with

--- a/src/helpers/zarith_ext.mli
+++ b/src/helpers/zarith_ext.mli
@@ -1,5 +1,7 @@
 include module type of struct
   include Z
 end
+
 val to_yojson : t -> Yojson.Safe.t
+
 val of_yojson : Yojson.Safe.t -> (t, string) result

--- a/src/lambda_vm/checks.mli
+++ b/src/lambda_vm/checks.mli
@@ -1,4 +1,5 @@
 exception Out_of_stack
 
 val max_stack_depth : int
+
 val check_stack : stack:int -> unit

--- a/src/lambda_vm/compiler.ml
+++ b/src/lambda_vm/compiler.ml
@@ -1,13 +1,13 @@
 open Ast
 open Ir
 open Checks
-
 module String_map = Map.Make (String)
 
 type error = (* user program bugs *)
   | Undefined_variable [@@deriving show]
 
 exception Error of error
+
 let raise error = raise (Error error)
 
 let compile_prim prim =
@@ -30,6 +30,7 @@ let compile_prim prim =
 
 module Vars = Map_with_cardinality.Make (struct
   include String
+
   type t = string [@@deriving yojson]
 end)
 
@@ -107,6 +108,7 @@ let compile gas script =
 let compile gas script =
   try Ok (compile gas script) with
   | Error error -> Error error
+
 let burn_gas gas = Gas.burn_constant gas
 
 let rec compile_value ~stack gas value =

--- a/src/lambda_vm/compiler.mli
+++ b/src/lambda_vm/compiler.mli
@@ -3,4 +3,5 @@ type error = (* user program bugs *)
 
 (* TODO: compile or translate? *)
 val compile : Gas.t -> Ast.script -> (Ir.code, error) result
+
 val compile_value : Gas.t -> Ast.value -> (Ir.value, error) result

--- a/src/lambda_vm/context.ml
+++ b/src/lambda_vm/context.ml
@@ -33,5 +33,7 @@ let make : sender:string -> source:string -> Gas.t -> t =
   { sender; source; gas }
 
 let[@inline always] sender t = t.sender
+
 let[@inline always] source t = t.source
+
 let[@inline always] gas t = t.gas

--- a/src/lambda_vm/context.mli
+++ b/src/lambda_vm/context.mli
@@ -4,6 +4,9 @@ type t
 
 (* TODO: decide on whether we accept crypto primitives or michelson*)
 val make : sender:string -> source:string -> Gas.t -> t
+
 val source : t -> unit -> Ir.value
+
 val sender : t -> unit -> Ir.value
+
 val gas : t -> Gas.t

--- a/src/lambda_vm/gas.ml
+++ b/src/lambda_vm/gas.ml
@@ -4,6 +4,7 @@ exception Out_of_gas
 type t = int ref
 
 let constant_burn = 100
+
 let log2_burn ~cardinality =
   let log2_cardinality =
     let open Float in
@@ -23,4 +24,5 @@ let burn t amount =
     raise Out_of_gas
 
 let burn_constant t = burn t constant_burn
+
 let burn_log2 t ~cardinality = burn t (log2_burn ~cardinality)

--- a/src/lambda_vm/gas.mli
+++ b/src/lambda_vm/gas.mli
@@ -7,4 +7,5 @@ val make : initial_gas:int -> t
 val is_empty : t -> bool
 
 val burn_constant : t -> unit
+
 val burn_log2 : t -> cardinality:int -> unit

--- a/src/lambda_vm/ident.ml
+++ b/src/lambda_vm/ident.ml
@@ -2,6 +2,7 @@
 type t = int [@@deriving yojson, eq, ord]
 
 let initial = 0
+
 let next t = t + 1
 
 let to_string = string_of_int

--- a/src/lambda_vm/ident.mli
+++ b/src/lambda_vm/ident.mli
@@ -1,6 +1,7 @@
 type t [@@deriving yojson, eq, ord]
 
 val initial : t
+
 val next : t -> t
 
 val to_string : t -> string

--- a/src/lambda_vm/interpreter.ml
+++ b/src/lambda_vm/interpreter.ml
@@ -13,13 +13,16 @@ type error =
 [@@deriving show]
 
 exception Error of error
+
 let raise error = raise (Error error)
 
 module Pattern : sig
   type 'a t
+
   type nil = unit
 
   val script_result : (value * (nil * nil)) t
+
   val parse : value -> 'a t -> 'a
 end = struct
   type nil = unit
@@ -30,10 +33,13 @@ end = struct
     | Nil : nil t
 
   let any = Any
+
   let pair first second = Pair (first, second)
+
   let nil = Nil
 
   let operations = nil
+
   let script_result = pair any (pair operations nil)
 
   let rec parse : type a. value -> a t -> a =

--- a/src/lambda_vm/lambda_vm.ml
+++ b/src/lambda_vm/lambda_vm.ml
@@ -20,6 +20,7 @@ module Ir = struct
 
   module Value_syntax = struct
     let int t = Ir.V_int64 t
+
     let pair fst snd = Ir.V_pair { first = fst; second = snd }
   end
 end

--- a/src/lambda_vm/lambda_vm.mli
+++ b/src/lambda_vm/lambda_vm.mli
@@ -2,11 +2,14 @@ module Gas : sig
   type t
 
   val make : initial_gas:int -> t
+
   val is_empty : t -> bool
 
   val burn_constant : t -> unit
+
   val burn_log2 : t -> cardinality:int -> unit
 end
+
 module Ast : sig
   type ident = string
 
@@ -74,13 +77,17 @@ end
 
 module Ir : sig
   type code [@@deriving yojson, eq]
+
   type value [@@deriving yojson, eq]
+
   module Value_syntax : sig
     val int : int64 -> value
+
     val pair : value -> value -> value
   end
 
   val pp_value : Format.formatter -> value -> unit
+
   val pp_code : Format.formatter -> code -> unit
 end
 
@@ -95,6 +102,7 @@ module Compiler : sig
   [@@deriving show]
 
   val compile : Gas.t -> Ast.script -> (Ir.code, error) result
+
   val compile_value : Gas.t -> Ast.value -> (Ir.value, error) result
 end
 

--- a/src/lambda_vm/map_with_cardinality.ml
+++ b/src/lambda_vm/map_with_cardinality.ml
@@ -18,6 +18,7 @@ end
 (* Map.S + O(1) cardinal*)
 module Make (K : sig
   type t [@@deriving yojson]
+
   val compare : t -> t -> int
 end) : S with type key = K.t = struct
   type key = K.t
@@ -26,11 +27,13 @@ end) : S with type key = K.t = struct
     include Map.Make (K)
 
     let to_yojson f t = t |> bindings |> [%to_yojson: (K.t * 'a) list] f
+
     let of_yojson f json =
       json
       |> [%of_yojson: (K.t * 'a) list] f
       |> Result.map (fun l -> l |> List.to_seq |> of_seq)
   end
+
   type 'a t = {
     cardinality : int;
     values : 'a Map.t;
@@ -51,5 +54,6 @@ end) : S with type key = K.t = struct
     { cardinality; values }
 
   let cardinal t = t.cardinality
+
   let find key t = Map.find_opt key t.values
 end

--- a/src/lambda_vm/map_with_cardinality.mli
+++ b/src/lambda_vm/map_with_cardinality.mli
@@ -17,5 +17,6 @@ end
 
 module Make (K : sig
   type t [@@deriving yojson]
+
   val compare : t -> t -> int
 end) : S with type key = K.t

--- a/src/metrics/config.ml
+++ b/src/metrics/config.ml
@@ -1,2 +1,3 @@
 let namespace = "Deku"
+
 let subsystem = "node"

--- a/src/network/network.ml
+++ b/src/network/network.ml
@@ -2,19 +2,31 @@ include Network_client
 include Network_packet
 
 let request_block_by_hash = request (module Block_by_hash_spec)
+
 let request_block_level = request (module Block_level)
+
 let request_protocol_snapshot = request (module Protocol_snapshot)
+
 let request_nonce = request (module Request_nonce)
+
 let request_register_uri = request (module Register_uri)
+
 let request_withdraw_proof = request (module Withdraw_proof)
+
 let broadcast_signature = broadcast_to_list (module Signature_spec)
+
 let broadcast_block_and_signature =
   broadcast_to_list (module Block_and_signature_spec)
+
 let broadcast_user_operation_gossip =
   broadcast_to_list (module User_operation_gossip)
+
 let broadcast_user_operation_gossip_to_list =
   broadcast_to_list (module User_operation_gossip)
+
 let request_user_operation_gossip = request (module User_operation_gossip)
+
 let request_consensus_operation = request (module Consensus_operation_gossip)
+
 let request_trusted_validator_membership =
   request (module Trusted_validators_membership_change)

--- a/src/network/network_client.ml
+++ b/src/network/network_client.ml
@@ -2,9 +2,12 @@ open Helpers
 
 module type Request_endpoint = sig
   type request [@@deriving yojson]
+
   type response [@@deriving yojson]
+
   val path : string
 end
+
 exception Error_status
 
 let raw_request path raw_data uri =

--- a/src/network/network_packet.ml
+++ b/src/network/network_packet.ml
@@ -9,28 +9,40 @@ module Signature_spec = struct
     signature : Signature.t;
   }
   [@@deriving yojson]
+
   type response = unit [@@deriving yojson]
+
   let path = "/append-signature"
 end
+
 module Block_and_signature_spec = struct
   type request = {
     block : Block.t;
     signature : Signature.t;
   }
   [@@deriving yojson]
+
   type response = unit [@@deriving yojson]
+
   let path = "/append-block-and-signature"
 end
+
 module Block_by_hash_spec = struct
   type request = { hash : BLAKE2B.t } [@@deriving yojson]
+
   type response = Block.t option [@@deriving yojson]
+
   let path = "/block-by-hash"
 end
+
 module Block_level = struct
   type request = unit [@@deriving yojson]
+
   type response = { level : int64 } [@@deriving yojson]
+
   let path = "/block-level"
 end
+
 module Protocol_snapshot = struct
   type request = unit [@@deriving yojson]
 
@@ -39,6 +51,7 @@ module Protocol_snapshot = struct
     data : string;
   }
   [@@deriving yojson]
+
   type response = {
     snapshot : snapshot;
     additional_blocks : Block.t list;
@@ -46,39 +59,54 @@ module Protocol_snapshot = struct
     last_block_signatures : Signature.t list;
   }
   [@@deriving yojson]
+
   let path = "/protocol-snapshot"
 end
+
 module Request_nonce = struct
   type request = { uri : Uri.t } [@@deriving yojson]
+
   type response = { nonce : BLAKE2B.t } [@@deriving yojson]
+
   let path = "/request-nonce"
 end
+
 module Register_uri = struct
   type request = {
     uri : Uri.t;
     signature : Signature.t;
   }
   [@@deriving yojson]
+
   type response = unit [@@deriving yojson]
+
   let path = "/register-uri"
 end
+
 module User_operation_gossip = struct
   type request = { user_operation : Protocol.Operation.Core_user.t }
   [@@deriving yojson]
+
   type response = unit [@@deriving yojson]
+
   let path = "/user-operation-gossip"
 end
+
 module Consensus_operation_gossip = struct
   type request = {
     consensus_operation : Protocol.Operation.Consensus.t;
     signature : Crypto.Signature.t;
   }
   [@@deriving yojson]
+
   type response = unit [@@deriving yojson]
+
   let path = "/consensus-operation-gossip"
 end
+
 module Withdraw_proof = struct
   type request = { operation_hash : BLAKE2B.t } [@@deriving yojson]
+
   type response =
     | Ok                          of {
         withdrawal_handles_hash : BLAKE2B.t;
@@ -88,32 +116,41 @@ module Withdraw_proof = struct
     | Unknown_operation
     | Operation_is_not_a_withdraw
   [@@deriving yojson]
+
   let path = "/withdraw-proof"
 end
+
 module Ticket_balance = struct
   type request = {
     address : Key_hash.t;
     ticket : Ticket_id.t;
   }
   [@@deriving yojson]
+
   type response = { amount : Amount.t } [@@deriving yojson]
+
   let path = "/ticket-balance"
 end
+
 module Trusted_validators_membership_change = struct
   type action =
     | Add
     | Remove
   [@@deriving yojson]
+
   type payload = {
     action : action;
     address : Key_hash.t;
   }
   [@@deriving yojson]
+
   type request = {
     signature : Signature.t;
     payload : payload;
   }
   [@@deriving yojson]
+
   type response = unit [@@deriving yojson]
+
   let path = "/trusted-validators-membership"
 end

--- a/src/node/block_pool.ml
+++ b/src/node/block_pool.ml
@@ -1,14 +1,17 @@
 open Helpers
 open Crypto
 open Protocol
+
 module Hash_map = Map.Make_with_yojson (struct
   type t = BLAKE2B.t [@@deriving ord, yojson]
 end)
+
 type block_and_signatures = {
   signatures : Signatures.t;
   block : Block.t option;
   hash : BLAKE2B.t;
 }
+
 type t = {
   self_key : Wallet.t;
   available : block_and_signatures Hash_map.t;
@@ -16,6 +19,7 @@ type t = {
   signed : block_and_signatures Hash_map.t;
   signed_by_previous : (Block.t * Signatures.t) Hash_map.t;
 }
+
 let update_block_and_signatures block_and_signatures t =
   let add_to_map __x = Hash_map.add __x block_and_signatures in
   let hash = block_and_signatures.hash in
@@ -39,14 +43,17 @@ let update_block_and_signatures block_and_signatures t =
           t.signed_by_previous
       | _ -> t.signed_by_previous);
   }
+
 let find_block_and_signature_or_return_empty ~hash t =
   match Hash_map.find_opt hash t.available with
   | Some block_and_signatures -> block_and_signatures
   | None ->
     let signatures = Signatures.make ~self_key:t.self_key in
     { signatures; block = None; hash }
+
 let is_signed block_and_signatures =
   Signatures.is_signed block_and_signatures.signatures
+
 let rec set_signed block_and_signatures t =
   let signatures = Signatures.set_signed block_and_signatures.signatures in
   let block_and_signatures = { block_and_signatures with signatures } in
@@ -63,6 +70,7 @@ and ensure_previous_is_signed block_and_signatures t =
     else
       set_signed previous_block_and_signatures t
   | None -> t
+
 let append_block block t =
   let block_and_signatures =
     find_block_and_signature_or_return_empty ~hash:block.Block.hash t in
@@ -81,6 +89,7 @@ let append_block block t =
     ensure_previous_is_signed block_and_signatures t
   else
     t
+
 let append_signature ~signatures_required ~hash signature t =
   let block_and_signatures = find_block_and_signature_or_return_empty ~hash t in
   let block_and_signatures =
@@ -95,22 +104,29 @@ let append_signature ~signatures_required ~hash signature t =
     ensure_previous_is_signed block_and_signatures t
   else
     t
+
 let is_signed ~hash t = Hash_map.mem hash t.signed
+
 let find_block ~hash t =
   let%some { block; _ } = Hash_map.find_opt hash t.available in
   block
+
 let find_signatures ~hash t =
   let%some { signatures; _ } = Hash_map.find_opt hash t.available in
   Some signatures
+
 let find_next_block_to_apply ~hash t =
   let%some block, _ = Hash_map.find_opt hash t.signed_by_previous in
   Some block
+
 let rec find_all_signed_blocks_above blocks (block, signatures) t =
   match Hash_map.find_opt block.Block.hash t.signed_by_previous with
   | Some (another_block, signatures) ->
     find_all_signed_blocks_above (block :: blocks) (another_block, signatures) t
   | None -> (blocks, (block, signatures))
+
 let find_all_signed_blocks_above = find_all_signed_blocks_above []
+
 let make ~self_key =
   let empty =
     {

--- a/src/node/block_pool.mli
+++ b/src/node/block_pool.mli
@@ -1,18 +1,28 @@
 open Crypto
 open Protocol
+
 type block_and_signatures = private {
   signatures : Signatures.t;
   block : Block.t option;
   hash : BLAKE2B.t;
 }
+
 type t
+
 val make : self_key:Wallet.t -> t
+
 val append_block : Block.t -> t -> t
+
 val append_signature :
   signatures_required:int -> hash:BLAKE2B.t -> Signature.t -> t -> t
+
 val is_signed : hash:BLAKE2B.t -> t -> bool
+
 val find_block : hash:BLAKE2B.t -> t -> Block.t option
+
 val find_signatures : hash:BLAKE2B.t -> t -> Signatures.t option
+
 val find_next_block_to_apply : hash:BLAKE2B.t -> t -> Block.t option
+
 val find_all_signed_blocks_above :
   Block.t * Signatures.t -> t -> Block.t list * (Block.t * Signatures.t)

--- a/src/node/server.ml
+++ b/src/node/server.ml
@@ -1,21 +1,29 @@
 open Helpers
 open Flows
+
 type t = {
   mutable state : State.t;
   mutable timeout : unit Lwt.t;
 }
+
 let global_server = ref None
+
 let start ~initial =
   match !global_server with
   | Some _ -> failwith "start should be called just once"
   | None -> global_server := Some { state = initial; timeout = Lwt.return_unit }
+
 let get () =
   match !global_server with
   | Some state -> state
   | None -> failwith "get called before start"
+
 let get_port () = (get ()).state.identity.uri |> Uri.port
+
 let get_state () = (get ()).state
+
 let set_state state = (get ()).state <- state
+
 let rec reset_timeout server =
   Lwt.cancel server.timeout;
   server.timeout <-
@@ -42,6 +50,9 @@ let get_task_pool () =
     pool
 
 let () = Flows.reset_timeout := fun () -> reset_timeout (get ())
+
 let () = Flows.get_state := get_state
+
 let () = Flows.set_state := set_state
+
 let () = Flows.get_task_pool := get_task_pool

--- a/src/node/server.mli
+++ b/src/node/server.mli
@@ -1,4 +1,7 @@
 val start : initial:State.t -> unit
+
 val get_state : unit -> State.t
+
 val set_state : State.t -> unit
+
 val get_port : unit -> int option

--- a/src/node/signatures.ml
+++ b/src/node/signatures.ml
@@ -1,8 +1,10 @@
 open Helpers
 open Protocol
+
 module Signature_set = Set.Make_with_yojson (struct
   type t = Signature.t [@@deriving yojson, ord]
 end)
+
 type t = {
   self_key : Wallet.t;
   self_signed : bool;
@@ -10,6 +12,7 @@ type t = {
   length : int;
   signatures : Signature_set.t;
 }
+
 let make ~self_key =
   {
     self_key;
@@ -18,6 +21,7 @@ let make ~self_key =
     length = 0;
     signatures = Signature_set.empty;
   }
+
 let add ~signatures_required signature t =
   if not (Signature_set.mem signature t.signatures) then
     let self_signed =
@@ -29,8 +33,13 @@ let add ~signatures_required signature t =
     { self_key = t.self_key; signed; self_signed; length; signatures }
   else
     t
+
 let mem signature t = Signature_set.mem signature t.signatures
+
 let is_signed t = t.signed
+
 let is_self_signed t = t.self_signed
+
 let set_signed t = { t with signed = true }
+
 let to_list t = Signature_set.to_seq t.signatures |> List.of_seq

--- a/src/node/signatures.mli
+++ b/src/node/signatures.mli
@@ -1,9 +1,17 @@
 open Protocol
+
 type t
+
 val make : self_key:Wallet.t -> t
+
 val is_self_signed : t -> bool
+
 val is_signed : t -> bool
+
 val set_signed : t -> t
+
 val add : signatures_required:int -> Signature.t -> t -> t
+
 val mem : Signature.t -> t -> bool
+
 val to_list : t -> Signature.t List.t

--- a/src/node/snapshots.ml
+++ b/src/node/snapshots.ml
@@ -1,12 +1,15 @@
 open Crypto
 open Protocol
 open Helpers
+
 type snapshot = Network.Protocol_snapshot.snapshot = {
   hash : BLAKE2B.t;
   data : string;
 }
 [@@deriving yojson]
+
 type snapshot_ref = snapshot option Atomic.t
+
 type t = {
   current_snapshot : snapshot_ref;
   next_snapshots : (int64 * snapshot_ref) list;
@@ -14,6 +17,7 @@ type t = {
   last_block_signatures : Signatures.t;
   additional_blocks : Block.t list;
 }
+
 let make ~initial_snapshot ~initial_block ~initial_signatures =
   {
     current_snapshot =
@@ -28,6 +32,7 @@ let make ~initial_snapshot ~initial_block ~initial_signatures =
     last_block_signatures = initial_signatures;
     additional_blocks = [];
   }
+
 let append_block ~pool (block, signatures) t =
   if t.last_block.block_height > block.Block.block_height then
     t
@@ -41,6 +46,7 @@ let append_block ~pool (block, signatures) t =
       last_block_signatures = signatures;
       additional_blocks = blocks @ [t.last_block] @ t.additional_blocks;
     }
+
 let add_snapshot_ref ~block_height t =
   let atom = Atomic.make None in
   ( atom,
@@ -51,10 +57,12 @@ let add_snapshot_ref ~block_height t =
       last_block_signatures = t.last_block_signatures;
       additional_blocks = t.additional_blocks;
     } )
+
 let set_snapshot_ref ref_ snapshot =
   Logs.app (fun m ->
       m "New protocol snapshot hash: %s" (snapshot.hash |> BLAKE2B.to_string));
   Atomic.set ref_ (Some snapshot)
+
 let start_new_epoch t =
   let rec truncate_additional_blocks block_height blocks =
     match blocks with

--- a/src/node/snapshots.mli
+++ b/src/node/snapshots.mli
@@ -1,11 +1,14 @@
 open Crypto
 open Protocol
+
 type snapshot = Network.Protocol_snapshot.snapshot = {
   hash : BLAKE2B.t;
   data : string;
 }
 [@@deriving yojson]
+
 type snapshot_ref
+
 type t = private {
   current_snapshot : snapshot_ref;
   next_snapshots : (int64 * snapshot_ref) list;
@@ -13,6 +16,7 @@ type t = private {
   last_block_signatures : Signatures.t;
   additional_blocks : Block.t list;
 }
+
 val make :
   initial_snapshot:snapshot ->
   initial_block:Block.t ->
@@ -23,8 +27,12 @@ val append_block : pool:Block_pool.t -> Block.t * Signatures.t -> t -> t
   [@@ocaml.doc " this should be called when a block is received "]
 
 val add_snapshot_ref : block_height:int64 -> t -> snapshot_ref * t
+
 val set_snapshot_ref : snapshot_ref -> snapshot -> unit
+
 val start_new_epoch : t -> t
+
 val get_most_recent_snapshot :
   t -> (snapshot, [> `Node_not_yet_initialized]) result
+
 val get_next_snapshot : t -> snapshot option

--- a/src/node/state.ml
+++ b/src/node/state.ml
@@ -1,6 +1,7 @@
 open Helpers
 open Crypto
 open Protocol
+
 type identity = {
   secret : Secret.t;
   key : Key.t;
@@ -8,13 +9,14 @@ type identity = {
   uri : Uri.t;
 }
 [@@deriving yojson]
+
 module Address_map = Map.Make (Key_hash)
 module Uri_map = Map.Make (Uri)
-
 module Operation_map = Map.Make (Operation)
 
 (* TODO: proper type for timestamps *)
 type timestamp = float
+
 type t = {
   identity : identity;
   trusted_validator_membership_change :
@@ -31,6 +33,7 @@ type t = {
   persist_trusted_membership_change :
     Trusted_validators_membership_change.t list -> unit Lwt.t;
 }
+
 let make ~identity ~trusted_validator_membership_change
     ~persist_trusted_membership_change ~interop_context ~data_folder
     ~initial_validators_uri =
@@ -61,6 +64,7 @@ let make ~identity ~trusted_validator_membership_change
     recent_operation_receipts = BLAKE2B.Map.empty;
     persist_trusted_membership_change;
   }
+
 let apply_block state block =
   let prev_protocol = state.protocol in
   let%ok protocol, receipts = Protocol.apply_block state.protocol block in
@@ -75,10 +79,12 @@ let apply_block state block =
       (fun results (hash, receipt) -> BLAKE2B.Map.add hash receipt results)
       state.recent_operation_receipts receipts in
   Ok { state with protocol; recent_operation_receipts; snapshots }
+
 let signatures_required state =
   let number_of_validators = Validators.length state.protocol.validators in
   let open Float in
   to_int (ceil (of_int number_of_validators *. (2.0 /. 3.0)))
+
 let load_snapshot ~snapshot ~additional_blocks ~last_block
     ~last_block_signatures t =
   let all_blocks =

--- a/src/node/state.mli
+++ b/src/node/state.mli
@@ -1,5 +1,6 @@
 open Crypto
 open Protocol
+
 type identity = {
   secret : Secret.t;
   key : Key.t;
@@ -7,8 +8,11 @@ type identity = {
   uri : Uri.t;
 }
 [@@deriving yojson]
+
 module Address_map : Map.S with type key = Key_hash.t
+
 module Uri_map : Map.S with type key = Uri.t
+
 module Operation_map : Map.S with type key = Protocol.Operation.t
 
 type t = {
@@ -27,6 +31,7 @@ type t = {
   persist_trusted_membership_change :
     Trusted_validators_membership_change.t list -> unit Lwt.t;
 }
+
 val make :
   identity:identity ->
   trusted_validator_membership_change:Trusted_validators_membership_change.Set.t ->
@@ -36,10 +41,12 @@ val make :
   data_folder:string ->
   initial_validators_uri:Uri.t Address_map.t ->
   t
+
 val apply_block :
   t ->
   Block.t ->
   (t, [> `Invalid_block_when_applying | `Invalid_state_root_hash]) result
+
 val load_snapshot :
   snapshot:Snapshots.snapshot ->
   additional_blocks:Block.t list ->

--- a/src/node/trusted_validators_membership_change.ml
+++ b/src/node/trusted_validators_membership_change.ml
@@ -2,12 +2,15 @@ type action =
   | Add
   | Remove
 [@@deriving yojson, ord]
+
 type t = {
   action : action;
   address : Crypto.Key_hash.t;
 }
 [@@deriving yojson, ord]
+
 module Set = Set.Make (struct
   type nonrec t = t
+
   let compare = compare
 end)

--- a/src/protocol/block.ml
+++ b/src/protocol/block.ml
@@ -1,6 +1,7 @@
 open Helpers
 open Crypto
 open Core_deku
+
 type t = {
   hash : BLAKE2B.t;
   payload_hash : BLAKE2B.t;
@@ -13,6 +14,7 @@ type t = {
   operations : Protocol_operation.t list;
 }
 [@@deriving yojson]
+
 let hash, verify =
   let apply f ~state_root_hash ~withdrawal_handles_hash ~validators_hash
       ~previous_hash ~author ~block_height ~operations =
@@ -45,6 +47,7 @@ let hash, verify =
   let verify ~hash:expected_hash =
     apply (fun (hash, _payload_hash) -> hash = expected_hash) in
   (hash, verify)
+
 let make ~state_root_hash ~withdrawal_handles_hash ~validators_hash
     ~previous_hash ~author ~block_height ~operations =
   let hash, payload_hash =
@@ -61,6 +64,7 @@ let make ~state_root_hash ~withdrawal_handles_hash ~validators_hash
     block_height;
     operations;
   }
+
 let of_yojson json =
   let%ok block = of_yojson json in
   let%ok () =
@@ -74,7 +78,9 @@ let of_yojson json =
     | true -> Ok ()
     | false -> Error "Invalid hash" in
   Ok block
+
 let compare a b = BLAKE2B.compare a.hash b.hash
+
 let genesis =
   make ~previous_hash:(BLAKE2B.hash "tuturu")
     ~state_root_hash:(BLAKE2B.hash "mayuushi")
@@ -82,6 +88,7 @@ let genesis =
     ~validators_hash:(Validators.hash Validators.empty)
     ~block_height:0L ~operations:[]
     ~author:(Key_hash.of_key Wallet.genesis_wallet)
+
 let produce ~state ~next_state_root_hash =
   let next_state_root_hash =
     Option.value ~default:state.Protocol_state.state_root_hash
@@ -93,9 +100,13 @@ let produce ~state ~next_state_root_hash =
       |> Ledger.withdrawal_handles_root_hash)
     ~validators_hash:(Validators.hash state.validators)
     ~block_height:(Int64.add state.block_height 1L)
+
 open Protocol_signature.Make (struct
   type nonrec t = t
+
   let hash t = t.hash
 end)
+
 let sign ~key t = (sign ~key t).signature
+
 let verify ~signature t = verify ~signature t

--- a/src/protocol/block.mli
+++ b/src/protocol/block.mli
@@ -1,4 +1,5 @@
 open Crypto
+
 type t = private {
   hash : BLAKE2B.t;
   payload_hash : BLAKE2B.t;
@@ -11,9 +12,13 @@ type t = private {
   operations : Protocol_operation.t list;
 }
 [@@deriving yojson, ord]
+
 val sign : key:Secret.t -> t -> Protocol_signature.t
+
 val verify : signature:Protocol_signature.t -> t -> bool
+
 val genesis : t
+
 val produce :
   state:Protocol_state.t ->
   next_state_root_hash:BLAKE2B.t option ->

--- a/src/protocol/protocol.ml
+++ b/src/protocol/protocol.ml
@@ -9,8 +9,11 @@ module Block = Block
 module Operation = Protocol_operation
 include Protocol_state
 open Protocol_operation
+
 let maximum_old_block_height_operation = 60L
+
 let maximum_stored_block_height = 75L
+
 let apply_core_tezos_operation state tezos_operation =
   let%assert () =
     ( `Duplicated_operation,
@@ -23,10 +26,12 @@ let apply_core_tezos_operation state tezos_operation =
   let core_state =
     Core_deku.State.apply_tezos_operation state.core_state tezos_operation in
   Ok { state with core_state; included_tezos_operations }
+
 let apply_core_tezos_operation state tezos_operation =
   match apply_core_tezos_operation state tezos_operation with
   | Ok state -> state
   | Error `Duplicated_operation -> state
+
 let apply_core_user_operation state user_operation =
   let Core_user.
         { hash = _; key = _; signature = _; nonce = _; block_height; data } =
@@ -45,11 +50,13 @@ let apply_core_user_operation state user_operation =
   let core_state, receipt =
     Core_deku.State.apply_user_operation state.core_state data in
   Ok ({ state with core_state; included_user_operations }, receipt)
+
 let apply_core_user_operation state tezos_operation =
   match apply_core_user_operation state tezos_operation with
   | Ok (state, receipts) -> (state, receipts)
   | Error (`Block_in_the_future | `Old_operation | `Duplicated_operation) ->
     (state, None)
+
 let apply_consensus_operation state consensus_operation =
   let validators = state.validators in
   let validators =
@@ -59,9 +66,11 @@ let apply_consensus_operation state consensus_operation =
       Validators.remove validator validators in
   let last_seen_membership_change_timestamp = Unix.time () in
   { state with validators; last_seen_membership_change_timestamp }
+
 let is_next state block =
   Int64.add state.block_height 1L = block.Block.block_height
   && state.last_block_hash = block.previous_hash
+
 let apply_operation (state, receipts) operation =
   match operation with
   | Core_tezos tezos_operation ->
@@ -77,6 +86,7 @@ let apply_operation (state, receipts) operation =
   | Consensus consensus_operation ->
     let state = apply_consensus_operation state consensus_operation in
     (state, receipts)
+
 let apply_block state block =
   Logs.app (fun m -> m "block: %Ld" block.Block.block_height);
   let state, receipts =
@@ -104,6 +114,7 @@ let apply_block state block =
       validators_hash = block.validators_hash;
     },
     receipts )
+
 let make ~initial_block =
   let empty =
     {
@@ -120,10 +131,12 @@ let make ~initial_block =
       last_seen_membership_change_timestamp = 0.0;
     } in
   apply_block empty initial_block |> fst
+
 let apply_block state block =
   let%assert () = (`Invalid_block_when_applying, is_next state block) in
   let state, result = apply_block state block in
   Ok (state, result)
+
 let get_current_block_producer state =
   if state.last_applied_block_timestamp = 0.0 then
     None

--- a/src/protocol/protocol_operation.ml
+++ b/src/protocol/protocol_operation.ml
@@ -1,22 +1,28 @@
 open Helpers
 open Crypto
 open Core_deku
+
 module Consensus = struct
   type t =
     | Add_validator    of Validators.validator
     | Remove_validator of Validators.validator
   [@@deriving eq, ord, yojson]
+
   let hash payload = to_yojson payload |> Yojson.Safe.to_string |> BLAKE2B.hash
+
   let sign secret t =
     let hash = hash t in
     Signature.sign secret hash
+
   let verify key signature t =
     let hash = hash t in
     Signature.verify key signature hash
 end
+
 module Core_tezos = struct
   type t = Tezos_operation.t [@@deriving eq, ord, yojson]
 end
+
 module Core_user = struct
   type t = {
     hash : BLAKE2B.t;
@@ -27,7 +33,9 @@ module Core_user = struct
     data : User_operation.t;
   }
   [@@deriving eq, yojson]
+
   let compare a b = BLAKE2B.compare a.hash b.hash
+
   let hash, verify =
     let apply f ~nonce ~block_height ~data =
       let to_yojson = [%to_yojson: int32 * int64 * User_operation.t] in
@@ -37,6 +45,7 @@ module Core_user = struct
     let hash = apply BLAKE2B.hash in
     let verify ~hash = apply (BLAKE2B.verify ~hash) in
     (hash, verify)
+
   let sign ~secret ~nonce ~block_height ~data =
     let open User_operation in
     let key = Key.of_secret secret in
@@ -49,6 +58,7 @@ module Core_user = struct
       failwith
         "Operations to be signed should come from a key_hash that matches the \
          secret"
+
   let verify ~hash ~key ~signature ~nonce ~block_height ~data =
     let source = data.User_operation.source in
     let%assert () =
@@ -58,13 +68,16 @@ module Core_user = struct
     let%assert () =
       ("Invalid core_user signature", Signature.verify key signature hash) in
     Ok { hash; key; signature; nonce; block_height; data }
+
   let of_yojson json =
     let%ok { hash; key; signature; nonce; block_height; data } =
       of_yojson json in
     verify ~hash ~key ~signature ~nonce ~block_height ~data
+
   let unsafe_make ~hash ~key ~signature ~nonce ~block_height ~data =
     { hash; key; signature; nonce; block_height; data }
 end
+
 type t =
   | Core_tezos of Core_deku.Tezos_operation.t
   | Core_user  of Core_user.t

--- a/src/protocol/protocol_operation.mli
+++ b/src/protocol/protocol_operation.mli
@@ -1,15 +1,20 @@
 open Crypto
+
 module Consensus : sig
   type t =
     | Add_validator    of Validators.validator
     | Remove_validator of Validators.validator
   [@@deriving eq, ord, yojson]
+
   val sign : Secret.t -> t -> Signature.t
+
   val verify : Key.t -> Signature.t -> t -> bool
 end
+
 module Core_tezos : sig
   type t = Core_deku.Tezos_operation.t [@@deriving eq, ord, yojson]
 end
+
 module Core_user : sig
   type t = private {
     hash : BLAKE2B.t;
@@ -20,12 +25,14 @@ module Core_user : sig
     data : Core_deku.User_operation.t;
   }
   [@@deriving eq, ord, yojson]
+
   val sign :
     secret:Secret.t ->
     nonce:int32 ->
     block_height:int64 ->
     data:Core_deku.User_operation.t ->
     t
+
   val unsafe_make :
     hash:BLAKE2B.t ->
     key:Key.t ->
@@ -35,6 +42,7 @@ module Core_user : sig
     data:Core_deku.User_operation.t ->
     t
 end
+
 type t =
   | Core_tezos of Core_deku.Tezos_operation.t
   | Core_user  of Core_user.t

--- a/src/protocol/protocol_signature.ml
+++ b/src/protocol/protocol_signature.ml
@@ -1,14 +1,19 @@
 open Helpers
 open Crypto
+
 type t = {
   signature : Signature.t;
   public_key : Wallet.t;
   address : Key_hash.t;
 }
 [@@deriving ord]
+
 let public_key t = t.public_key
+
 let address t = t.address
+
 let signature t = t.signature
+
 let to_yojson, of_yojson =
   let module Serialized_data = struct
     type t = {
@@ -25,36 +30,49 @@ let to_yojson, of_yojson =
     let address = Key_hash.of_key public_key in
     Ok { signature; public_key; address } in
   (to_yojson, of_yojson)
+
 let sign ~key:secret hash =
   let signature = Signature.sign secret hash in
   let public_key = Key.of_secret secret in
   let address = Key_hash.of_key public_key in
   { signature; public_key; address }
+
 let verify ~signature hash =
   Signature.verify signature.public_key signature.signature hash
+
 module type S = sig
   type value
+
   type signature = t
+
   type t = private {
     value : value;
     signature : signature;
   }
+
   val sign : key:Secret.t -> value -> t
+
   val verify : signature:signature -> value -> bool
 end
+
 module Make (P : sig
   type t
+
   val hash : t -> BLAKE2B.t
 end) =
 struct
   type value = P.t
+
   type signature = t
+
   type t = {
     value : value;
     signature : signature;
   }
+
   let sign ~key value =
     let signature = P.hash value |> sign ~key in
     { value; signature }
+
   let verify ~signature value = P.hash value |> verify ~signature
 end

--- a/src/protocol/protocol_signature.mli
+++ b/src/protocol/protocol_signature.mli
@@ -1,24 +1,38 @@
 open Crypto
+
 type t [@@deriving yojson]
+
 val compare : t -> t -> int
+
 val public_key : t -> Wallet.t
+
 val address : t -> Key_hash.t
+
 val signature : t -> Signature.t
+
 val sign : key:Secret.t -> BLAKE2B.t -> t
+
 val verify : signature:t -> BLAKE2B.t -> bool
+
 module type S = sig
   type value
+
   type signature = t
+
   type t = private {
     value : value;
     signature : signature;
   }
+
   val sign : key:Secret.t -> value -> t
+
   val verify : signature:signature -> value -> bool
 end
+
 module Make : functor
   (P : sig
      type t
+
      val hash : t -> BLAKE2B.t
    end)
   -> S with type value = P.t

--- a/src/protocol/protocol_state.ml
+++ b/src/protocol/protocol_state.ml
@@ -2,6 +2,7 @@ open Helpers
 open Crypto
 module Tezos_operation_set = Set.Make_with_yojson (Protocol_operation.Core_tezos)
 module User_operation_set = Set.Make_with_yojson (Protocol_operation.Core_user)
+
 type t = {
   core_state : Core_deku.State.t;
   included_tezos_operations : Tezos_operation_set.t;
@@ -15,6 +16,7 @@ type t = {
   last_applied_block_timestamp : float;
   last_seen_membership_change_timestamp : float;
 }
+
 let hash t =
   let to_yojson =
     [%to_yojson:

--- a/src/protocol/validators.ml
+++ b/src/protocol/validators.ml
@@ -1,6 +1,8 @@
 open Helpers
 open Crypto
+
 type validator = { address : Key_hash.t } [@@deriving eq, ord, yojson]
+
 type t = {
   current : validator option;
   validators : validator list;
@@ -8,9 +10,13 @@ type t = {
   hash : BLAKE2B.t;
 }
 [@@deriving yojson]
+
 let current t = t.current
+
 let to_list t = t.validators
+
 let length t = t.length
+
 let after_current n t =
   let%some current_producer = t.current in
   let%some current_index =
@@ -21,17 +27,21 @@ let after_current n t =
     | true -> t.length + relative_index
     | false -> relative_index in
   List.nth_opt t.validators index
+
 let update_current address t =
   let validator =
     t.validators |> List.find_opt (fun validator -> validator.address = address)
   in
   { t with current = validator }
+
 let hash_validators validators =
   validators
   |> List.map (fun validator -> validator.address)
   |> Tezos.Deku.Consensus.hash_validators
+
 let empty =
   { current = None; validators = []; length = 0; hash = hash_validators [] }
+
 let add validator t =
   let validators =
     t.validators @ [validator] |> List.in_order_uniq compare_validator in
@@ -41,6 +51,7 @@ let add validator t =
     | false -> t.current in
   let hash = hash_validators validators in
   { current = new_proposer; validators; length = List.length validators; hash }
+
 let remove validator t =
   let validators = t.validators |> List.filter (( <> ) validator) in
   let length = List.length validators in
@@ -51,4 +62,5 @@ let remove validator t =
     | _ -> t.current in
   let hash = hash_validators validators in
   { current; validators; length; hash }
+
 let hash t = t.hash

--- a/src/protocol/validators.mli
+++ b/src/protocol/validators.mli
@@ -1,8 +1,13 @@
 open Crypto
+
 type validator = { address : Key_hash.t } [@@deriving eq, ord, yojson]
+
 type t [@@deriving yojson]
+
 val current : t -> validator option
+
 val to_list : t -> validator list
+
 val length : t -> int
 
 val after_current : int -> t -> validator option
@@ -12,7 +17,11 @@ val after_current : int -> t -> validator option
     \  worst: O(n) "]
 
 val update_current : Key_hash.t -> t -> t
+
 val empty : t
+
 val add : validator -> t -> t
+
 val remove : validator -> t -> t
+
 val hash : t -> BLAKE2B.t

--- a/src/protocol/wallet.ml
+++ b/src/protocol/wallet.ml
@@ -1,18 +1,28 @@
 open Crypto
+
 type t = Key.t
+
 let compare = Key.compare
+
 let to_string = Key.to_string
+
 let of_string = Key.of_string
+
 let to_yojson = Key.to_yojson
+
 let of_yojson = Key.of_yojson
+
 let of_key secret =
   match secret with
   | Secret.Ed25519 secret -> Key.Ed25519 (Ed25519.Key.of_secret secret)
   | Secret.Secp256k1 secret -> Key.Secp256k1 (Secp256k1.Key.of_secret secret)
   | Secret.P256 secret -> Key.P256 (P256.Key.of_secret secret)
+
 let genesis_key = {|edsk4bfbFdb4s2BdkW3ipfB23i9u82fgji6KT3oj2SCWTeHUthbSVd|}
+
 let genesis_key =
   match Secret.of_yojson (`String genesis_key) with
   | Ok key -> key
   | Error error -> failwith error
+
 let genesis_wallet = of_key genesis_key

--- a/src/protocol/wallet.mli
+++ b/src/protocol/wallet.mli
@@ -1,7 +1,13 @@
 open Crypto
+
 type t = Key.t [@@deriving yojson, ord]
+
 val of_key : Secret.t -> t
+
 val genesis_key : Secret.t
+
 val genesis_wallet : t
+
 val to_string : t -> string
+
 val of_string : string -> t option

--- a/src/tezos/address.ml
+++ b/src/tezos/address.ml
@@ -1,5 +1,6 @@
 open Crypto
 open Helpers
+
 type t =
   | Implicit   of Key_hash.t
   | Originated of {
@@ -7,12 +8,14 @@ type t =
       entrypoint : string option;
     }
 [@@deriving eq, ord]
+
 let to_string = function
   | Implicit key_hash -> Key_hash.to_string key_hash
   | Originated { contract; entrypoint = None } ->
     Contract_hash.to_string contract
   | Originated { contract; entrypoint = Some entrypoint } ->
     Contract_hash.to_string contract ^ "%" ^ entrypoint
+
 let of_string =
   let implicit string =
     let%some implicit = Key_hash.of_string string in
@@ -50,6 +53,7 @@ let contract_encoding =
              | _ -> None)
            (fun contract -> Originated { contract; entrypoint = None });
        ]
+
 let encoding =
   let open Data_encoding in
   let name = "address" in
@@ -71,5 +75,6 @@ let encoding =
       (tup2 contract_encoding Variable.string) in
   Encoding_helpers.make_encoding ~name ~title ~to_string ~of_string
     ~raw_encoding
+
 let to_yojson, of_yojson =
   Yojson_ext.with_yojson_string "address" to_string of_string

--- a/src/tezos/address.mli
+++ b/src/tezos/address.mli
@@ -1,4 +1,5 @@
 open Crypto
+
 type t =
   | Implicit   of Key_hash.t
   | Originated of {
@@ -9,6 +10,9 @@ type t =
 
 (* TODO: explain why this encoding? TLDR fixed size and no entrypoint  *)
 val contract_encoding : t Data_encoding.t
+
 val encoding : t Data_encoding.t
+
 val to_string : t -> string
+
 val of_string : string -> t option

--- a/src/tezos/block_hash.ml
+++ b/src/tezos/block_hash.ml
@@ -5,13 +5,17 @@ type t = BLAKE2B.t [@@deriving eq, ord]
 
 include Encoding_helpers.Make_b58 (struct
   type nonrec t = t
+
   let name = "block_hash"
+
   let title = "A block identifier"
 
   let size = BLAKE2B.size
+
   let prefix = Base58.Prefix.block_hash
 
   let to_raw = BLAKE2B.to_raw_string
+
   let of_raw = BLAKE2B.of_raw_string
 end)
 

--- a/src/tezos/block_hash.mli
+++ b/src/tezos/block_hash.mli
@@ -3,5 +3,7 @@ open Crypto
 type t = BLAKE2B.t [@@deriving eq, ord, yojson]
 
 val encoding : t Data_encoding.t
+
 val to_string : t -> string
+
 val of_string : string -> t option

--- a/src/tezos/chain_id.ml
+++ b/src/tezos/chain_id.ml
@@ -5,11 +5,17 @@ type t = string [@@deriving eq, ord]
 
 include Encoding_helpers.Make_b58 (struct
   type nonrec t = t
+
   let name = "Chain_id"
+
   let title = "Network identifier"
+
   let size = 4
+
   let prefix = Base58.Prefix.chain_id
+
   let to_raw = Fun.id
+
   let of_raw s = if String.length s <> size then None else Some s
 end)
 

--- a/src/tezos/chain_id.mli
+++ b/src/tezos/chain_id.mli
@@ -1,5 +1,7 @@
 type t [@@deriving eq, ord, yojson]
 
 val encoding : t Data_encoding.t
+
 val to_string : t -> string
+
 val of_string : string -> t option

--- a/src/tezos/contract_hash.ml
+++ b/src/tezos/contract_hash.ml
@@ -1,14 +1,23 @@
 open Helpers
 open Crypto
+
 type t = BLAKE2B_20.t [@@deriving eq, ord]
+
 include Encoding_helpers.Make_b58 (struct
   type nonrec t = t
+
   let name = "Contract_hash"
+
   let title = "A contract ID"
+
   let size = BLAKE2B_20.size
+
   let prefix = Base58.Prefix.contract_hash
+
   let to_raw = BLAKE2B_20.to_raw_string
+
   let of_raw = BLAKE2B_20.of_raw_string
 end)
+
 let to_yojson, of_yojson =
   Yojson_ext.with_yojson_string "contract_hash" to_string of_string

--- a/src/tezos/contract_hash.mli
+++ b/src/tezos/contract_hash.mli
@@ -1,5 +1,9 @@
 open Crypto
+
 type t = BLAKE2B_20.t [@@deriving eq, ord, yojson]
+
 val encoding : t Data_encoding.t
+
 val to_string : t -> string
+
 val of_string : string -> t option

--- a/src/tezos/deku.ml
+++ b/src/tezos/deku.ml
@@ -1,11 +1,16 @@
 open Crypto
+
 module Consensus = struct
   open Pack
+
   let hash_packed_data data =
     data |> to_bytes |> Bytes.to_string |> BLAKE2B.hash
+
   let hash_validators validators =
     list (List.map key_hash validators) |> hash_packed_data
+
   let hash hash = bytes (BLAKE2B.to_raw_string hash |> Bytes.of_string)
+
   let hash_block ~block_height ~block_payload_hash ~state_root_hash
       ~withdrawal_handles_hash ~validators_hash =
     pair
@@ -14,6 +19,7 @@ module Consensus = struct
          (pair (hash withdrawal_handles_hash) (hash state_root_hash)))
       (hash validators_hash)
     |> hash_packed_data
+
   let hash_withdraw_handle ~id ~owner ~amount ~ticketer ~data =
     pair
       (pair (pair (nat amount) (bytes data)) (pair (nat id) (address owner)))

--- a/src/tezos/deku.mli
+++ b/src/tezos/deku.mli
@@ -1,6 +1,8 @@
 open Crypto
+
 module Consensus : sig
   val hash_validators : Key_hash.t list -> BLAKE2B.t
+
   val hash_block :
     block_height:int64 ->
     block_payload_hash:BLAKE2B.t ->
@@ -8,6 +10,7 @@ module Consensus : sig
     withdrawal_handles_hash:BLAKE2B.t ->
     validators_hash:BLAKE2B.t ->
     BLAKE2B.t
+
   val hash_withdraw_handle :
     id:Z.t ->
     owner:Address.t ->

--- a/src/tezos/michelson.ml
+++ b/src/tezos/michelson.ml
@@ -1,5 +1,4 @@
 open Tezos_micheline
-
 module Michelson_v1_primitives = Michelson_v1_primitives
 
 type t = Michelson_v1_primitives.prim Tezos_micheline.Micheline.canonical
@@ -10,6 +9,7 @@ let expr_encoding =
 
 let unit =
   Micheline.strip_locations (Prim (-1, Michelson_v1_primitives.D_Unit, [], []))
+
 let is_unit value =
   match Micheline.root value with
   | Prim (_, Michelson_v1_primitives.D_Unit, [], []) -> true

--- a/src/tezos/michelson.mli
+++ b/src/tezos/michelson.mli
@@ -5,6 +5,7 @@ type t = Michelson_v1_primitives.prim Tezos_micheline.Micheline.canonical
 val expr_encoding : t Data_encoding.t
 
 val unit : t
+
 val is_unit : t -> bool
 
 (* TODO: this seems like it should be in a tezos library somewhere already *)

--- a/src/tezos/michelson_v1_primitives.ml
+++ b/src/tezos/michelson_v1_primitives.ml
@@ -166,6 +166,7 @@ type prim =
   | T_bls12_381_g2
   | T_bls12_381_fr
   | T_ticket
+
 let prim_encoding =
   let open Data_encoding in
   def "michelson.v1.primitives"

--- a/src/tezos/operation.ml
+++ b/src/tezos/operation.ml
@@ -9,7 +9,9 @@ type transaction = {
   entrypoint : string;
   value : Michelson.t;
 }
+
 type content = Transaction of transaction
+
 type t = {
   source : Key_hash.t;
   fee : Tez.t;
@@ -98,7 +100,9 @@ let encoding =
         encoding
 
     let tag = 108
+
     let name = "transaction"
+
     let case =
       make_operation_case ~tag ~name ~encoding
         (fun (Transaction transaction) -> Some transaction)
@@ -109,7 +113,9 @@ let encoding =
 let shell_header_encoding =
   def "operation.shell_header" ~description:"An operation's shell header."
   @@ obj1 (req "branch" Block_hash.encoding)
+
 let contents_list_encoding = Variable.list encoding
+
 let injection_encoding =
   merge_objs shell_header_encoding
     (obj1 (req "contents" contents_list_encoding))
@@ -153,6 +159,7 @@ let next_operation_encoding next_protocol_hash =
           (merge_objs
              (dynamic_size shell_header_encoding)
              (dynamic_size operation_data_encoding)))
+
 let preapply_input_encoding next_protocol_hash =
   list (next_operation_encoding next_protocol_hash)
 

--- a/src/tezos/operation.mli
+++ b/src/tezos/operation.mli
@@ -11,6 +11,7 @@ type transaction = {
 }
 
 type content = Transaction of transaction
+
 type t = {
   source : Key_hash.t;
   fee : Tez.t;

--- a/src/tezos/operation_hash.ml
+++ b/src/tezos/operation_hash.ml
@@ -1,14 +1,23 @@
 open Helpers
 open Crypto
+
 type t = BLAKE2B.t [@@deriving eq, ord]
+
 include Encoding_helpers.Make_b58 (struct
   type nonrec t = t
+
   let name = "Operation_hash"
+
   let title = "A Tezos operation ID"
+
   let size = BLAKE2B.size
+
   let prefix = Base58.Prefix.operation_hash
+
   let to_raw = BLAKE2B.to_raw_string
+
   let of_raw = BLAKE2B.of_raw_string
 end)
+
 let to_yojson, of_yojson =
   Yojson_ext.with_yojson_string "operation_hash" to_string of_string

--- a/src/tezos/operation_hash.mli
+++ b/src/tezos/operation_hash.mli
@@ -1,4 +1,7 @@
 type t [@@deriving eq, ord, yojson]
+
 val encoding : t Data_encoding.t
+
 val to_string : t -> string
+
 val of_string : string -> t option

--- a/src/tezos/pack.ml
+++ b/src/tezos/pack.ml
@@ -6,13 +6,20 @@ open Michelson_v1_primitives
 type t = (canonical_location, prim) node
 
 let int n = Int (-1, n)
+
 let nat n = Int (-1, n)
+
 let bytes b = Bytes (-1, b)
+
 let pair l r = Prim (-1, D_Pair, [l; r], [])
+
 let list l = Seq (-1, l)
+
 let key k = Bytes (-1, Data_encoding.Binary.to_bytes_exn Key.encoding k)
+
 let key_hash h =
   Bytes (-1, Data_encoding.Binary.to_bytes_exn Key_hash.encoding h)
+
 let address addr =
   Bytes (-1, Data_encoding.Binary.to_bytes_exn Address.encoding addr)
 

--- a/src/tezos/pack.mli
+++ b/src/tezos/pack.mli
@@ -3,12 +3,19 @@ open Crypto
 type t
 
 val int : Z.t -> t
+
 val nat : Z.t -> t
+
 val bytes : bytes -> t
+
 val pair : t -> t -> t
+
 val list : t list -> t
+
 val key : Key.t -> t
+
 val key_hash : Key_hash.t -> t
+
 val address : Address.t -> t
 
 val to_bytes : t -> bytes

--- a/src/tezos/protocol_hash.ml
+++ b/src/tezos/protocol_hash.ml
@@ -5,14 +5,17 @@ type t = BLAKE2B.t [@@deriving eq, ord]
 
 include Encoding_helpers.Make_b58 (struct
   type nonrec t = t
+
   let name = "Protocol_hash"
 
   let title = "A Tezos protocol ID"
 
   let size = BLAKE2B.size
+
   let prefix = Base58.Prefix.protocol_hash
 
   let to_raw = BLAKE2B.to_raw_string
+
   let of_raw = BLAKE2B.of_raw_string
 end)
 

--- a/src/tezos/protocol_hash.mli
+++ b/src/tezos/protocol_hash.mli
@@ -3,5 +3,7 @@ open Crypto
 type t = BLAKE2B.t [@@deriving eq, ord, yojson]
 
 val encoding : t Data_encoding.t
+
 val to_string : t -> string
+
 val of_string : string -> t option

--- a/src/tezos/tez.ml
+++ b/src/tezos/tez.ml
@@ -10,7 +10,9 @@ let encoding =
 let to_yojson, of_yojson = Yojson_ext.with_data_encoding encoding
 
 let zero = 0L
+
 let one_mutez = 1L
+
 let one = 1_000_000L
 
 let of_mutez t = if t < 0L then None else Some t

--- a/src/tezos/tez.mli
+++ b/src/tezos/tez.mli
@@ -3,7 +3,9 @@ type t [@@deriving eq, ord, yojson]
 val encoding : t Data_encoding.t
 
 val zero : t
+
 val one_mutez : t
+
 val one : t
 
 val of_mutez : int64 -> t option

--- a/src/tezos/ticket_id.ml
+++ b/src/tezos/ticket_id.ml
@@ -1,10 +1,12 @@
 open Tezos_micheline
 open Helpers
+
 type t = {
   ticketer : Address.t;
   data : bytes;
 }
 [@@deriving eq, ord]
+
 let parse_micheline string =
   let tokens, errors = Micheline_parser.tokenize string in
   match errors with
@@ -14,6 +16,7 @@ let parse_micheline string =
     | [] -> Some micheline
     | _ -> None)
   | _ -> None
+
 let to_string t =
   let loc =
     let open Micheline_printer in
@@ -25,6 +28,7 @@ let to_string t =
         [String (loc, Address.to_string t.ticketer); Bytes (loc, t.data)],
         [] ) in
   Format.asprintf "%a" Micheline_printer.print_expr micheline
+
 let of_string string =
   let%some micheline = parse_micheline string in
   let%some ticketer, data =
@@ -34,5 +38,6 @@ let of_string string =
     | _ -> None in
   let%some ticketer = Address.of_string ticketer in
   Some { ticketer; data }
+
 let to_yojson, of_yojson =
   Yojson_ext.with_yojson_string "ticket_id" to_string of_string

--- a/src/tezos/ticket_id.mli
+++ b/src/tezos/ticket_id.mli
@@ -3,5 +3,7 @@ type t = {
   data : bytes;
 }
 [@@deriving eq, ord, yojson]
+
 val to_string : t -> string
+
 val of_string : string -> t option

--- a/src/tezos_interop/long_lived_js_process.ml
+++ b/src/tezos_interop/long_lived_js_process.ml
@@ -5,22 +5,32 @@ open Helpers
 
 module Id : sig
   type t [@@deriving yojson]
+
   val pp : Format.formatter -> t -> unit
 
   val initial : t
+
   val next : t -> t
+
   module Map : Map.S with type key = t
 end = struct
   type t = int [@@deriving yojson]
+
   let pp fmt t = Format.fprintf fmt "%d" t
+
   let initial = 0
+
   let next t = t + 1
+
   module Map = Map.Make (Int)
 end
 
 exception Process_closed of Unix.process_status
+
 exception Failed_to_parse_json of string * Yojson.Safe.t
+
 exception Duplicated_id of Id.t
+
 exception Unknown_id of Id.t * Yojson.Safe.t
 
 (* enhance error messages *)
@@ -59,25 +69,36 @@ end
 
 module Pending : sig
   type t
+
   type add_error = private Duplicated_id of Id.t
+
   type resolve_error = private Unknown_id of Id.t
+
   type kind =
     | Listen
     | Request
+
   val make : unit -> t
+
   val add :
     t -> Id.t -> kind -> (Yojson.Safe.t -> unit) -> (unit, add_error) result
+
   val push : t -> Id.t -> Yojson.Safe.t -> (unit, resolve_error) result
 end = struct
   type add_error = Duplicated_id of Id.t
+
   type resolve_error = Unknown_id of Id.t
+
   type kind =
     | Listen
     | Request
+
   type t = (kind * (Yojson.Safe.t -> unit)) Id.Map.t ref
 
   let make () = ref Id.Map.empty
+
   let find t id = Id.Map.find_opt id !t
+
   let mem t id = Id.Map.mem id !t
 
   let add t id kind resolver =
@@ -111,6 +132,7 @@ type t = {
    must kill the node.
      Use [raise_and_exit] instead. *)
 let[@warning "-unused-value-declaration"] raise = ()
+
 let raise_and_exit exn =
   (* TODO: https://github.com/marigold-dev/deku/issues/502 *)
   Format.eprintf "tezos_interop failure: %s\n%!" (Printexc.to_string exn);

--- a/src/tezos_interop/long_lived_js_process.mli
+++ b/src/tezos_interop/long_lived_js_process.mli
@@ -1,13 +1,16 @@
 (** Interface between a long lived JS script and an OCaml consumer *)
 
 type t
+
 val spawn : file:string -> t
+
 val listen :
   t ->
   to_yojson:('request -> Yojson.Safe.t) ->
   of_yojson:(Yojson.Safe.t -> ('message, string) result) ->
   'request ->
   'message Lwt_stream.t
+
 val request :
   t ->
   to_yojson:('request -> Yojson.Safe.t) ->

--- a/src/tezos_interop/tezos_bridge.ml
+++ b/src/tezos_interop/tezos_bridge.ml
@@ -4,17 +4,23 @@ open Tezos
 
 module Michelson = struct
   include Michelson
+
   type t = Michelson.t
+
   let of_yojson json =
     let%ok json = Yojson.Safe.to_string json |> Data_encoding.Json.from_string in
     try Ok (Data_encoding.Json.destruct Michelson.expr_encoding json) with
     | _ -> Error "invalid json"
+
   let big_map_key_to_yojson (Key_hash key_hash) : Yojson.Safe.t =
     `String (Key_hash.to_string key_hash)
 end
+
 module Listen_transaction = struct
   type kind = Listen
+
   let kind_to_yojson Listen = `String "listen"
+
   type request = {
     kind : kind;
     rpc_node : string;
@@ -28,15 +34,19 @@ module Listen_transaction = struct
     value : Michelson.t;
   }
   [@@deriving of_yojson]
+
   type t = {
     hash : string;
     transactions : transaction list;
   }
   [@@deriving of_yojson]
 end
+
 module Inject_transaction = struct
   type kind = Transaction
+
   let kind_to_yojson Transaction = `String "transaction"
+
   type request = {
     kind : kind;
     rpc_node : string;
@@ -60,10 +70,13 @@ module Inject_transaction = struct
   let of_yojson json =
     let module T = struct
       type t = { status : string } [@@deriving of_yojson { strict = false }]
+
       type with_hash = { hash : string }
       [@@deriving of_yojson { strict = false }]
+
       type maybe_hash = { hash : string option }
       [@@deriving of_yojson { strict = false }]
+
       type error = { error : string } [@@deriving of_yojson { strict = false }]
     end in
     let other make =
@@ -87,7 +100,9 @@ end
 
 module Storage = struct
   type kind = Storage
+
   let kind_to_yojson Storage = `String "storage"
+
   type request = {
     kind : kind;
     rpc_node : string;
@@ -99,8 +114,10 @@ module Storage = struct
   let of_yojson json =
     let module T = struct
       type t = { status : string } [@@deriving of_yojson { strict = false }]
+
       type success = { storage : Michelson.t }
       [@@deriving of_yojson { strict = false }]
+
       type error = { error : string } [@@deriving of_yojson { strict = false }]
     end in
     let%ok { status } = T.of_yojson json in
@@ -116,7 +133,9 @@ end
 
 module Big_map_keys = struct
   type kind = Big_map_keys
+
   let kind_to_yojson Big_map_keys = `String "big_map_keys"
+
   type request = {
     kind : kind;
     rpc_node : string;
@@ -137,6 +156,7 @@ module Big_map_keys = struct
       *)
       type success = { values : Yojson.Safe.t option list }
       [@@deriving of_yojson { strict = false }]
+
       type error = { error : string } [@@deriving of_yojson { strict = false }]
     end in
     let%ok { status } = T.of_yojson json in
@@ -151,9 +171,11 @@ module Big_map_keys = struct
 end
 
 type t = Long_lived_js_process.t
+
 let spawn () =
   let file = Scripts.file_tezos_js_bridge in
   Long_lived_js_process.spawn ~file
+
 let listen_transaction t ~rpc_node ~required_confirmations ~destination =
   let request =
     Listen_transaction.

--- a/src/tezos_interop/tezos_bridge.mli
+++ b/src/tezos_interop/tezos_bridge.mli
@@ -8,6 +8,7 @@ module Listen_transaction : sig
     value : Michelson.t;
   }
   [@@deriving of_yojson]
+
   type t = {
     hash : string;
     transactions : transaction list;
@@ -27,6 +28,7 @@ module Inject_transaction : sig
 end
 
 type t
+
 val spawn : unit -> t
 
 val listen_transaction :

--- a/src/tezos_interop/tezos_interop.ml
+++ b/src/tezos_interop/tezos_interop.ml
@@ -10,6 +10,7 @@ type t = {
   required_confirmations : int;
   bridge_process : Tezos_bridge.t;
 }
+
 let make ~rpc_node ~secret ~consensus_contract ~discovery_contract
     ~required_confirmations =
   let bridge_process = Tezos_bridge.spawn () in
@@ -49,6 +50,7 @@ end = struct
     Tezos_bridge.storage t.bridge_process ~rpc_node ~required_confirmations
       ~destination:contract_address
 end
+
 module Fetch_big_map_keys : sig
   val run :
     t ->
@@ -62,6 +64,7 @@ end = struct
     Tezos_bridge.big_map_keys t.bridge_process ~rpc_node ~required_confirmations
       ~destination:contract_address ~keys
 end
+
 module Listen_transactions = struct
   let listen t ~rpc_node ~required_confirmations ~destination ~on_message =
     let message_stream =
@@ -69,9 +72,11 @@ module Listen_transactions = struct
         ~required_confirmations ~destination in
     Lwt.async (fun () -> Lwt_stream.iter on_message message_stream)
 end
+
 module Consensus = struct
   open Michelson.Michelson_v1_primitives
   open Tezos_micheline
+
   let commit_state_hash t ~block_height ~block_payload_hash ~state_hash
       ~withdrawal_handles_hash ~validators ~signatures =
     let module Payload = struct
@@ -115,6 +120,7 @@ module Consensus = struct
         ~entrypoint:"update_root_hash"
         ~payload:(Payload.to_yojson payload) in
     await ()
+
   type transaction =
     | Deposit          of {
         ticket : Ticket_id.t;
@@ -122,10 +128,12 @@ module Consensus = struct
         destination : Address.t;
       }
     | Update_root_hash of BLAKE2B.t
+
   type operation = {
     hash : Operation_hash.t;
     transactions : transaction list;
   }
+
   let parse_transaction transaction =
     let Tezos_bridge.Listen_transaction.{ entrypoint; value } = transaction in
     let value = Micheline.root value in
@@ -190,11 +198,13 @@ module Consensus = struct
         { ticketer; data } in
       Some (Deposit { ticket; destination; amount })
     | _ -> None
+
   let parse_operation output =
     let Tezos_bridge.Listen_transaction.{ hash; transactions } = output in
     let%some hash = Operation_hash.of_string hash in
     let transactions = List.filter_map parse_transaction transactions in
     Some { hash; transactions }
+
   let listen_operations t ~on_operation =
     let on_message output =
       match parse_operation output with
@@ -203,6 +213,7 @@ module Consensus = struct
     Listen_transactions.listen t ~rpc_node:t.rpc_node
       ~required_confirmations:t.required_confirmations
       ~destination:t.consensus_contract ~on_message
+
   let fetch_uris_from_discovery t validator_key_hashes =
     let {
       rpc_node;
@@ -296,8 +307,10 @@ module Consensus = struct
         Lwt.return (Ok validator_uri_pairs))
     | Error e -> Lwt.return (Error e)
 end
+
 module Discovery = struct
   open Pack
+
   let sign secret ~nonce uri =
     to_bytes
       (pair

--- a/src/tezos_interop/tezos_interop.mli
+++ b/src/tezos_interop/tezos_interop.mli
@@ -3,6 +3,7 @@ open Crypto
 open Tezos
 
 type t
+
 val make :
   rpc_node:Uri.t ->
   secret:Secret.t ->
@@ -30,14 +31,18 @@ module Consensus : sig
         destination : Address.t;
       }
     | Update_root_hash of BLAKE2B.t
+
   type operation = {
     hash : Operation_hash.t;
     transactions : transaction list;
   }
+
   val listen_operations : t -> on_operation:(operation -> unit) -> unit
+
   val fetch_validators :
     t -> ((Key_hash.t * Uri.t option) list, string) result Lwt.t
 end
+
 module Discovery : sig
   val sign : Secret.t -> nonce:int64 -> Uri.t -> Signature.t
 end

--- a/src/tezos_rpc/block_header.ml
+++ b/src/tezos_rpc/block_header.ml
@@ -1,4 +1,5 @@
 open Tezos
+
 type t = {
   hash : Block_hash.t;
   level : int32;

--- a/src/tezos_rpc/fetch_block_header.mli
+++ b/src/tezos_rpc/fetch_block_header.mli
@@ -1,6 +1,7 @@
 open Tezos
 
 type response = Block_header.t
+
 val execute :
   node_uri:Uri.t ->
   chain:Chain_id.t option ->

--- a/src/tezos_rpc/fetch_block_operations.ml
+++ b/src/tezos_rpc/fetch_block_operations.ml
@@ -10,10 +10,12 @@ type block_operation = {
   branch : Block_hash.t;
   contents : Operation_content_with_result.t list;
 }
+
 type response = block_operation list
 
 module Decoder = struct
   type operation_content_with_result = Operation_content_with_result.t
+
   let operation_content_with_result_of_yojson =
     Operation_content_with_result.of_tezos_json
 

--- a/src/tezos_rpc/fetch_block_operations.mli
+++ b/src/tezos_rpc/fetch_block_operations.mli
@@ -8,6 +8,7 @@ type block_operation = {
   branch : Block_hash.t;
   contents : Operation_content_with_result.t list;
 }
+
 type response = block_operation list
 
 val execute :

--- a/src/tezos_rpc/fetch_constants.ml
+++ b/src/tezos_rpc/fetch_constants.ml
@@ -4,7 +4,9 @@ open Http
 
 let _z_integral_to_yojson, z_integral_of_yojson =
   Yojson_ext.with_data_encoding Gas.z_integral_encoding
+
 type gas_z_integral = Gas.integral
+
 let gas_z_integral_of_yojson = z_integral_of_yojson
 
 type response = {

--- a/src/tezos_rpc/http.ml
+++ b/src/tezos_rpc/http.ml
@@ -4,6 +4,7 @@ open Error
 type 'a method_ =
   | GET : unit method_
   | POST : string method_
+
 let http_request (type a) ~uri ~(method_ : a method_) (data : a) =
   let open Piaf in
   let%await response =
@@ -36,9 +37,11 @@ let http_request ~node_uri ~path ~method_ response_of_yojson data =
 
 let http_get ~node_uri ~path ~of_yojson =
   http_request ~node_uri ~path ~method_:GET of_yojson ()
+
 let http_post ~node_uri ~path ~of_yojson ~data =
   let data = Yojson.Safe.to_string data in
   http_request ~node_uri ~path ~method_:POST of_yojson data
+
 let http_post_data_encoding ~node_uri ~path ~of_yojson ~data =
   let data = Data_encoding.Json.to_string data in
   http_request ~node_uri ~path ~method_:POST of_yojson data

--- a/src/tezos_rpc/inject_operations.mli
+++ b/src/tezos_rpc/inject_operations.mli
@@ -2,6 +2,7 @@ open Crypto
 open Tezos
 
 type response = Operation_hash.t
+
 val execute :
   node_uri:Uri.t ->
   secret:Secret.t ->

--- a/src/tezos_rpc/listen_to_blocks.ml
+++ b/src/tezos_rpc/listen_to_blocks.ml
@@ -3,5 +3,6 @@ open Http
 let path = "/monitor/valid_blocks"
 
 type response = Block_header.t Lwt_stream.t
+
 let execute ~node_uri =
   http_get_listen ~node_uri ~path ~of_yojson:Block_header.of_yojson

--- a/src/tezos_rpc/listen_to_chain_heads.ml
+++ b/src/tezos_rpc/listen_to_chain_heads.ml
@@ -10,6 +10,7 @@ let path ~chain =
   Format.sprintf "/monitor/heads/%s" chain
 
 type response = Block_header.t Lwt_stream.t
+
 let execute ~node_uri ~chain =
   let path = path ~chain in
   http_get_listen ~node_uri ~path ~of_yojson:Block_header.of_yojson

--- a/src/tezos_rpc/operation_content_with_result.ml
+++ b/src/tezos_rpc/operation_content_with_result.ml
@@ -6,6 +6,7 @@ type parameters = {
   entrypoint : string;
   value : Michelson.t;
 }
+
 type internal_operation =
   | Internal_transaction     of {
       sender : Address.t;
@@ -13,9 +14,11 @@ type internal_operation =
       parameters : parameters option;
     }
   | Internal_non_transaction
+
 type status =
   | Applied
   | Other
+
 type t =
   | Transaction     of {
       source : Key_hash.t;
@@ -31,6 +34,7 @@ module Decoder = struct
   type kind =
     | Kind_transaction
     | Kind_not_transaction
+
   let kind_of_yojson json =
     (* TODO: probably can be done better *)
     let%ok kind = [%of_yojson: string] json in

--- a/src/tezos_rpc/operation_content_with_result.mli
+++ b/src/tezos_rpc/operation_content_with_result.mli
@@ -5,6 +5,7 @@ type parameters = {
   entrypoint : string;
   value : Michelson.t;
 }
+
 type internal_operation =
   | Internal_transaction     of {
       sender : Address.t;
@@ -12,9 +13,11 @@ type internal_operation =
       parameters : parameters option;
     }
   | Internal_non_transaction
+
 type status =
   | Applied
   | Other
+
 type t =
   | Transaction     of {
       source : Key_hash.t;

--- a/src/tezos_rpc/preapply_operations.ml
+++ b/src/tezos_rpc/preapply_operations.ml
@@ -4,6 +4,7 @@ open Http
 
 module Decoder = struct
   type operation_content_with_result = Operation_content_with_result.t
+
   let operation_content_with_result_of_yojson =
     Operation_content_with_result.of_tezos_json
 
@@ -14,6 +15,7 @@ module Decoder = struct
 end
 
 type response = Operation_content_with_result.t list
+
 let response_of_yojson json =
   let%ok next_operations = Decoder.of_yojson json in
   match next_operations with
@@ -25,6 +27,7 @@ let response_of_yojson json =
 let path ~chain ~branch =
   (* TODO: I don't like this Format.sprintf *)
   Format.sprintf "/chains/%s/blocks/%s/helpers/preapply/operations" chain branch
+
 let execute ~node_uri ~secret ~chain ~protocol ~branch ~operations =
   let path =
     let chain =

--- a/src/tezos_rpc/tezos_rpc.mli
+++ b/src/tezos_rpc/tezos_rpc.mli
@@ -4,7 +4,6 @@ module Inject_operations = Inject_operations
 module Fetch_block_operations = Fetch_block_operations
 module Fetch_block_header = Fetch_block_header
 module Fetch_constants = Fetch_constants
-
 module Block_header = Block_header
 module Listen_to_chain_heads = Listen_to_chain_heads
 module Listen_to_blocks = Listen_to_blocks

--- a/tests/contracts/test_invocation.ml
+++ b/tests/contracts/test_invocation.ml
@@ -102,6 +102,7 @@ let test_ok msg =
           ~expected:(Contract_vm.Contract.equal new_contract old_contract)
           ~actual:false);
   ]
+
 let test_failure msg =
   let initial_state, address = setup () in
   let script = [%lambda_vm.script fun x -> (x + 1L, (0L, 0L))] in
@@ -174,6 +175,7 @@ let test_dummy_ok msg =
           ~expected:(Contract_vm.Contract.equal new_contract old_contract)
           ~actual:false);
   ]
+
 let test_dummy_failure msg =
   let initial_state, address = setup () in
   let payload = Contract_vm.Origination_payload.dummy_of_yojson ~storage:0 in
@@ -207,6 +209,7 @@ let test_dummy_failure msg =
           ~expected:(Contract_vm.Contract.equal new_contract old_contract)
           ~actual:true);
   ]
+
 let test_invocation =
   ( "Invocation",
     [

--- a/tests/contracts/test_origination.ml
+++ b/tests/contracts/test_origination.ml
@@ -85,6 +85,7 @@ let test msg =
                (State.contract_storage state)
                Contract_storage.empty));
   ]
+
 let test_dummy msg =
   let initial_state, address = setup () in
   let storage = 0 in

--- a/tests/setup.ml
+++ b/tests/setup.ml
@@ -1,4 +1,5 @@
 Printexc.record_backtrace true
+
 include Rely.Make (struct
   let config =
     Rely.TestFrameworkConfig.initialize

--- a/tests/test_incremental_patricia.ml
+++ b/tests/test_incremental_patricia.ml
@@ -1,16 +1,22 @@
 open Setup
 open Crypto
+
 module M = struct
   type t = {
     key : int;
     hash : BLAKE2B.t;
   }
   [@@deriving yojson]
+
   let hash t = t.hash
+
   let make key = { key; hash = BLAKE2B.hash (string_of_int key) }
 end
+
 open M
+
 open Incremental_patricia.Make (M)
+
 let () =
   describe "incremental Patricia" (fun { test; _ } ->
       test "add and find" (fun { expect; _ } ->

--- a/tests/test_runner.ml
+++ b/tests/test_runner.ml
@@ -1,2 +1,3 @@
 Printexc.record_backtrace true
+
 let () = Protocol_test_lib.Setup.cli ()

--- a/tests/test_tezos_interop.ml
+++ b/tests/test_tezos_interop.ml
@@ -4,22 +4,27 @@ open Wallet
 open Crypto
 open Tezos
 open Tezos_interop
+
 module TZ2_ex = struct
   let sk =
     Secret.of_string "spsk3LfH15rYByf7whY9YNAxS5ghpjzCr96jZ16Jt4pv2mnshf8Tcy"
     |> Option.get
+
   let pk =
     Key.of_string "sppk7aCim2kYBWGoEQGezcg8LbHi99XxrAE5dh6DDUru26pT93V2c5U"
     |> Option.get
 end
+
 module TZ3_ex = struct
   let sk =
     Secret.of_string "p2sk2s8WFJdvL6J9JxY7R3tWwMnaqJotbcTFgXg3pSVNPvrxKL1AkQ"
     |> Option.get
+
   let pk =
     Key.of_string "p2pk67mCLEZ2iFivprKpjugLakXfahdq9VUqmiTho1fhtv9P3AeJoc7"
     |> Option.get
 end
+
 let some_contract_hash =
   Contract_hash.of_string "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc" |> Option.get
 
@@ -92,6 +97,7 @@ let () =
              (of_string "p2pk67mCLE2iFivprKpjugLakXfahdq9VUqmiTho1fhtv9P3AeJoc7"))
             .toBeNone
             ()))
+
 let () =
   describe "key_hash" (fun { test; _ } ->
       let open Key_hash in
@@ -133,6 +139,7 @@ let () =
             .toBeNone ();
           (expect.option (of_string "tz38hJcRfJzz5ZNCTepE9kU1QnTrL8Acy3y"))
             .toBeNone ()))
+
 let () =
   describe "secret" (fun { test; _ } ->
       let open Secret in
@@ -198,6 +205,7 @@ let () =
              (of_string "p2sk2s8wFJdvL6J9JxY7R3tWwMnaqJotbcTFgXg3pSVNPvrxKL1AkQ"))
             .toBeNone
             ()))
+
 let () =
   describe "signature" (fun { test; _ } ->
       let open BLAKE2B in
@@ -311,6 +319,7 @@ let () =
                 "p2sigt13usEEBeyJkpRCarwHnMUZ744xeAQFv65ZT5UZeNgoGaFDdFfw27MEGpGSSAdxpSyBdfBhkrtUf7cwHx6NQnCpjWbpo"))
             .toBeNone
             ()))
+
 let () =
   describe "contract_hash" (fun { test; _ } ->
       let open Contract_hash in
@@ -330,6 +339,7 @@ let () =
       test "invalid size" (fun { expect; _ } ->
           (expect.option (of_string "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABT"))
             .toBeNone ()))
+
 let () =
   describe "address" (fun { test; _ } ->
       let open Address in
@@ -388,6 +398,7 @@ let () =
             .toBeNone ();
           (expect.option (of_string "tz3b8hJRfJzz5ZNCTepE9kU1QnTrL8Acy3y"))
             .toBeNone ()))
+
 let () =
   describe "ticket" (fun { test; _ } ->
       let open Ticket_id in
@@ -413,6 +424,7 @@ let () =
              (of_string {|(Pair "BT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc" 0x6Z)|}))
             .toBeNone
             ()))
+
 let () =
   describe "operation_hash" (fun { test; _ } ->
       let open Operation_hash in
@@ -442,6 +454,7 @@ let () =
              (of_string "opCAkifFMh1Ya2J4WhRHskaXc297ELtx32wnc2WzeNtdQHp7DW"))
             .toBeNone
             ()))
+
 let () =
   describe "operation forging" (fun { test; _ } ->
       let open Tezos in
@@ -493,6 +506,7 @@ let () =
             "f6e43992b2f45aedbfdc7f5f6a21aa68c99973afffa0ddbe8b98e33672dec6396c001004051072b588b39e25b9f4dbf4673abcd63147a403b4dfc901970a000001533ace00d71497d23fdac2a8809bb1e9df14c579000048a432efc5ef0e700c2f696957996e90194787995d43826b18ade1823d05857f35787f4e7a223d3ea226f22b1809ee56a9046bd313f547e3746fb46bc8ed3803"
           in
           (expect.string forged_bytes).toEqual taquito_forged_bytes))
+
 let () =
   describe "pack" (fun { test; _ } ->
       let open Pack in
@@ -546,6 +560,7 @@ let () =
         (address
            (Originated { contract = some_contract_hash; entrypoint = None }))
         "050a0000001601370027c6c8f3fbafda4f9bfd08b14f45e6a29ce300")
+
 let () =
   describe "consensus" (fun { test; _ } ->
       let open Helpers in
@@ -594,6 +609,7 @@ let () =
           let hash = BLAKE2B.to_string hash in
           (expect.string hash).toEqual
             "63dfd90ec7be98a9c23bf374692de4d36f41fe03c4c768fc0c650641d3ed4f86"))
+
 let () =
   describe "discovery" (fun { test; _ } ->
       let open Discovery in

--- a/tests/test_tezos_rpc.ml
+++ b/tests/test_tezos_rpc.ml
@@ -9,10 +9,13 @@ open Tezos_rpc
    You may also want to change the node_uri and/or the secret key below. *)
 
 let node_uri = Uri.of_string "http://localhost:8732"
+
 let secret =
   Secret.of_string "edsk4RbgwutwsEdVNuJsE5JDsxeJ6qFcG8F5rKFGnj5finT6FV46sd"
   |> Option.get
+
 let key = Key.of_secret secret
+
 let key_hash = Key_hash.of_key key
 
 let failwith_err err =

--- a/tests/test_validators.ml
+++ b/tests/test_validators.ml
@@ -1,6 +1,7 @@
 open Setup
 open Protocol
 open Validators
+
 let () =
   describe "validators" (fun { test; _ } ->
       let make_validator () =

--- a/tests/vm/test_errors.ml
+++ b/tests/vm/test_errors.ml
@@ -1,5 +1,4 @@
 open Lambda_vm
-
 module Testable = Vm_test.Testable
 
 let sender =

--- a/tests/vm/test_prim.ml
+++ b/tests/vm/test_prim.ml
@@ -1,5 +1,4 @@
 open Lambda_vm
-
 module Testable = Vm_test.Testable
 
 let sender =

--- a/tests/vm/test_recursion.ml
+++ b/tests/vm/test_recursion.ml
@@ -89,6 +89,7 @@ let check_runtime_error ~msg ~actual ~expected =
     Alcotest.(check Testable.runtime_limits_error) msg expected error
   | Ok _ -> Alcotest.fail "Ast shouldn't execute"
   | _ -> Alcotest.fail "unexpected error"
+
 let test_stack_limit () =
   check_runtime_error ~msg:"Stack has a limit" ~expected:Out_of_stack
     ~actual:

--- a/tests/vm/test_voting_contract.ml
+++ b/tests/vm/test_voting_contract.ml
@@ -153,15 +153,25 @@ let vote vote =
     [%lambda_vm.value 1L, 0L]
 
 let admin = "tz1ibMpWS6n6MJn73nQHtK5f4ogyYC1z9T9z"
+
 let alice = "tz1L738ifd66ah69PrmKAZzckvvHnbcSeqjf"
+
 let bob = "tz1LFuHW4Z9zsCwg1cgGTKU12WZAs27ZD14v"
+
 let frank = "tz1Qd971cetwNr5f4oKp9xno6jBvghZHRsDr"
+
 let pascal = "tz1TgK3oaBaqcCHankT97AUNMjcs87Tfj5vb"
+
 let jacob = "tz1VphG4Lgp39MfQ9rTUnsm7BBWyXeXnJSMZ"
+
 let lucina = "tz1ZAZo1xW4Veq5t7YqWy2SMbLdskmeBmzqs"
+
 let mark = "tz1ccWCuJqMxG4hoa1g5SKhgdTwXoJBM8kpc"
+
 let jean = "tz1hQzKQpprB5JhNxZZRowEDRBoieHRAL84b"
+
 let boby = "tz1hTic2GpaNumpTtYwqyPSBd9KcWifRMuEN"
+
 let bartholome = "tz1hv9CrgtaxiCayc567KUvCyWDQRF9sVNuf"
 
 let test_vote () =


### PR DESCRIPTION
Add breakline at the end of the function. It helps to read the codes easier. 


Note from @d4hines:
- Don't squash this PR when merging
- To rebase your command, see the commit message of the second commit:

```
chore: reformat the code with new module spacing

Instructions for rebasing on this PR:

Try a normal `git rebase`.

If that doesn't work, do the following:
- Rebase on the commit previous to this one: 349b7e8c577e5f71a08995a6b298f2cce41ba1b6. This will change only .ocamlformat.
- Then do this command
  `git rebase -i --exec "nix develop -c dune build @fmt --auto" origin/main`
- You'll be prompted to ammend each commit that needs changes.
```