### PR TITLE
protocol: split operations in a block

### DIFF
--- a/src/bin/deku_cli.ml
+++ b/src/bin/deku_cli.ml
@@ -598,7 +598,8 @@ let produce_block node_folder =
   let address = identity.t in
   let block =
     Block.produce ~state:state.protocol ~next_state_root_hash:None
-      ~author:address ~operations:[] in
+      ~author:address ~consensus_operations:[] ~tezos_operations:[]
+      ~user_operations:[] in
   let signature = Block.sign ~key:identity.secret block in
   let%await interop_context = interop_context node_folder in
   let%await validator_uris = validator_uris ~interop_context in

--- a/src/protocol/block.mli
+++ b/src/protocol/block.mli
@@ -9,7 +9,9 @@ type t = private {
   previous_hash : BLAKE2B.t;
   author : Key_hash.t;
   block_height : int64;
-  operations : Protocol_operation.t list;
+  consensus_operations : Protocol_operation.Consensus.t list;
+  tezos_operations : Protocol_operation.Core_tezos.t list;
+  user_operations : Protocol_operation.Core_user.t list;
 }
 [@@deriving yojson, ord]
 
@@ -21,5 +23,7 @@ val produce :
   state:Protocol_state.t ->
   next_state_root_hash:BLAKE2B.t option ->
   author:Key_hash.t ->
-  operations:Protocol_operation.t list ->
+  consensus_operations:Protocol_operation.Consensus.t list ->
+  tezos_operations:Protocol_operation.Core_tezos.t list ->
+  user_operations:Protocol_operation.Core_user.t list ->
   t


### PR DESCRIPTION
## Depends

- [x] #671

## Problem

To improve Deku TPS, one trick is to only parse user operations in a block after the block is accepted, but currently all Deku operations are grouped together in the block.operations fields, making so that to access one kind of operation you need to first parse all the other operations.

## Solution

As consensus_operations and tezos_operations, are both required for the consensus, I split the operations fields in the block, so that in future work we can make `user_operations` opaque and lazy.

## Warning

This code is not great, but I have plans to refactor it in the following days.