### PR TITLE
chore: remove x86_64-darwin from CI

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest,  macos-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        system: [ubuntu, macos]
+        system: [ubuntu]
 
     runs-on: ${{ matrix.system }}-latest
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ A sidechain to Tezos by Marigold focused on higher throughput.
 
 ### Pre-requisites
 
+Deku supports the following platforms: x86_64-linux, aarch64-linux, and
+aarch64-darwin (Mac M1).
+
 You'll need a one of the two package managers Deku is developed with:
 
 #### [Esy](https://esy.sh)

--- a/flake.nix
+++ b/flake.nix
@@ -49,8 +49,7 @@
   outputs = { self, nixpkgs, flake-utils, nix-filter, dream2nix, ocaml-overlays
     , prometheus-web, tezos, json-logs-reporter }:
     let
-      supportedSystems =
-        [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
 
       dream2nix-lib = dream2nix.lib2.init {
         systems = supportedSystems;


### PR DESCRIPTION
No one on the team is using x86_64-darwin, and
it's slowing down our CI. Let's remove it.
