### PR TITLE
fix: add snapshot logging back

### DIFF
--- a/src/node/snapshots.ml
+++ b/src/node/snapshots.ml
@@ -52,7 +52,7 @@ let add_snapshot_ref ~block_height t =
       additional_blocks = t.additional_blocks;
     } )
 let set_snapshot_ref ref_ snapshot =
-  Logs.info (fun m ->
+  Logs.app (fun m ->
       m "New protocol snapshot hash: %s" (snapshot.hash |> BLAKE2B.to_string));
   Atomic.set ref_ (Some snapshot)
 let start_new_epoch t =


### PR DESCRIPTION
<!---
  if some of the following sections doesn't apply,
  delete the section.

  Also feel free to delete the comments.
--->


## Problem
There's no way to tell when we hashed a new snapshot as of #604

<!--- Restate the problem addressed by the PR here --->

## Solution

This is a hacky solution - just put it on the `app` log level. A better solution would be to understand how `Logs` actually works, and use Cmdliner to control it. I've started this in #630.
