### PR TITLE
fix: use absolute path for PATH in shell.nix

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,7 +1,8 @@
 { pkgs, system, deku, ligo, nodejs ? pkgs.nodejs }:
 pkgs.mkShell {
   shellHook = ''
-    export PATH=_build/install/default/bin:$PATH
+    export PATH="$(pwd)/_build/install/default/bin:$PATH"
+
     # This is a flag picked up by our sandbox.sh that's used
     # to know when to use esy instead of nix.
     # You can turn this off with the command 'unset USE_NIX'.


### PR DESCRIPTION

## Depends
- [ ] #645 

## Problem

Our `PATH` is relative in shell.nix, which breaks things when you're working in deep directories.

## Solution
Use absolute path.
