### PR TITLE
[d4hines] feat: make minimum block time configurable

### DIFF
--- a/src/bin/deku_cli.ml
+++ b/src/bin/deku_cli.ml
@@ -594,7 +594,10 @@ let info_produce_block =
 
 let produce_block node_folder =
   let%await identity = read_identity ~node_folder in
-  let%await state = Node_state.get_initial_state ~folder:node_folder in
+  (* TODO: this should be refactored out of the CLI per https://github.com/marigold-dev/deku/issues/659 *)
+  let%await state =
+    Node_state.get_initial_state ~folder:node_folder ~minimum_block_delay:1.
+  in
   let address = identity.t in
   let block =
     Block.produce ~state:state.protocol ~next_state_root_hash:None

--- a/src/bin/node_state.ml
+++ b/src/bin/node_state.ml
@@ -2,7 +2,7 @@ open Helpers
 open Protocol
 open Node
 
-let get_initial_state ~folder =
+let get_initial_state ~folder ~minimum_block_delay =
   let%await identity = Files.Identity.read ~file:(folder ^ "/identity.json") in
   let trusted_validator_membership_change_file =
     folder ^ "/trusted-validator-membership-change.json" in
@@ -40,7 +40,7 @@ let get_initial_state ~folder =
   let persist_trusted_membership_change =
     Files.Trusted_validators_membership_change.write
       ~file:trusted_validator_membership_change_file in
-  let config = Config.make ~identity in
+  let config = Config.make ~identity ~minimum_block_delay in
   let node =
     State.make ~config ~trusted_validator_membership_change ~interop_context
       ~data_folder:folder ~initial_validators_uri

--- a/src/bin/node_state.mli
+++ b/src/bin/node_state.mli
@@ -1,1 +1,2 @@
-val get_initial_state : folder:string -> Node.State.t Lwt.t
+val get_initial_state :
+  folder:string -> minimum_block_delay:float -> Node.State.t Lwt.t

--- a/src/node/building_blocks.ml
+++ b/src/node/building_blocks.ml
@@ -232,7 +232,7 @@ let broadcast_signature state ~hash ~signature =
 let broadcast_block_and_signature state ~block ~signature =
   let uris = validator_uris state in
   Lwt.async (fun () ->
-      let%await () = Lwt_unix.sleep 1.0 in
+      let%await () = Lwt_unix.sleep state.config.minimum_block_delay in
       Network.broadcast_block_and_signature uris { block; signature })
 
 let broadcast_user_operation_gossip state operation =

--- a/src/node/config.ml
+++ b/src/node/config.ml
@@ -12,6 +12,13 @@ type identity = {
 let make_identity ~secret ~key ~uri =
   { secret; key; t = Key_hash.of_key key; uri }
 
-type t = { identity : identity } [@@deriving yojson]
+type t = {
+  identity : identity;
+  minimum_block_delay : float;
+}
+[@@deriving yojson]
 
-let make ~identity = { identity }
+let make ~identity ~minimum_block_delay =
+  if minimum_block_delay < 0. then
+    failwith "Minimum block delay must be positive";
+  { identity; minimum_block_delay }

--- a/src/node/config.mli
+++ b/src/node/config.mli
@@ -9,6 +9,10 @@ type identity = private {
 val make_identity :
   secret:Crypto.Secret.t -> key:Crypto.Key.t -> uri:Uri.t -> identity
 
-type t = private { identity : identity } [@@deriving yojson]
+type t = private {
+  identity : identity;
+  minimum_block_delay : float;
+}
+[@@deriving yojson]
 
-val make : identity:identity -> t
+val make : identity:identity -> minimum_block_delay:float -> t


### PR DESCRIPTION
## Problem

Currently, we rate limit block production to 1 second. This is useful for normal manual testing, but doesn't make sense when you're trying to maximize throughput. We should make this configurable.


## Solution

Accept configuration for minimum block time at the command line

<!---GHSTACKOPEN-->
### Stacked PR Chain: d4hines
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#647|feat: block rate and transaction rate metrics  d4hines/block-rate-and-tps|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/647?label=Pending)|-|
|#658|chore: refactor cli terms                      d4hines/batch-operations|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/658?label=Pending)|#537|
|#681|chore: refactor config out of node state|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/681?label=Pending)|#658|
|#539|Benchmarking: ticket transfers                 d4hines/ticket-transfer-benchmarking|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/539?label=Approved)|#658|
|#668|make minimum block time configurable           d4hines/configurable-blocktime|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/668?label=Pending)|#658|
|#682|👉feat: make minimum block time configurable|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/682?label=Pending)|#681|
|#560|~~remove static.Dockerfile~~|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/560?label=%20)|-|
|#558|~~Simplify Sandbox.sh~~|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/558?label=%20)|-|
|#559|~~add gh-stack variable~~|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/559?label=%20)|-|
|#527|~~Dummy-ticket~~|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/527?label=%20)|-|
|#536|~~feat: add block-by-level rpc~~|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/536?label=Closed)|#527|
|#537|~~Add block rate and operation rate metrics~~|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/537?label=Closed)|#536|
<!---GHSTACKCLOSE-->
