### PR TITLE
Annoying debug messages: upgrading piaf and dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
     "crane": {
       "flake": false,
       "locked": {
-        "lastModified": 1644785799,
-        "narHash": "sha256-VpAJO1L0XeBvtCuNGK4IDKp6ENHIpTrlaZT7yfBCvwo=",
+        "lastModified": 1654444508,
+        "narHash": "sha256-4OBvQ4V7jyt7afs6iKUvRzJ1u/9eYnKzVQbeQdiamuY=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "fc7a94f841347c88f2cb44217b2a3faa93e2a0b2",
+        "rev": "db5482bf225acc3160899124a1df5a617cfa27b5",
         "type": "github"
       },
       "original": {
@@ -38,10 +38,27 @@
         "type": "github"
       }
     },
+    "devshell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1653917170,
+        "narHash": "sha256-FyxOnEE/V4PNEcMU62ikY4FfYPo349MOhMM97HS0XEo=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "fc7a3e3adde9bbcab68af6d1e3c6eb738e296a92",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
     "dream2nix": {
       "inputs": {
         "alejandra": "alejandra",
         "crane": "crane",
+        "devshell": "devshell",
         "flake-utils-pre-commit": "flake-utils-pre-commit",
         "gomod2nix": "gomod2nix",
         "mach-nix": "mach-nix",
@@ -53,11 +70,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1653135531,
-        "narHash": "sha256-pYwJrEQrG8BgeVcI+lveK3KbOBDx9MT28HxV09v+jgI=",
+        "lastModified": 1654451959,
+        "narHash": "sha256-yWztC96o8Dw65jDbmNUxV1i61T3uLqvqhC3ziwnB/Fk=",
         "owner": "nix-community",
         "repo": "dream2nix",
-        "rev": "4b3dfb101fd2fdbe25bd128072f138276aa4bc82",
+        "rev": "90b353682ef927bd39b59085e0dc6b7454888de7",
         "type": "github"
       },
       "original": {
@@ -68,11 +85,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
         "type": "github"
       },
       "original": {
@@ -171,11 +188,11 @@
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1649838635,
-        "narHash": "sha256-P1h48+l9vUvMz4JwHBgkTXiX6mE8oYR75vBVUbe6Cuc=",
+        "lastModified": 1653590866,
+        "narHash": "sha256-E4yKIrt/S//WfW5D9IhQ1dVuaAy8RE7EiCMfnbrOC78=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "40a58baa248a8b335e2d66ca258a74248af9d834",
+        "rev": "3e81a637cdf9f6e9b39aeb4d6e6394d1ad158e16",
         "type": "github"
       },
       "original": {
@@ -186,11 +203,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1653060744,
-        "narHash": "sha256-kfRusllRumpt33J1hPV+CeCCylCXEU7e0gn2/cIM7cY=",
+        "lastModified": 1654230545,
+        "narHash": "sha256-8Vlwf0x8ow6pPOK2a04bT+pxIeRnM1+O0Xv9/CuDzRs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dfd82985c273aac6eced03625f454b334daae2e8",
+        "rev": "236cc2971ac72acd90f0ae3a797f9f83098b17ec",
         "type": "github"
       },
       "original": {
@@ -226,11 +243,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1653401415,
-        "narHash": "sha256-yugn7ODU/dLpn7Bqv3wozcKJsByOd6vvOIGgSGOJbJU=",
+        "lastModified": 1654363376,
+        "narHash": "sha256-J/isefhczw2KElNzmxJcjUetC+5dlvorYimlh9Gn9CA=",
         "owner": "anmonteiro",
         "repo": "nix-overlays",
-        "rev": "afa9af9f6525ddeb8868816e4bd71b631cdb1193",
+        "rev": "f553d0457f13a6562605d5fb12b6322e8d8c48a1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -47,19 +47,9 @@
     , prometheus-web, tezos, json-logs-reporter }:
     let
       supportedSystems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
-
-      dream2nix-lib = dream2nix.lib2.init {
-        systems = supportedSystems;
-        config.projectRoot = ./.;
-      };
     in with flake-utils.lib;
     eachSystem supportedSystems (system:
       let
-        nodejs = pkgs.nodejs-16_x;
-
-        ligo = (import nixpkgs { inherit system; }).ligo.overrideAttrs
-          (_: { meta = { platforms = pkgs.ocaml.meta.platforms; }; });
-
         pkgs = (ocaml-overlays.makePkgs { inherit system; }).appendOverlays [
           (import ./nix/overlay.nix)
           prometheus-web.overlays.default
@@ -68,6 +58,15 @@
         ];
 
         pkgs_static = pkgs.pkgsCross.musl64;
+
+        dream2nix-lib = dream2nix.lib.init {
+          inherit pkgs;
+          config.projectRoot = ./.;
+        };
+        nodejs = pkgs.nodejs-16_x;
+
+        ligo = (import nixpkgs { inherit system; }).ligo.overrideAttrs
+          (_: { meta = { platforms = pkgs.ocaml.meta.platforms; }; });
 
         npmPackages = import ./nix/npm.nix {
           inherit system dream2nix-lib nix-filter nodejs;

--- a/flake.nix
+++ b/flake.nix
@@ -45,8 +45,7 @@
 
   outputs = { self, nixpkgs, flake-utils, nix-filter, dream2nix, ocaml-overlays
     , prometheus-web, tezos, json-logs-reporter }:
-    let
-      supportedSystems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
+    let supportedSystems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
     in with flake-utils.lib;
     eachSystem supportedSystems (system:
       let

--- a/nix/npm.nix
+++ b/nix/npm.nix
@@ -1,7 +1,7 @@
 { system, dream2nix-lib, nix-filter, nodejs }:
 
 let
-  outputs = (dream2nix-lib.makeFlakeOutputs {
+  outputs = (dream2nix-lib.makeOutputs {
     source = nix-filter.lib.filter {
       root = ../.;
       include = [ ../package-lock.json ../package.json ];
@@ -18,7 +18,7 @@ let
     settings =
       [{ subsystemInfo.nodejs = (builtins.substring 0 2 nodejs.version); }];
   });
-  npmPackages = outputs.packages."${system}".sidechain;
+  npmPackages = outputs.packages.sidechain;
 
   node_modules' = builtins.attrValues
     (builtins.removeAttrs npmPackages.dependencies [ "webpack" ]);

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,7 +1,10 @@
 final: prev:
 let
   disableCheck = package: package.overrideAttrs (o: { doCheck = false; });
-  addCheckInputs = package: package.overrideAttrs ({ buildInputs ? [], checkInputs, ... }: { buildInputs = buildInputs ++ checkInputs; });
+  addCheckInputs = package:
+    package.overrideAttrs ({ buildInputs ? [ ], checkInputs, ... }: {
+      buildInputs = buildInputs ++ checkInputs;
+    });
 in {
   ocaml-ng = builtins.mapAttrs (_: ocamlVersion:
     ocamlVersion.overrideScope' (oself: osuper: {

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,5 +1,7 @@
 final: prev:
-let disableCheck = package: package.overrideAttrs (o: { doCheck = false; });
+let
+  disableCheck = package: package.overrideAttrs (o: { doCheck = false; });
+  addCheckInputs = package: package.overrideAttrs ({ buildInputs ? [], checkInputs, ... }: { buildInputs = buildInputs ++ checkInputs; });
 in {
   ocaml-ng = builtins.mapAttrs (_: ocamlVersion:
     ocamlVersion.overrideScope' (oself: osuper: {
@@ -35,6 +37,21 @@ in {
         else
           o.src;
       });
+
+      # Fix packages that don't have checkInputs as buildInputs (bug in nixpkgs)
+      # This is a problem for static builds mainly
+      stringext = addCheckInputs osuper.stringext;
+      duration = addCheckInputs osuper.duration;
+      cstruct = addCheckInputs osuper.cstruct;
+      psq = addCheckInputs osuper.psq;
+      faraday = addCheckInputs osuper.faraday;
+      ke = addCheckInputs osuper.ke;
+      base64 = addCheckInputs osuper.base64;
+      prettym = addCheckInputs osuper.prettym;
+      angstrom = addCheckInputs osuper.angstrom;
+      multipart_form = addCheckInputs osuper.multipart_form;
+      uri = addCheckInputs osuper.uri;
+      caqti = addCheckInputs osuper.caqti;
 
       # disable broken tests
       dream = disableCheck osuper.dream;

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -24,7 +24,6 @@ pkgs.mkShell {
       # formatters
       nixfmt
       nodePackages.prettier
-      ocamlformat
     ] ++ (pkgs.lib.optional (system != "x86_64-darwin") tilt)
     ++ (with pkgs.ocaml-ng.ocamlPackages_5_00; [
       # OCaml developer tooling

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -247,7 +247,7 @@ start_deku_cluster() {
   echo "Starting nodes."
   for i in "${VALIDATORS[@]}"; do
     if [ "$mode" = "local" ]; then
-      deku-node "$DATA_DIRECTORY/$i" --verbosity=${DEKU_LOG_VERBOSITY:-debug} --listen-prometheus="900$i" &
+      deku-node "$DATA_DIRECTORY/$i" --verbosity="${DEKU_LOG_VERBOSITY:-debug}" --listen-prometheus="900$i" &
       SERVERS+=($!)
     fi
   done

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -247,7 +247,7 @@ start_deku_cluster() {
   echo "Starting nodes."
   for i in "${VALIDATORS[@]}"; do
     if [ "$mode" = "local" ]; then
-      deku-node "$DATA_DIRECTORY/$i" --verbosity=debug --listen-prometheus="900$i" &
+      deku-node "$DATA_DIRECTORY/$i" --verbosity=${DEKU_LOG_VERBOSITY:-debug} --listen-prometheus="900$i" &
       SERVERS+=($!)
     fi
   done

--- a/src/tezos_rpc/http.ml
+++ b/src/tezos_rpc/http.ml
@@ -131,7 +131,7 @@ let http_get_listen ~uri =
   | Ok response ->
     (* TODO: how to cancel body_stream *)
     (* TODO: what to do with this promise?*)
-    let body_stream, _promise = Piaf.Body.to_string_stream response.body in
+    let%await body_stream, _promise = Piaf.Body.to_string_stream response.body in
     await (Ok body_stream)
   | Error err -> await (Error (Piaf_request err))
 


### PR DESCRIPTION
This PR is a draft because I need feedback regarding Nix.

## Problem

In his logging PR, @anchpop had to remove annoying debug messages from Piaf, and pin a specific commit of Piaf. His PR got accepted into Piaf so he removed the pin, but we didn't change the version we're using, and the debug messages are back.

Unfortunately, latest versions of Piaf use several dependencies that are not published, so the resulting esy file is a bit of a mess. Also I'm not sure about the state of affairs for Nix, can someone please take a look?

In the long run we should probably stop using Piaf.

(Sidenote: I should have tested logging one last time before merging and I'm sorry I didn't.)

## Solution

* Update Piaf
* Pin specific versions of `ocaml-sendfile` and `gluten` that are all required by Piaf
