### PR TITLE
consensus: make the library usable

### DIFF
--- a/src/bin/files.mli
+++ b/src/bin/files.mli
@@ -1,7 +1,6 @@
 open Consensus
 open Node
 open State
-open Consensus
 
 exception Invalid_json of string
 

--- a/src/bin/files.mli
+++ b/src/bin/files.mli
@@ -1,6 +1,7 @@
 open Consensus
 open Node
 open State
+open Consensus
 
 exception Invalid_json of string
 

--- a/src/consensus/apply_block.ml
+++ b/src/consensus/apply_block.ml
@@ -9,12 +9,16 @@ let apply_block ~block state =
   (* TODO: handle this errors here *)
   let%ok protocol, user_operations, receipts =
     apply_block state.protocol block in
-  let snapshots =
+  let snapshots, snapshot_ref =
     if BLAKE2B.equal block.state_root_hash previous_protocol.state_root_hash
     then
-      state.snapshots
+      (state.snapshots, None)
     else
-      Snapshots.start_new_epoch state.snapshots in
+      let snapshots = Snapshots.start_new_epoch state.snapshots in
+      let snapshot_ref, snapshots =
+        Snapshots.add_snapshot_ref ~block_height:previous_protocol.block_height
+          snapshots in
+      (snapshots, Some snapshot_ref) in
 
   (* TODO: definitely should separate on the pending *)
   let pending_operations =
@@ -75,7 +79,13 @@ let apply_block ~block state =
   (* this is all the node is gonna see *)
   let applied_block_effect =
     Effect.Applied_block
-      { prev_protocol = previous_protocol; block; receipts; self_signed } in
+      {
+        prev_protocol = previous_protocol;
+        block;
+        receipts;
+        self_signed;
+        snapshot_ref;
+      } in
   let persist_trusted_membership_change_effect =
     Effect.Persist_trusted_membership_change
       { trusted_validator_membership_change } in

--- a/src/consensus/apply_block.ml
+++ b/src/consensus/apply_block.ml
@@ -73,13 +73,14 @@ let apply_block ~block state =
     | None -> None in
 
   (* this is all the node is gonna see *)
-  let effect =
+  let applied_block_effect =
     Effect.Applied_block
-      {
-        prev_protocol = previous_protocol;
-        block;
-        receipts;
-        trusted_validator_membership_change;
-        self_signed;
-      } in
-  Ok (state, Both (Effect effect, Can_produce_block))
+      { prev_protocol = previous_protocol; block; receipts; self_signed } in
+  let persist_trusted_membership_change_effect =
+    Effect.Persist_trusted_membership_change
+      { trusted_validator_membership_change } in
+  let effects =
+    Both
+      ( Effect applied_block_effect,
+        Effect persist_trusted_membership_change_effect ) in
+  Ok (state, Both (effects, Can_produce_block))

--- a/src/consensus/consensus.ml
+++ b/src/consensus/consensus.ml
@@ -20,6 +20,8 @@ let with_block effect block state =
 let with_signature effect ~hash ~signature state =
   Dispatch.dispatch effect (Check_signature { hash; signature }) state
 
+let with_timeout effect state = Dispatch.dispatch effect Can_produce_block state
+
 let with_operation effect operation state =
   Dispatch.dispatch effect (Check_operation { operation }) state
 

--- a/src/consensus/consensus.ml
+++ b/src/consensus/consensus.ml
@@ -11,7 +11,9 @@ type error =
   | `Invalid_block                   of string
   | `Invalid_block_when_applying
   | `Invalid_signature_for_this_hash
-  | `Not_a_validator ]
+  | `Not_a_validator
+  | `Failed_to_verify_payload
+  | `Invalid_signature_author ]
 
 let with_block effect block state =
   Dispatch.dispatch effect (Check_block { block }) state
@@ -23,6 +25,9 @@ let with_timeout effect state = Dispatch.dispatch effect Can_produce_block state
 
 let with_operation effect operation state =
   Dispatch.dispatch effect (Check_operation { operation }) state
+
+let with_trusted_validators_membership_change effect ~payload ~signature state =
+  Dispatch.dispatch effect (Check_validator_change { payload; signature }) state
 
 let new_snapshot_ref state protocol =
   let snapshot_ref, snapshots =

--- a/src/consensus/consensus.ml
+++ b/src/consensus/consensus.ml
@@ -29,12 +29,6 @@ let with_operation effect operation state =
 let with_trusted_validators_membership_change effect ~payload ~signature state =
   Dispatch.dispatch effect (Check_validator_change { payload; signature }) state
 
-let new_snapshot_ref state protocol =
-  let snapshot_ref, snapshots =
-    Snapshots.add_snapshot_ref ~block_height:protocol.Protocol.block_height
-      state.snapshots in
-  ({ state with snapshots }, snapshot_ref)
-
 module Snapshots = Snapshots
 module Trusted_validators_membership_change =
   Trusted_validators_membership_change

--- a/src/consensus/consensus.ml
+++ b/src/consensus/consensus.ml
@@ -1,18 +1,17 @@
 include State
 include Effect
 include Load_snapshot
+include Consensus_utils
 
 type t = state
 
-type 'a error =
-  [> `Already_known_block
+type error =
+  [ `Already_known_block
   | `Already_known_signature
   | `Invalid_block                   of string
   | `Invalid_block_when_applying
   | `Invalid_signature_for_this_hash
   | `Not_a_validator ]
-  as
-  'a
 
 let with_block effect block state =
   Dispatch.dispatch effect (Check_block { block }) state

--- a/src/consensus/consensus.ml
+++ b/src/consensus/consensus.ml
@@ -1,5 +1,6 @@
 include State
 include Effect
+include Load_snapshot
 
 type t = state
 

--- a/src/consensus/consensus.ml
+++ b/src/consensus/consensus.ml
@@ -24,6 +24,12 @@ let with_timeout effect state = Dispatch.dispatch effect Can_produce_block state
 let with_operation effect operation state =
   Dispatch.dispatch effect (Check_operation { operation }) state
 
+let new_snapshot_ref state protocol =
+  let snapshot_ref, snapshots =
+    Snapshots.add_snapshot_ref ~block_height:protocol.Protocol.block_height
+      state.snapshots in
+  ({ state with snapshots }, snapshot_ref)
+
 module Snapshots = Snapshots
 module Trusted_validators_membership_change =
   Trusted_validators_membership_change

--- a/src/consensus/consensus.ml
+++ b/src/consensus/consensus.ml
@@ -4,6 +4,16 @@ include Load_snapshot
 
 type t = state
 
+type 'a error =
+  [> `Already_known_block
+  | `Already_known_signature
+  | `Invalid_block                   of string
+  | `Invalid_block_when_applying
+  | `Invalid_signature_for_this_hash
+  | `Not_a_validator ]
+  as
+  'a
+
 let with_block effect block state =
   Dispatch.dispatch effect (Check_block { block }) state
 

--- a/src/consensus/consensus.ml
+++ b/src/consensus/consensus.ml
@@ -20,6 +20,9 @@ let with_block effect block state =
 let with_signature effect ~hash ~signature state =
   Dispatch.dispatch effect (Check_signature { hash; signature }) state
 
+let with_operation effect operation state =
+  Dispatch.dispatch effect (Check_operation { operation }) state
+
 module Snapshots = Snapshots
 module Trusted_validators_membership_change =
   Trusted_validators_membership_change

--- a/src/consensus/consensus.mli
+++ b/src/consensus/consensus.mli
@@ -29,14 +29,15 @@ val make :
   t
 
 type effect = private
-  | Request_block           of { hash : BLAKE2B.t }
-  | Request_previous_blocks of { block : Block.t }
-  | Broadcast_block         of { block : Block.t }
-  | Broadcast_signature     of {
+  | Request_block            of { hash : BLAKE2B.t }
+  | Request_previous_blocks  of { block : Block.t }
+  | Broadcast_block          of { block : Block.t }
+  | Broadcast_signature      of {
       hash : BLAKE2B.t;
       signature : Signature.t;
     }
-  | Applied_block           of {
+  | Broadcast_user_operation of { user_operation : Operation.Core_user.t }
+  | Applied_block            of {
       block : Block.t;
       receipts : (BLAKE2B.t * Core_deku.State.receipt) list;
       trusted_validator_membership_change :
@@ -61,6 +62,9 @@ val with_signature :
   signature:Signature.t ->
   t ->
   t * _ error list
+
+val with_operation :
+  (effect -> t -> unit) -> Operation.t -> t -> t * _ error list
 
 val load_snapshot :
   snapshot:Snapshots.snapshot ->

--- a/src/consensus/consensus.mli
+++ b/src/consensus/consensus.mli
@@ -43,32 +43,24 @@ type effect = private
         Trusted_validators_membership_change.Set.t;
     }
 
-val with_block :
-  (effect -> t -> unit) ->
-  Block.t ->
-  t ->
-  t
-  * [> `Already_known_block
-    | `Already_known_signature
-    | `Invalid_block                   of string
-    | `Invalid_block_when_applying
-    | `Invalid_signature_for_this_hash
-    | `Not_a_validator ]
-    list
+type 'a error =
+  [> `Already_known_block
+  | `Already_known_signature
+  | `Invalid_block                   of string
+  | `Invalid_block_when_applying
+  | `Invalid_signature_for_this_hash
+  | `Not_a_validator ]
+  as
+  'a
+
+val with_block : (effect -> t -> unit) -> Block.t -> t -> t * _ error list
 
 val with_signature :
   (effect -> t -> unit) ->
   hash:BLAKE2B.t ->
   signature:Signature.t ->
   t ->
-  t
-  * [> `Already_known_block
-    | `Already_known_signature
-    | `Invalid_block                   of string
-    | `Invalid_block_when_applying
-    | `Invalid_signature_for_this_hash
-    | `Not_a_validator ]
-    list
+  t * _ error list
 
 val load_snapshot :
   snapshot:Snapshots.snapshot ->
@@ -76,14 +68,7 @@ val load_snapshot :
   last_block:Block.t ->
   last_block_signatures:Signature.t list ->
   t ->
-  ( t,
-    [> `Already_known_block
-    | `Already_known_signature
-    | `Invalid_block                   of string
-    | `Invalid_block_when_applying
-    | `Invalid_signature_for_this_hash
-    | `Not_a_validator ] )
-  result
+  (t, _ error) result
 
 module Snapshots = Snapshots
 module Trusted_validators_membership_change =

--- a/src/consensus/consensus.mli
+++ b/src/consensus/consensus.mli
@@ -44,34 +44,27 @@ type effect = private
         Trusted_validators_membership_change.Set.t;
     }
 
-type 'a error =
-  [> `Already_known_block
+type error =
+  [ `Already_known_block
   | `Already_known_signature
   | `Invalid_block                   of string
   | `Invalid_block_when_applying
   | `Invalid_signature_for_this_hash
   | `Not_a_validator ]
-  as
-  'a
 
-val with_block : (effect -> t -> unit) -> Block.t -> t -> t * _ error list
+val with_block : (effect -> t -> unit) -> Block.t -> t -> t * [> error] list
 
 val with_signature :
   (effect -> t -> unit) ->
   hash:BLAKE2B.t ->
   signature:Signature.t ->
   t ->
-  t * _ error list
+  t * [> error] list
 
-val with_timeout :
-  (effect -> t -> unit) ->
-  hash:BLAKE2B.t ->
-  signature:Signature.t ->
-  t ->
-  t * _ error list
+val with_timeout : (effect -> t -> unit) -> t -> t * [> error] list
 
 val with_operation :
-  (effect -> t -> unit) -> Operation.t -> t -> t * _ error list
+  (effect -> t -> unit) -> Operation.t -> t -> t * [> error] list
 
 val load_snapshot :
   snapshot:Snapshots.snapshot ->
@@ -79,7 +72,13 @@ val load_snapshot :
   last_block:Block.t ->
   last_block_signatures:Signature.t list ->
   t ->
-  (t, _ error) result
+  ( t,
+    [> error
+    | `Invalid_snapshot_height
+    | `Not_all_blocks_are_signed
+    | `Snapshots_with_invalid_hash
+    | `State_root_not_the_expected ] )
+  result
 
 module Snapshots = Snapshots
 module Trusted_validators_membership_change =

--- a/src/consensus/consensus.mli
+++ b/src/consensus/consensus.mli
@@ -63,6 +63,13 @@ val with_signature :
   t ->
   t * _ error list
 
+val with_timeout :
+  (effect -> t -> unit) ->
+  hash:BLAKE2B.t ->
+  signature:Signature.t ->
+  t ->
+  t * _ error list
+
 val with_operation :
   (effect -> t -> unit) -> Operation.t -> t -> t * _ error list
 

--- a/src/consensus/consensus.mli
+++ b/src/consensus/consensus.mli
@@ -10,7 +10,7 @@ type identity = {
   uri : Uri.t;
 }
 
-type state = private {
+type state = {
   (* TODO: duplicated on Node.State.t *)
   identity : identity;
   trusted_validator_membership_change :

--- a/src/consensus/consensus.mli
+++ b/src/consensus/consensus.mli
@@ -42,6 +42,8 @@ type effect = private
       receipts : (BLAKE2B.t * Core_deku.State.receipt) list;
       trusted_validator_membership_change :
         Trusted_validators_membership_change.Set.t;
+      prev_protocol : Protocol.t;
+      self_signed : Signatures.t option;
     }
 
 type error =

--- a/src/consensus/consensus.mli
+++ b/src/consensus/consensus.mli
@@ -82,6 +82,12 @@ val load_snapshot :
     | `State_root_not_the_expected ] )
   result
 
+val new_snapshot_ref : t -> Protocol.t -> t * Snapshots.snapshot_ref
+
+val block_matches_current_state_root_hash : state -> Block.t -> bool
+
+val block_matches_next_state_root_hash : state -> Block.t -> bool
+
 module Snapshots = Snapshots
 module Trusted_validators_membership_change =
   Trusted_validators_membership_change

--- a/src/consensus/consensus.mli
+++ b/src/consensus/consensus.mli
@@ -52,7 +52,9 @@ type error =
   | `Invalid_block                   of string
   | `Invalid_block_when_applying
   | `Invalid_signature_for_this_hash
-  | `Not_a_validator ]
+  | `Not_a_validator
+  | `Failed_to_verify_payload
+  | `Invalid_signature_author ]
 
 val with_block : (effect -> t -> unit) -> Block.t -> t -> t * [> error] list
 
@@ -67,6 +69,13 @@ val with_timeout : (effect -> t -> unit) -> t -> t * [> error] list
 
 val with_operation :
   (effect -> t -> unit) -> Operation.t -> t -> t * [> error] list
+
+val with_trusted_validators_membership_change :
+  (effect -> t -> unit) ->
+  payload:Network.Trusted_validators_membership_change.payload ->
+  signature:Signature.t ->
+  t ->
+  t * [> error] list
 
 val load_snapshot :
   snapshot:Snapshots.snapshot ->

--- a/src/consensus/consensus.mli
+++ b/src/consensus/consensus.mli
@@ -44,6 +44,7 @@ type effect = private
       receipts : (BLAKE2B.t * Core_deku.State.receipt) list;
       prev_protocol : Protocol.t;
       self_signed : Signatures.t option;
+      snapshot_ref : Snapshots.snapshot_ref option;
     }
   | Persist_trusted_membership_change of {
       trusted_validator_membership_change :
@@ -94,8 +95,6 @@ val load_snapshot :
     | `Snapshots_with_invalid_hash
     | `State_root_not_the_expected ] )
   result
-
-val new_snapshot_ref : t -> Protocol.t -> t * Snapshots.snapshot_ref
 
 val block_matches_current_state_root_hash : state -> Block.t -> bool
 

--- a/src/consensus/consensus.mli
+++ b/src/consensus/consensus.mli
@@ -29,21 +29,25 @@ val make :
   t
 
 type effect = private
-  | Request_block            of { hash : BLAKE2B.t }
-  | Request_previous_blocks  of { block : Block.t }
-  | Broadcast_block          of { block : Block.t }
-  | Broadcast_signature      of {
+  | Request_block                     of { hash : BLAKE2B.t }
+  | Request_previous_blocks           of { block : Block.t }
+  | Broadcast_block                   of { block : Block.t }
+  | Broadcast_signature               of {
       hash : BLAKE2B.t;
       signature : Signature.t;
     }
-  | Broadcast_user_operation of { user_operation : Operation.Core_user.t }
-  | Applied_block            of {
+  | Broadcast_user_operation          of {
+      user_operation : Operation.Core_user.t;
+    }
+  | Applied_block                     of {
       block : Block.t;
       receipts : (BLAKE2B.t * Core_deku.State.receipt) list;
-      trusted_validator_membership_change :
-        Trusted_validators_membership_change.Set.t;
       prev_protocol : Protocol.t;
       self_signed : Signatures.t option;
+    }
+  | Persist_trusted_membership_change of {
+      trusted_validator_membership_change :
+        Trusted_validators_membership_change.Set.t;
     }
 
 type error =

--- a/src/consensus/consensus.mli
+++ b/src/consensus/consensus.mli
@@ -70,6 +70,21 @@ val with_signature :
     | `Not_a_validator ]
     list
 
+val load_snapshot :
+  snapshot:Snapshots.snapshot ->
+  additional_blocks:Block.t list ->
+  last_block:Block.t ->
+  last_block_signatures:Signature.t list ->
+  t ->
+  ( t,
+    [> `Already_known_block
+    | `Already_known_signature
+    | `Invalid_block                   of string
+    | `Invalid_block_when_applying
+    | `Invalid_signature_for_this_hash
+    | `Not_a_validator ] )
+  result
+
 module Snapshots = Snapshots
 module Trusted_validators_membership_change =
   Trusted_validators_membership_change

--- a/src/consensus/consensus_utils.ml
+++ b/src/consensus/consensus_utils.ml
@@ -1,0 +1,63 @@
+open Helpers
+open Crypto
+open Protocol
+open State
+
+let block_matches_current_state_root_hash state block =
+  BLAKE2B.equal block.Block.state_root_hash state.protocol.state_root_hash
+
+let block_matches_next_state_root_hash state block =
+  match Snapshots.get_next_snapshot state.snapshots with
+  | Some { hash = next_state_root_hash; _ } ->
+    BLAKE2B.equal block.Block.state_root_hash next_state_root_hash
+  | None -> false
+
+let is_validator_address state address =
+  List.exists
+    (fun validator -> Key_hash.equal validator.Validators.address address)
+    (Validators.to_list state.protocol.validators)
+
+let is_known_block state ~hash =
+  match Block_pool.find_block ~hash state.block_pool with
+  | Some _block -> true
+  | None -> false
+
+let is_known_signature state ~hash ~signature =
+  match Block_pool.find_signatures ~hash state.block_pool with
+  | Some signatures -> Signatures.mem signature signatures
+  | None -> false
+
+let signatures_required state =
+  let number_of_validators = Validators.length state.protocol.validators in
+  let open Float in
+  to_int (ceil (of_int number_of_validators *. (2.0 /. 3.0)))
+
+let is_next state block = Protocol.is_next state.protocol block
+
+(* `Next means current_block_height + 1
+   `Future means current_block_height + 2 + n
+   `Past means current_block_height - n *)
+let is_future_block state block =
+  if is_next state block then
+    `Next
+  else if block.block_height > state.protocol.block_height then
+    `Future
+  else
+    `Past
+
+let is_signed_block_hash ~hash state =
+  match Block_pool.find_signatures ~hash state.block_pool with
+  | Some signatures -> Signatures.is_signed signatures
+  | None -> false
+
+let is_valid_block state block =
+  let is_all_operations_properly_signed _block = true in
+  let%assert () =
+    ( Printf.sprintf
+        "new block has a lower block height (%Ld) than the current state (%Ld)"
+        block.Block.block_height state.protocol.block_height,
+      block.Block.block_height >= state.protocol.block_height ) in
+  let%assert () =
+    ( "some operation in the block is not properly signed",
+      is_all_operations_properly_signed block ) in
+  Ok ()

--- a/src/consensus/dispatch.ml
+++ b/src/consensus/dispatch.ml
@@ -10,6 +10,8 @@ let rec dispatch effect step state =
     let state, err_left = dispatch effect left state in
     let state, err_right = dispatch effect right state in
     (state, err_left @ err_right)
+  | Check_operation { operation } -> check_operation ~operation effect state
+  | Append_operation { operation } -> append_operation ~operation effect state
   | Check_block { block } -> check_block ~block effect state
   | Append_block { block } -> append_block ~block effect state
   | Check_signature { hash; signature } ->
@@ -25,6 +27,14 @@ let rec dispatch effect step state =
   | Apply_block { block } -> apply_block ~block effect state
   | Can_produce_block -> can_produce_block effect state
   | Produce_block -> produce_block effect state
+
+and check_operation ~operation effect state =
+  let step = Steps.check_operation ~operation state in
+  dispatch effect step state
+
+and append_operation ~operation effect state =
+  let state, step = Steps.append_operation ~operation state in
+  dispatch effect step state
 
 and check_block ~block effect state =
   match Steps.check_block ~block state with

--- a/src/consensus/dispatch.ml
+++ b/src/consensus/dispatch.ml
@@ -30,9 +30,9 @@ let rec dispatch effect step state =
   | Check_validator_change { payload; signature } ->
     check_validator_change ~payload ~signature effect state
   | Allow_to_add_validator { key_hash } ->
-    allow_to_add_validator ~key_hash state
+    allow_to_add_validator ~key_hash effect state
   | Allow_to_remove_validator { key_hash } ->
-    allow_to_remove_validator ~key_hash state
+    allow_to_remove_validator ~key_hash effect state
 
 and check_operation ~operation effect state =
   let step = Steps.check_operation ~operation state in
@@ -98,10 +98,10 @@ and check_validator_change ~payload ~signature effect state =
   | Ok step -> dispatch effect step state
   | Error err -> (state, [err])
 
-and allow_to_add_validator ~key_hash state =
-  let state = Steps.allow_to_add_validator ~key_hash state in
-  (state, [])
+and allow_to_add_validator ~key_hash effect state =
+  let state, step = Steps.allow_to_add_validator ~key_hash state in
+  dispatch effect step state
 
-and allow_to_remove_validator ~key_hash state =
-  let state = Steps.allow_to_remove_validator ~key_hash state in
-  (state, [])
+and allow_to_remove_validator ~key_hash effect state =
+  let state, step = Steps.allow_to_remove_validator ~key_hash state in
+  dispatch effect step state

--- a/src/consensus/dispatch.ml
+++ b/src/consensus/dispatch.ml
@@ -27,6 +27,12 @@ let rec dispatch effect step state =
   | Apply_block { block } -> apply_block ~block effect state
   | Can_produce_block -> can_produce_block effect state
   | Produce_block -> produce_block effect state
+  | Check_validator_change { payload; signature } ->
+    check_validator_change ~payload ~signature effect state
+  | Allow_to_add_validator { key_hash } ->
+    allow_to_add_validator ~key_hash state
+  | Allow_to_remove_validator { key_hash } ->
+    allow_to_remove_validator ~key_hash state
 
 and check_operation ~operation effect state =
   let step = Steps.check_operation ~operation state in
@@ -86,3 +92,16 @@ and can_produce_block effect state =
 and produce_block effect state =
   let step = Produce_block.produce_block state in
   dispatch effect step state
+
+and check_validator_change ~payload ~signature effect state =
+  match Steps.check_validator_change ~payload ~signature state with
+  | Ok step -> dispatch effect step state
+  | Error err -> (state, [err])
+
+and allow_to_add_validator ~key_hash state =
+  let state = Steps.allow_to_add_validator ~key_hash state in
+  (state, [])
+
+and allow_to_remove_validator ~key_hash state =
+  let state = Steps.allow_to_remove_validator ~key_hash state in
+  (state, [])

--- a/src/consensus/effect.ml
+++ b/src/consensus/effect.ml
@@ -15,6 +15,8 @@ type effect =
       receipts : (BLAKE2B.t * Core_deku.State.receipt) list;
       trusted_validator_membership_change :
         Trusted_validators_membership_change.Set.t;
+      prev_protocol : Protocol.t;
+      self_signed : Signatures.t option;
     }
 
 type t = effect

--- a/src/consensus/effect.ml
+++ b/src/consensus/effect.ml
@@ -2,14 +2,15 @@ open Crypto
 open Protocol
 
 type effect =
-  | Request_block           of { hash : BLAKE2B.t }
-  | Request_previous_blocks of { block : Block.t }
-  | Broadcast_block         of { block : Block.t }
-  | Broadcast_signature     of {
+  | Request_block            of { hash : BLAKE2B.t }
+  | Request_previous_blocks  of { block : Block.t }
+  | Broadcast_block          of { block : Block.t }
+  | Broadcast_signature      of {
       hash : BLAKE2B.t;
       signature : Signature.t;
     }
-  | Applied_block           of {
+  | Broadcast_user_operation of { user_operation : Operation.Core_user.t }
+  | Applied_block            of {
       block : Block.t;
       receipts : (BLAKE2B.t * Core_deku.State.receipt) list;
       trusted_validator_membership_change :

--- a/src/consensus/effect.ml
+++ b/src/consensus/effect.ml
@@ -2,21 +2,25 @@ open Crypto
 open Protocol
 
 type effect =
-  | Request_block            of { hash : BLAKE2B.t }
-  | Request_previous_blocks  of { block : Block.t }
-  | Broadcast_block          of { block : Block.t }
-  | Broadcast_signature      of {
+  | Request_block                     of { hash : BLAKE2B.t }
+  | Request_previous_blocks           of { block : Block.t }
+  | Broadcast_block                   of { block : Block.t }
+  | Broadcast_signature               of {
       hash : BLAKE2B.t;
       signature : Signature.t;
     }
-  | Broadcast_user_operation of { user_operation : Operation.Core_user.t }
-  | Applied_block            of {
+  | Broadcast_user_operation          of {
+      user_operation : Operation.Core_user.t;
+    }
+  | Applied_block                     of {
       block : Block.t;
       receipts : (BLAKE2B.t * Core_deku.State.receipt) list;
-      trusted_validator_membership_change :
-        Trusted_validators_membership_change.Set.t;
       prev_protocol : Protocol.t;
       self_signed : Signatures.t option;
+    }
+  | Persist_trusted_membership_change of {
+      trusted_validator_membership_change :
+        Trusted_validators_membership_change.Set.t;
     }
 
 type t = effect

--- a/src/consensus/effect.ml
+++ b/src/consensus/effect.ml
@@ -17,6 +17,7 @@ type effect =
       receipts : (BLAKE2B.t * Core_deku.State.receipt) list;
       prev_protocol : Protocol.t;
       self_signed : Signatures.t option;
+      snapshot_ref : Snapshots.snapshot_ref option;
     }
   | Persist_trusted_membership_change of {
       trusted_validator_membership_change :

--- a/src/consensus/is_signable.mli
+++ b/src/consensus/is_signable.mli
@@ -1,1 +1,1 @@
-val is_signable : Protocol.Block.t -> State.t -> bool
+val is_signable : State.t -> Protocol.Block.t -> bool

--- a/src/consensus/load_snapshot.ml
+++ b/src/consensus/load_snapshot.ml
@@ -1,0 +1,100 @@
+open Helpers
+open Crypto
+open Protocol
+open State
+open Steps
+open Apply_block
+
+let load_snapshot ~snapshot ~additional_blocks ~last_block
+    ~last_block_signatures t =
+  let all_blocks =
+    last_block :: additional_blocks
+    |> List.sort (fun a b ->
+           let open Int64 in
+           to_int (sub a.Block.block_height b.Block.block_height)) in
+  let block_pool =
+    let block_pool =
+      List.fold_left
+        (fun block_pool block -> Block_pool.append_block block block_pool)
+        t.block_pool all_blocks in
+    let signatures_required = signatures_required t in
+    List.fold_left
+      (fun block_pool signature ->
+        Block_pool.append_signature ~signatures_required
+          ~hash:last_block.Block.hash signature block_pool)
+      block_pool last_block_signatures in
+  let%assert () =
+    ( `Not_all_blocks_are_signed,
+      List.for_all
+        (fun block -> Block_pool.is_signed ~hash:block.Block.hash block_pool)
+        all_blocks ) in
+  let%assert () =
+    ( `State_root_not_the_expected,
+      snapshot.Snapshots.hash = last_block.state_root_hash ) in
+  let%assert () =
+    ( `Snapshots_with_invalid_hash,
+      BLAKE2B.verify ~hash:snapshot.hash snapshot.data ) in
+  let of_yojson =
+    [%of_yojson:
+      Core_deku.State.t
+      * Tezos_operation_set.t
+      * User_operation_set.t
+      * Validators.t
+      * BLAKE2B.t
+      * int64
+      * BLAKE2B.t
+      * BLAKE2B.t] in
+  let ( core_state,
+        included_tezos_operations,
+        included_user_operations,
+        validators,
+        validators_hash,
+        block_height,
+        last_block_hash,
+        state_root_hash ) =
+    snapshot.data |> Yojson.Safe.from_string |> of_yojson |> Result.get_ok in
+  let protocol =
+    let open Protocol in
+    {
+      core_state;
+      included_tezos_operations;
+      included_user_operations;
+      validators;
+      validators_hash;
+      block_height;
+      last_block_hash;
+      state_root_hash;
+      last_state_root_update = 0.0;
+      last_applied_block_timestamp = 0.0;
+      last_seen_membership_change_timestamp = 0.0;
+    } in
+  (* TODO: this causes syncing to fail unless the snapshot is newer than the
+     current block height, which is not always true (i.e, if you restart
+     a node that's in sync very quickly. We need to have a more discerning
+     validation here. *)
+  let%assert () =
+    (`Invalid_snapshot_height, protocol.block_height > t.protocol.block_height)
+  in
+  let t = { t with protocol; block_pool } in
+  (* TODO: it doesn't seem valid to add a snapshot here based on the information received
+     from our (untrusted) peer; however, that's exactly what we're doing here. Supposing
+     the peer sending the snapshot is dishonest, we will then start propogating a bad snapshot.
+     In the future, we should only add snapshots once we're in sync. *)
+  List.fold_left_ok
+    (fun prev_state block ->
+      let%ok state, _step = apply_block ~block prev_state in
+      if
+        BLAKE2B.equal prev_state.protocol.state_root_hash
+          state.protocol.state_root_hash
+      then
+        Ok state
+      else
+        (* TODO: this should be done in parallel, as otherwise the node
+           may not be able to load the snapshot fast enough. *)
+        let hash, data = Protocol.hash prev_state.protocol in
+        let snapshot_ref, snapshots =
+          Snapshots.add_snapshot_ref
+            ~block_height:prev_state.protocol.block_height state.snapshots in
+        let () = Snapshots.set_snapshot_ref snapshot_ref { hash; data } in
+        Ok { state with snapshots })
+    t all_blocks

--- a/src/consensus/load_snapshot.ml
+++ b/src/consensus/load_snapshot.ml
@@ -2,7 +2,7 @@ open Helpers
 open Crypto
 open Protocol
 open State
-open Steps
+open Consensus_utils
 open Apply_block
 
 let load_snapshot ~snapshot ~additional_blocks ~last_block

--- a/src/consensus/steps.ml
+++ b/src/consensus/steps.ml
@@ -191,11 +191,20 @@ let allow_to_add_validator ~key_hash state =
     Trusted_validators_membership_change.Set.add
       { action = Add; address = key_hash }
       state.trusted_validator_membership_change in
-  { state with trusted_validator_membership_change }
+  let state = { state with trusted_validator_membership_change } in
+  let effect =
+    Effect.Persist_trusted_membership_change
+      { trusted_validator_membership_change } in
+  (state, Effect effect)
 
 let allow_to_remove_validator ~key_hash state =
   let trusted_validator_membership_change =
     Trusted_validators_membership_change.Set.add
       { action = Remove; address = key_hash }
       state.trusted_validator_membership_change in
-  { state with trusted_validator_membership_change }
+
+  let state = { state with trusted_validator_membership_change } in
+  let effect =
+    Effect.Persist_trusted_membership_change
+      { trusted_validator_membership_change } in
+  (state, Effect effect)

--- a/src/consensus/steps.ml
+++ b/src/consensus/steps.ml
@@ -122,12 +122,11 @@ let append_signature ~hash ~signature state =
   ({ state with block_pool }, Is_signed_block { hash })
 
 let is_signed_block ~hash state =
-  if is_signed_block_hash ~hash state then
-    match Block_pool.find_block ~hash state.block_pool with
-    | Some block -> Is_future_block { signed = Signed; block }
-    | None -> Effect (Request_block { hash })
-  else
-    Noop
+  let signed = if is_signed_block_hash ~hash state then Signed else Not_signed in
+  match (Block_pool.find_block ~hash state.block_pool, signed) with
+  | Some block, _ -> Is_future_block { signed; block }
+  | None, Signed -> Effect (Request_block { hash })
+  | None, Not_signed -> Noop
 
 (* TODO: this is checking too much*)
 let is_future_block ~signed ~block state =

--- a/src/node/flows.ml
+++ b/src/node/flows.ml
@@ -1,9 +1,9 @@
 open Helpers
 open Crypto
 open Protocol
-open Building_blocks
 open Domainslib
 open Consensus
+open Building_blocks
 module Node = State
 
 let write_state_to_file path protocol =


### PR DESCRIPTION
## Depends

- [ ] #674

## Problem

Following #674 we have a quite nicer consensus library, but it doesn't include all operations required by flows.ml.

## Solution

This PR provides all the tools needed to use the consensus library on Deku.

Mostly handling of operations and validators change was missing. Additionally a lot of small hacks are needed on the current solution so I decided to add even if that makes the consensus library itself a bit worse.