### PR TITLE
fix: override jsonrpc to a working commit

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -23,6 +23,18 @@ in {
         propagatedBuildInputs =
           prev.lib.lists.remove osuper.uuidm o.propagatedBuildInputs;
       });
+      jsonrpc = osuper.jsonrpc.overrideAttrs (o: {
+        src = if prev.lib.versionAtLeast ocamlVersion "5.00" then
+          prev.fetchFromGitHub {
+            owner = "ulrikstrid";
+            repo = "ocaml-lsp";
+            fetchSubmodules = true;
+            rev = "191f65ab82efc56c370e9e3122123590b96071fd";
+            sha256 = "sha256-FqQzh+SvRmZ6xTdcyr0iF3EE+8o+I9LSUJ5FgI5UyoU=";
+          }
+        else
+          o.src;
+      });
 
       # disable broken tests
       dream = disableCheck osuper.dream;

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -24,7 +24,7 @@ in {
           prev.lib.lists.remove osuper.uuidm o.propagatedBuildInputs;
       });
       jsonrpc = osuper.jsonrpc.overrideAttrs (o: {
-        src = if prev.lib.versionAtLeast ocamlVersion "5.00" then
+        src = if prev.lib.versionAtLeast oself.ocaml.version "5.00" then
           prev.fetchFromGitHub {
             owner = "ulrikstrid";
             repo = "ocaml-lsp";


### PR DESCRIPTION
## Problem

Our nix setup isn't working because a commit was removed that was referenced from https://github.com/anmonteiro/nix-overlays. 

## Solution

@ulrikstrid created a working patch in his fork.
