### PR TITLE
feat: block by level RPC

### DIFF
--- a/src/bin/deku_node.ml
+++ b/src/bin/deku_node.ml
@@ -68,12 +68,26 @@ let handle_block_by_hash =
       Ok block)
 
 (* POST /block-level *)
-(* Retrieve height of the chain? *)
+(* Retrieve height of the chain *)
 let handle_block_level =
   handle_request
     (module Network.Block_level)
     (fun _update_state _request ->
       Ok { level = Flows.find_block_level (Server.get_state ()) })
+
+(* POST /block-by-level *)
+(* Retrieves the block at the given level if it exists *)
+let handle_block_by_level =
+  handle_request
+    (module Network.Block_by_level_spec)
+    (fun _update_state request ->
+      let state = Server.get_state () in
+      let block =
+        List.find_opt
+          (fun block ->
+            Int64.equal block.Protocol.Block.block_height request.level)
+          state.applied_blocks in
+      Ok block)
 
 (* POST /protocol-snapshot *)
 (* Get the snapshot of the protocol (last block and associated signature) *)
@@ -176,6 +190,7 @@ let node folder prometheus_port =
              handle_received_block_and_signature;
              handle_received_signature;
              handle_block_by_hash;
+             handle_block_by_level;
              handle_protocol_snapshot;
              handle_request_nonce;
              handle_register_uri;

--- a/src/network/network_packet.ml
+++ b/src/network/network_packet.ml
@@ -35,6 +35,14 @@ module Block_by_hash_spec = struct
   let path = "/block-by-hash"
 end
 
+module Block_by_level_spec = struct
+  type request = { level : int64 } [@@deriving yojson]
+
+  type response = Block.t option [@@deriving yojson]
+
+  let path = "/block-by-level"
+end
+
 module Block_level = struct
   type request = unit [@@deriving yojson]
 

--- a/src/node/state.mli
+++ b/src/node/state.mli
@@ -23,6 +23,7 @@ type t = {
   data_folder : string;
   pending_operations : float Operation_map.t;
   block_pool : Block_pool.t;
+  applied_blocks : Block.t list;
   protocol : Protocol.t;
   snapshots : Snapshots.t;
   uri_state : string Uri_map.t;


### PR DESCRIPTION
Successor to #536

## Problem

There is no way to inspect the contents of blocks from outside a deku node.

## Solution

Add a `block-by-level` rpc that takes a block level as an int and returns the block with that block height, or `null` if it doesn't know the contents of that block.

This is a workaround to the fact we have no indexer, see #535. But it's pretty essential for using Deku at all, so I think the work-around is justified for now.

