### PR TITLE
[d4hines] make minimum block time configurable

### DIFF
--- a/sandbox.sh
+++ b/sandbox.sh
@@ -345,7 +345,7 @@ deposit_ticket() {
 deposit_withdraw_test() {
   # Deposit 100 tickets
   deposit_ticket | grep tezos-client | tr -d '\r'
-  sleep 10
+  sleep 20
 
   echo "{\"address\": \"$DEKU_ADDRESS\", \"priv_key\": \"$DEKU_PRIVATE_KEY\"}" > wallet.json
 
@@ -361,7 +361,7 @@ deposit_withdraw_test() {
 
   # # We can withdraw 10 tickets from deku
   OPERATION_HASH=$(deku-cli withdraw data/0 ./wallet.json "$DUMMY_TICKET" 10 "Pair \"$DUMMY_TICKET\" 0x" | awk '{ print $2 }' | tr -d '\t\n\r')
-  sleep 10
+  sleep 20
 
   WITHDRAW_PROOF=$(deku-cli withdraw-proof data/0 "$OPERATION_HASH" "$DUMMY_TICKET%burn_callback" | tr -d '\t\n\r')
   if [ -z "$WITHDRAW_PROOF" ]; then

--- a/src/bin/deku_cli.ml
+++ b/src/bin/deku_cli.ml
@@ -639,7 +639,10 @@ let info_produce_block =
 
 let produce_block node_folder =
   let%await identity = read_identity ~node_folder in
-  let%await state = Node_state.get_initial_state ~folder:node_folder in
+  (* TODO: this should be refactored out of the CLI per https://github.com/marigold-dev/deku/issues/659 *)
+  let%await state =
+    Node_state.get_initial_state ~folder:node_folder ~minimum_block_delay:1.
+  in
   let address = identity.t in
   let block =
     Block.produce ~state:state.consensus.protocol ~next_state_root_hash:None

--- a/src/bin/deku_node.ml
+++ b/src/bin/deku_node.ml
@@ -178,8 +178,10 @@ let handle_ticket_balance =
           ~address:(Core_deku.Address.of_key_hash address) in
       Ok { amount })
 
-let node folder port prometheus_port =
-  let node = Node_state.get_initial_state ~folder |> Lwt_main.run in
+let node folder port minimum_block_delay prometheus_port =
+  let node =
+    Node_state.get_initial_state ~folder ~minimum_block_delay |> Lwt_main.run
+  in
   Tezos_interop.Consensus.listen_operations node.Node.State.interop_context
     ~on_operation:(fun operation -> Flows.received_tezos_operation operation);
   Node.Server.start ~initial:node;
@@ -249,7 +251,13 @@ let node =
     let doc = "Path to the folder containing the node configuration data." in
     let open Arg in
     required & pos 0 (some string) None & info [] ~doc ~docv in
-
+  let minimum_block_delay =
+    let docv = "minimum_block_delay" in
+    let doc =
+      "Determines the minimum time the node will wait before propagating a \
+       newly produced block." in
+    let open Arg in
+    value & opt float 5. & info ["minimum_block_delay"] ~doc ~docv in
   let json_logs =
     let docv = "Json logs" in
     let doc = "This determines whether logs will be printed in json format." in
@@ -267,6 +275,7 @@ let node =
   $ Logs_cli.level ()
   $ folder_node
   $ port
+  $ minimum_block_delay
   $ Prometheus_dream.opts
 
 let _ = Cmd.eval @@ Cmd.v (Cmd.info "deku-node") node

--- a/src/bin/node_state.ml
+++ b/src/bin/node_state.ml
@@ -3,7 +3,7 @@ open Protocol
 open Node
 open Consensus
 
-let get_initial_state ~folder =
+let get_initial_state ~folder ~minimum_block_delay =
   let%await identity = Files.Identity.read ~file:(folder ^ "/identity.json") in
   let trusted_validator_membership_change_file =
     folder ^ "/trusted-validator-membership-change.json" in
@@ -41,7 +41,7 @@ let get_initial_state ~folder =
   let persist_trusted_membership_change =
     Files.Trusted_validators_membership_change.write
       ~file:trusted_validator_membership_change_file in
-  let config = Config.make ~identity in
+  let config = Config.make ~identity ~minimum_block_delay in
   let node =
     State.make ~config ~trusted_validator_membership_change ~interop_context
       ~data_folder:folder ~initial_validators_uri

--- a/src/bin/node_state.mli
+++ b/src/bin/node_state.mli
@@ -1,1 +1,2 @@
-val get_initial_state : folder:string -> Node.State.t Lwt.t
+val get_initial_state :
+  folder:string -> minimum_block_delay:float -> Node.State.t Lwt.t

--- a/src/node/config.ml
+++ b/src/node/config.ml
@@ -1,3 +1,10 @@
-type t = { identity : Consensus.identity } [@@deriving yojson]
+type t = {
+  identity : Consensus.identity;
+  minimum_block_delay : float;
+}
+[@@deriving yojson]
 
-let make ~identity = { identity }
+let make ~identity ~minimum_block_delay =
+  if minimum_block_delay < 0. then
+    failwith "Minimum block delay must be positive";
+  { identity; minimum_block_delay }

--- a/src/node/config.mli
+++ b/src/node/config.mli
@@ -1,3 +1,7 @@
-type t = private { identity : Consensus.identity } [@@deriving yojson]
+type t = private {
+  identity : Consensus.identity;
+  minimum_block_delay : float;
+}
+[@@deriving yojson]
 
-val make : identity:Consensus.identity -> t
+val make : identity:Consensus.identity -> minimum_block_delay:float -> t


### PR DESCRIPTION
## Depends
- [ ] #648 

## Problem

Right now, Deku throttles itself to produce blocks every second. Users may want to configure this throttle.

Update:
As @EduardoRFS suggested in #692, this PR additionally implements a short-circuit to the delay if there are any pending operations and changes the default block delay to 5 seconds.

## Solution
Add an option at the command line to configure the throttle.




<!---GHSTACKOPEN-->
### Stacked PR Chain: d4hines
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#691|fix: fix prometheus with tilt|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/691?label=Pending)|-|
|#647|feat: block rate and transaction rate metrics  d4hines/block-rate-and-tps|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/647?label=Approved)|#691|
|#658|chore: refactor cli terms                      d4hines/batch-operations|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/658?label=Pending)|#647|
|#681|chore: refactor config out of node state|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/681?label=Pending)|#658|
|#668|👉make minimum block time configurable|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/668?label=Pending)|#658|
|#539|Benchmarking: ticket transfers                 d4hines/ticket-transfer-benchmarking|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/539?label=Approved)|#658|
<!---GHSTACKCLOSE-->



