### PR TITLE
set networking_mode to "host"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,6 +130,7 @@ services:
     container_name: deku_prometheus
     restart: always
     image: prom/prometheus
+    network_mode: host
     ports:
       - "9090:9090"
     expose:

--- a/dummy_ticket.mligo
+++ b/dummy_ticket.mligo
@@ -38,7 +38,7 @@ type parameter =
       handle : vault_handle_structure;
       proof : vault_handle_proof;
     }
-  | Burn_callback of bytes ticket
+  | Burn_callback of vault_deposit
 
 type return = operation list * unit
 
@@ -74,7 +74,7 @@ let main ((param, ()) : parameter * unit) : return =
     -> 
       let ticket = Tezos.create_ticket ticket_data ticket_amount in
       let deposit_operation  = deposit_to_deku deku_consensus ticket deku_recipient in
-      ([ deposit_operation  ], ())
+      ([ deposit_operation ], ())
   | Withdraw_from_deku {deku_consensus; handles_hash; handle; proof} ->
       let callback : vault_ticket contract = Tezos.self "%burn_callback" in
       let withdraw_operation =


### PR DESCRIPTION
    The Prometheus server is broken when running in local mode
    because it is configured to connect with the targets running
    on localhost per prometheus.yml. By adding the
    "network_mode: host" option to our docker-compose.yml
    we can let prometheus talk to the targets in local mode as well as in the
    Tilt configuration
 