### PR TITLE
protocol: opaque user operations

### DIFF
--- a/src/node/building_blocks.ml
+++ b/src/node/building_blocks.ml
@@ -193,10 +193,10 @@ let add_block_to_pool state update_state block =
   update_state { state with block_pool }
 
 let apply_block state update_state block =
-  let%ok state = Node.apply_block state block in
-  Ok (update_state state)
+  let%ok state, user_operations = Node.apply_block state block in
+  Ok (update_state state, user_operations)
 
-let clean state update_state block =
+let clean state update_state user_operations block =
   (* TODO: definitely should separate on the pending *)
   let pending_operations =
     let remove_operations operations pending_operations =
@@ -218,7 +218,7 @@ let clean state update_state block =
       List.map
         (fun consensus_operation ->
           Protocol.Operation.Core_user consensus_operation)
-        block.Block.user_operations in
+        user_operations in
     state.State.pending_operations
     |> remove_operations consensus_operations
     |> remove_operations tezos_operations

--- a/src/node/flows.ml
+++ b/src/node/flows.ml
@@ -256,10 +256,10 @@ let rec try_to_apply_block state update_state block =
   let is_new_state_root_hash =
     not (BLAKE2B.equal state.protocol.state_root_hash block.state_root_hash)
   in
-  let%ok state = apply_block state update_state block in
+  let%ok state, user_operations = apply_block state update_state block in
   write_state_to_file (state.Node.data_folder ^ "/state.bin") state.protocol;
   !reset_timeout ();
-  let state = clean state update_state block in
+  let state = clean state update_state user_operations block in
   let state =
     if is_new_state_root_hash then (
       write_state_to_file

--- a/src/node/state.mli
+++ b/src/node/state.mli
@@ -46,7 +46,9 @@ val make :
 val apply_block :
   t ->
   Block.t ->
-  (t, [> `Invalid_block_when_applying | `Invalid_state_root_hash]) result
+  ( t * Protocol.Operation.Core_user.t list,
+    [> `Invalid_block_when_applying | `Invalid_state_root_hash] )
+  result
 
 val load_snapshot :
   snapshot:Snapshots.snapshot ->

--- a/src/protocol/block.mli
+++ b/src/protocol/block.mli
@@ -11,7 +11,7 @@ type t = private {
   block_height : int64;
   consensus_operations : Protocol_operation.Consensus.t list;
   tezos_operations : Protocol_operation.Core_tezos.t list;
-  user_operations : Protocol_operation.Core_user.t list;
+  user_operations : string;
 }
 [@@deriving yojson, ord]
 
@@ -27,3 +27,5 @@ val produce :
   tezos_operations:Protocol_operation.Core_tezos.t list ->
   user_operations:Protocol_operation.Core_user.t list ->
   t
+
+val parse_user_operations : t -> Protocol_operation.Core_user.t list


### PR DESCRIPTION
## Depends

- [x] #672

## Problem

Parsing blocks that contain a lot of user operations takes some considerable time, this leads to the block producer waiting the other validators to parse the user operations before they submit the signatures, making a bubble on our pipeline.

## Solution

As user_operations is not required to sign a block, we make it opaque and only parse it when actually applying a block

## Warning

This code is not great, it essentially suffers a bit from "prop drilling" but this is so that we avoid parsing the user operations more than once. But I will refactor this in the near future, so please bare with me.
