### PR TITLE
Fix contract originated address

### DIFF
--- a/src/core_deku/state.mli
+++ b/src/core_deku/state.mli
@@ -13,6 +13,7 @@ val contract_storage : t -> Contract_storage.t
 
 val hash : t -> BLAKE2B.t
 
-val apply_user_operation : t -> User_operation.t -> t * receipt option
+val apply_user_operation :
+  t -> BLAKE2B.t -> User_operation.t -> t * receipt option
 
 val apply_tezos_operation : t -> Tezos_operation.t -> t

--- a/src/protocol/protocol.ml
+++ b/src/protocol/protocol.ml
@@ -33,8 +33,8 @@ let apply_core_tezos_operation state tezos_operation =
   | Error `Duplicated_operation -> state
 
 let apply_core_user_operation state user_operation =
-  let Core_user.
-        { hash = _; key = _; signature = _; nonce = _; block_height; data } =
+  let Core_user.{ hash; key = _; signature = _; nonce = _; block_height; data }
+      =
     user_operation in
   let%assert () = (`Block_in_the_future, block_height <= state.block_height) in
   let%assert () =
@@ -48,7 +48,7 @@ let apply_core_user_operation state user_operation =
   let included_user_operations =
     User_operation_set.add user_operation state.included_user_operations in
   let core_state, receipt =
-    Core_deku.State.apply_user_operation state.core_state data in
+    Core_deku.State.apply_user_operation state.core_state hash data in
   Ok ({ state with core_state; included_user_operations }, receipt)
 
 let apply_core_user_operation state tezos_operation =

--- a/tests/contracts/test_invocation.ml
+++ b/tests/contracts/test_invocation.ml
@@ -75,9 +75,9 @@ let test_ok msg =
     |> Result.get_ok in
   let operation = User_operation.Contract_origination payload in
   let user_op = User_operation.make ~source:address operation in
-  let contract_address =
-    user_op.hash |> Contract_address.of_user_operation_hash in
-  let state, _ = State.apply_user_operation initial_state user_op in
+  let mock_hash = BLAKE2B.hash "mocked op hash" in
+  let contract_address = mock_hash |> Contract_address.of_user_operation_hash in
+  let state, _ = State.apply_user_operation initial_state mock_hash user_op in
   let init_storage = State.contract_storage state in
   let payload =
     Contract_vm.Invocation_payload.lambda_of_yojson
@@ -87,7 +87,7 @@ let test_ok msg =
     User_operation.Contract_invocation
       { to_invoke = contract_address; argument = payload } in
   let operation = User_operation.make ~source:address operation in
-  let state, _ = State.apply_user_operation state operation in
+  let state, _ = State.apply_user_operation state mock_hash operation in
   let new_storage = State.contract_storage state in
   let old_contract =
     Contract_storage.get_contract ~address:contract_address init_storage
@@ -114,9 +114,9 @@ let test_failure msg =
     |> Result.get_ok in
   let operation = User_operation.Contract_origination payload in
   let user_op = User_operation.make ~source:address operation in
-  let contract_address =
-    user_op.hash |> Contract_address.of_user_operation_hash in
-  let state, _ = State.apply_user_operation initial_state user_op in
+  let mock_hash = BLAKE2B.hash "mocked op hash" in
+  let contract_address = mock_hash |> Contract_address.of_user_operation_hash in
+  let state, _ = State.apply_user_operation initial_state mock_hash user_op in
   let init_storage = State.contract_storage state in
   let payload =
     Contract_vm.Invocation_payload.lambda_of_yojson
@@ -126,7 +126,7 @@ let test_failure msg =
     User_operation.Contract_invocation
       { to_invoke = contract_address; argument = payload } in
   let operation = User_operation.make ~source:address operation in
-  let state, _ = State.apply_user_operation state operation in
+  let state, _ = State.apply_user_operation state mock_hash operation in
   let new_storage = State.contract_storage state in
   let old_contract =
     Contract_storage.get_contract ~address:contract_address init_storage
@@ -148,9 +148,9 @@ let test_dummy_ok msg =
   let payload = Contract_vm.Origination_payload.dummy_of_yojson ~storage:0 in
   let operation = User_operation.Contract_origination payload in
   let user_op = User_operation.make ~source:address operation in
-  let contract_address =
-    user_op.hash |> Contract_address.of_user_operation_hash in
-  let state, _ = State.apply_user_operation initial_state user_op in
+  let mock_hash = BLAKE2B.hash "mocked op hash" in
+  let contract_address = mock_hash |> Contract_address.of_user_operation_hash in
+  let state, _ = State.apply_user_operation initial_state mock_hash user_op in
   let init_storage = State.contract_storage state in
   let payload =
     Contract_vm.Invocation_payload.dummy_of_yojson ~arg:(`List [`Int 0; `Int 1])
@@ -159,7 +159,7 @@ let test_dummy_ok msg =
     User_operation.Contract_invocation
       { to_invoke = contract_address; argument = payload } in
   let operation = User_operation.make ~source:address operation in
-  let state, _ = State.apply_user_operation state operation in
+  let state, _ = State.apply_user_operation state mock_hash operation in
   let new_storage = State.contract_storage state in
   let old_contract =
     Contract_storage.get_contract ~address:contract_address init_storage
@@ -181,9 +181,9 @@ let test_dummy_failure msg =
   let payload = Contract_vm.Origination_payload.dummy_of_yojson ~storage:0 in
   let operation = User_operation.Contract_origination payload in
   let user_op = User_operation.make ~source:address operation in
-  let contract_address =
-    user_op.hash |> Contract_address.of_user_operation_hash in
-  let state, _ = State.apply_user_operation initial_state user_op in
+  let mock_hash = BLAKE2B.hash "mocked op hash" in
+  let contract_address = mock_hash |> Contract_address.of_user_operation_hash in
+  let state, _ = State.apply_user_operation initial_state mock_hash user_op in
   let init_storage = State.contract_storage state in
   let payload =
     Contract_vm.Invocation_payload.lambda_of_yojson
@@ -193,7 +193,7 @@ let test_dummy_failure msg =
     User_operation.Contract_invocation
       { to_invoke = contract_address; argument = payload } in
   let operation = User_operation.make ~source:address operation in
-  let state, _ = State.apply_user_operation state operation in
+  let state, _ = State.apply_user_operation state mock_hash operation in
   let new_storage = State.contract_storage state in
   let old_contract =
     Contract_storage.get_contract ~address:contract_address init_storage

--- a/tests/contracts/test_origination.ml
+++ b/tests/contracts/test_origination.ml
@@ -75,7 +75,8 @@ let test msg =
     |> Result.get_ok in
   let operation = User_operation.Contract_origination payload in
   let user_op = User_operation.make ~source:address operation in
-  let state, _ = State.apply_user_operation initial_state user_op in
+  let mock_hash = BLAKE2B.hash "mocked op hash" in
+  let state, _ = State.apply_user_operation initial_state mock_hash user_op in
   [
     Alcotest.test_case msg `Quick (fun () ->
         Alcotest.(check' bool)
@@ -92,7 +93,8 @@ let test_dummy msg =
   let payload = Contract_vm.Origination_payload.dummy_of_yojson ~storage in
   let operation = User_operation.Contract_origination payload in
   let user_op = User_operation.make ~source:address operation in
-  let state, _ = State.apply_user_operation initial_state user_op in
+  let mock_hash = BLAKE2B.hash "mocked op hash" in
+  let state, _ = State.apply_user_operation initial_state mock_hash user_op in
   [
     Alcotest.test_case msg `Quick (fun () ->
         Alcotest.(check' bool)


### PR DESCRIPTION
<!---
  if some of the following sections doesn't apply,
  delete the section.

  Also feel free to delete the comments.
--->

## Problem

<!--- Restate the problem addressed by the PR here --->

Contract origination is using the  hash of the `User_operation`, which is the same for the same `sender * code * storage` triple. The would make possible to overwrite a contract's storage with it's initial value, also making not possible for an implicit account to have multiple contracts with same initial state.

## Solution

Use the protocol operation hash instead, which depends on stuff like block height and nonce. Also adds an endpoint for making possible to test it.

<!--- Restate the basic ideas behind your solution --->
<!--- Here it is also a good space to put details of your implementation --->

 