### PR TITLE
[d4hines] feat: batches of operations

### DIFF
--- a/src/bin/deku_node.ml
+++ b/src/bin/deku_node.ml
@@ -146,7 +146,6 @@ let handle_receive_user_operations_gossip =
     (module Network.User_operations_gossip)
     (fun update_state request ->
       let operations = request.user_operations in
-      Log.debug "packed: %d\n%!" (List.length operations);
       List.fold_left_ok
         (fun () operation ->
           (* TODO: quadratic function *)

--- a/src/bin/deku_node.ml
+++ b/src/bin/deku_node.ml
@@ -139,6 +139,21 @@ let handle_receive_user_operation_gossip =
       Flows.received_user_operation (Server.get_state ()) update_state
         request.user_operation)
 
+(* POST /user-operations-gossip *)
+(* Propagate a batch of user operations (core_user.t) over gossip network *)
+let handle_receive_user_operations_gossip =
+  handle_request
+    (module Network.User_operations_gossip)
+    (fun update_state request ->
+      let operations = request.user_operations in
+      Log.debug "packed: %d\n%!" (List.length operations);
+      List.fold_left_ok
+        (fun () operation ->
+          (* TODO: quadratic function *)
+          Flows.received_user_operation (Server.get_state ()) update_state
+            operation)
+        () operations)
+
 (* POST /consensus-operation-gossip *)
 (* Add operation from consensu to pending operations *)
 let handle_receive_consensus_operation =
@@ -199,6 +214,7 @@ let node folder prometheus_port =
              handle_request_nonce;
              handle_register_uri;
              handle_receive_user_operation_gossip;
+             handle_receive_user_operations_gossip;
              handle_receive_consensus_operation;
              handle_withdraw_proof;
              handle_ticket_balance;

--- a/src/network/network.ml
+++ b/src/network/network.ml
@@ -26,6 +26,8 @@ let broadcast_user_operation_gossip_to_list =
 
 let request_user_operation_gossip = request (module User_operation_gossip)
 
+let request_user_operations_gossip = request (module User_operations_gossip)
+
 let request_consensus_operation = request (module Consensus_operation_gossip)
 
 let request_trusted_validator_membership =

--- a/src/network/network_packet.ml
+++ b/src/network/network_packet.ml
@@ -100,6 +100,15 @@ module User_operation_gossip = struct
   let path = "/user-operation-gossip"
 end
 
+module User_operations_gossip = struct
+  type request = { user_operations : Protocol.Operation.Core_user.t list }
+  [@@deriving yojson]
+
+  type response = unit [@@deriving yojson]
+
+  let path = "/user-operations-gossip"
+end
+
 module Consensus_operation_gossip = struct
   type request = {
     consensus_operation : Protocol.Operation.Consensus.t;


### PR DESCRIPTION
## Depends

- [ ] #647 

## Problem

We currently don't have any way for users to send batch operations. This kills our TPS, especially since our networking layer is not optimized currently.

## Solution

Add a `User_operations_gossip` network message (note the plural tense).




<!---GHSTACKOPEN-->
### Stacked PR Chain: d4hines
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#691|fix: fix prometheus with tilt|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/691?label=Pending)|-|
|#647|feat: block rate and transaction rate metrics  d4hines/block-rate-and-tps|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/647?label=Approved)|#691|
|#658|👉chore: refactor cli terms                      d4hines/batch-operations|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/658?label=Pending)|#647|
|#681|chore: refactor config out of node state|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/681?label=Pending)|#658|
|#668|make minimum block time configurable|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/668?label=Pending)|#658|
|#539|Benchmarking: ticket transfers                 d4hines/ticket-transfer-benchmarking|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/539?label=Approved)|#658|
<!---GHSTACKCLOSE-->



