### PR TITLE
allowing controlling verbosity of node from CLI

### DIFF
--- a/sandbox.sh
+++ b/sandbox.sh
@@ -263,7 +263,7 @@ start_deku_cluster() {
   echo "Starting nodes."
   for i in "${VALIDATORS[@]}"; do
     if [ "$mode" = "local" ]; then
-      deku-node "$DATA_DIRECTORY/$i" --listen-prometheus="900$i" &
+      deku-node "$DATA_DIRECTORY/$i" --listen-prometheus="900$i" -vv &
       SERVERS+=($!)
     fi
   done

--- a/src/bin/dune
+++ b/src/bin/dune
@@ -7,6 +7,8 @@
   node
   helpers
   cmdliner
+  logs
+  logs.cli
   prometheus-dream
   json-logs-reporter)
  (modules Deku_node)
@@ -15,7 +17,7 @@
 
 (executable
  (name deku_cli)
- (libraries node bin_common helpers cmdliner)
+ (libraries node bin_common helpers cmdliner logs)
  (modules Deku_cli)
  (public_name deku-cli)
  (preprocess


### PR DESCRIPTION


## Problem

Merging #604 removed some logs from the default sandbox setup that were used to assess whether the node was working or not.

## Solution

<!--- Restate the basic ideas behind your solution --->
<!--- Here it is also a good space to put details of your implementation --->

Add the Logs Cmdliner terms to our setup, so we can control the verbosity from the command line.

Created in draft mode because I'm having some trouble building the node with this setup.