### PR TITLE
Change Ticket table representation

### DIFF
--- a/src/core_deku/ledger.ml
+++ b/src/core_deku/ledger.ml
@@ -1,26 +1,6 @@
 open Helpers
 open Crypto
 
-module Address_and_ticket_map = struct
-  type key = {
-    address : Key_hash.t;
-    ticket : Ticket_id.t;
-  }
-  [@@deriving ord, yojson]
-
-  module Map = Map.Make_with_yojson (struct
-    type t = key [@@deriving ord, yojson]
-  end)
-
-  type t = Amount.t Map.t [@@deriving yojson]
-
-  let empty = Map.empty
-
-  let find_opt address ticket = Map.find_opt { address; ticket }
-
-  let add address ticket = Map.add { address; ticket }
-end
-
 module Withdrawal_handle = struct
   type t = {
     hash : BLAKE2B.t;
@@ -45,71 +25,50 @@ module Withdrawal_handle_tree = Incremental_patricia.Make (struct
 end)
 
 type t = {
-  ledger : Address_and_ticket_map.t;
+  table : Ticket_table.t;
   withdrawal_handles : Withdrawal_handle_tree.t;
 }
 [@@deriving yojson]
 
 let empty =
   {
-    ledger = Address_and_ticket_map.empty;
+    table = Ticket_table.empty;
     withdrawal_handles = Withdrawal_handle_tree.empty;
   }
 
 let balance address ticket t =
-  Address_and_ticket_map.find_opt address ticket t.ledger
+  Ticket_table.balance t.table ~sender:(Address.of_key_hash address) ~ticket
   |> Option.value ~default:Amount.zero
 
-let assert_available ~sender ~(amount : Amount.t) =
-  if sender >= amount then
-    Ok ()
-  else
-    Error `Not_enough_funds
-
 let transfer ~sender ~destination amount ticket t =
-  let open Amount in
-  let sender_balance = balance sender ticket t in
-  let%ok () = assert_available ~sender:sender_balance ~amount in
-  let destination_balance = balance destination ticket t in
-  Ok
-    {
-      ledger =
-        t.ledger
-        |> Address_and_ticket_map.add sender ticket (sender_balance - amount)
-        |> Address_and_ticket_map.add destination ticket
-             (destination_balance + amount);
-      withdrawal_handles = t.withdrawal_handles;
-    }
+  let%ok table =
+    Ticket_table.transfer t.table ~sender
+      ~destination:(Address.of_key_hash destination)
+      ~amount ~ticket
+    |> Result.map_error (fun _ -> `Insufficient_funds) in
+  Ok { table; withdrawal_handles = t.withdrawal_handles }
 
 let deposit destination amount ticket t =
-  let open Amount in
-  let destination_balance = balance destination ticket t in
-  {
-    ledger =
-      t.ledger
-      |> Address_and_ticket_map.add destination ticket
-           (destination_balance + amount);
-    withdrawal_handles = t.withdrawal_handles;
-  }
+  let table =
+    Ticket_table.deposit t.table ~ticket
+      ~destination:(Address.of_key_hash destination)
+      ~amount in
+  { table; withdrawal_handles = t.withdrawal_handles }
 
 let withdraw ~sender ~destination amount ticket t =
-  let open Amount in
-  let owner = destination in
-  let sender_balance = balance sender ticket t in
-  let%ok () = assert_available ~sender:sender_balance ~amount in
+  let%ok table =
+    Ticket_table.withdraw t.table
+      ~sender:(Address.of_key_hash sender)
+      ~amount ~ticket
+    |> Result.map_error (function _ -> `Insufficient_funds) in
   let withdrawal_handles, handle =
     Withdrawal_handle_tree.add
       (fun id ->
-        let hash = Withdrawal_handle.hash ~id ~owner ~amount ~ticket in
-        { id; hash; owner; amount; ticket })
+        let hash =
+          Withdrawal_handle.hash ~id ~owner:destination ~amount ~ticket in
+        { id; hash; owner = destination; amount; ticket })
       t.withdrawal_handles in
-  let t =
-    {
-      ledger =
-        t.ledger
-        |> Address_and_ticket_map.add sender ticket (sender_balance - amount);
-      withdrawal_handles;
-    } in
+  let t = { table; withdrawal_handles } in
   Ok (t, handle)
 
 let withdrawal_handles_find_proof handle t =

--- a/src/core_deku/ledger.mli
+++ b/src/core_deku/ledger.mli
@@ -18,12 +18,12 @@ val empty : t
 val balance : Key_hash.t -> Ticket_id.t -> t -> Amount.t
 
 val transfer :
-  sender:Key_hash.t ->
+  sender:Address.t ->
   destination:Key_hash.t ->
   Amount.t ->
   Ticket_id.t ->
   t ->
-  (t, [> `Not_enough_funds]) result
+  (t, [> `Insufficient_funds]) result
 
 val deposit : Key_hash.t -> Amount.t -> Ticket_id.t -> t -> t
 
@@ -33,7 +33,7 @@ val withdraw :
   Amount.t ->
   Ticket_id.t ->
   t ->
-  (t * Withdrawal_handle.t, [> `Not_enough_funds]) result
+  (t * Withdrawal_handle.t, [> `Insufficient_funds]) result
 
 val withdrawal_handles_find_proof :
   Withdrawal_handle.t -> t -> (BLAKE2B.t * BLAKE2B.t) list

--- a/src/core_deku/state.ml
+++ b/src/core_deku/state.ml
@@ -42,7 +42,9 @@ let apply_user_operation t operation_hash user_operation =
   match initial_operation with
   | Transaction { destination; amount; ticket } ->
     let%ok ledger =
-      Ledger.transfer ~sender:source ~destination amount ticket ledger in
+      Ledger.transfer
+        ~sender:(Address.of_key_hash source)
+        ~destination amount ticket ledger in
     Ok ({ contract_storage; ledger }, None)
   | Tezos_withdraw { owner; amount; ticket } ->
     let%ok ledger, handle =
@@ -102,4 +104,4 @@ let apply_user_operation t hash user_operation =
   | Ok (t, receipt) -> (t, receipt)
   (* TODO: use this erros for something *)
   | Error (`Origination_error _ | `Invocation_error _) -> (t, None)
-  | Error `Not_enough_funds -> (t, None)
+  | Error `Insufficient_funds -> (t, None)

--- a/src/core_deku/ticket_table.ml
+++ b/src/core_deku/ticket_table.ml
@@ -12,14 +12,14 @@ module Tickets = struct
   let singleton ~ticket ~amount =
     Ticket_map.of_seq (Seq.return (ticket, amount))
 
-  let merge t ~ticket ~amount =
-    let merger option ~amount =
+  let join t ~ticket ~amount =
+    let join option ~amount =
       let value = Option.fold ~none:amount ~some:Amount.(( + ) amount) option in
       value in
     Ticket_map.update ticket
       (fun x ->
-        let merged = merger ~amount x in
-        Option.some merged)
+        let joined = join ~amount x in
+        Option.some joined)
       t
 
   let get_and_remove t ~ticket ~to_take =
@@ -67,7 +67,7 @@ let balance t ~sender ~ticket =
 
 let update_or_create ~amount ~ticket t =
   Option.fold
-    ~some:(fun x -> Tickets.merge ~amount ~ticket x)
+    ~some:(fun x -> Tickets.join ~amount ~ticket x)
     ~none:(Tickets.singleton ~amount ~ticket)
     t
   |> Option.some

--- a/src/core_deku/ticket_table.ml
+++ b/src/core_deku/ticket_table.ml
@@ -1,0 +1,113 @@
+open Helpers
+
+module Tickets = struct
+  module Ticket_map = Map.Make_with_yojson (Ticket_id)
+
+  type t = Amount.t Ticket_map.t [@@deriving yojson]
+
+  let get_balance t ~ticket = Ticket_map.find_opt ticket t
+
+  let to_seq map = Ticket_map.to_seq map
+
+  let singleton ~ticket ~amount =
+    Ticket_map.of_seq (Seq.return (ticket, amount))
+
+  let merge t ~ticket ~amount =
+    let merger option ~amount =
+      let value = Option.fold ~none:amount ~some:Amount.(( + ) amount) option in
+      value in
+    Ticket_map.update ticket
+      (fun x ->
+        let merged = merger ~amount x in
+        Option.some merged)
+      t
+
+  let get_and_remove t ~ticket ~to_take =
+    match
+      Ticket_map.update ticket
+        (function
+          | Some amount ->
+            let () =
+              let compared = Amount.compare amount to_take in
+              if compared >= 0 then () else failwith "error" in
+            if Amount.equal amount to_take then
+              None
+            else
+              Some Amount.(amount - to_take)
+          | None -> failwith "error")
+        t
+    with
+    | _ as x -> Ok x
+    | exception Failure _ -> Error `Insufficient_funds
+
+  let get_and_remove_many t tickets =
+    let fetched =
+      List.fold_left_ok
+        (fun (lst, m) (ticket, amount) ->
+          let%ok m = get_and_remove m ~ticket ~to_take:amount in
+          let lst = Seq.cons (ticket, amount) lst in
+          Ok (lst, m))
+        (Seq.empty, t) tickets in
+    fetched
+
+  let empty = Ticket_map.empty
+
+  let is_empty = Ticket_map.is_empty
+end
+
+module Address_map = Map.Make_with_yojson (Address)
+
+type t = Tickets.t Address_map.t [@@deriving yojson]
+
+let empty = Address_map.empty
+
+let balance t ~sender ~ticket =
+  let%some map = Address_map.find_opt sender t in
+  Tickets.get_balance ~ticket map
+
+let update_or_create ~amount ~ticket t =
+  Option.fold
+    ~some:(fun x -> Tickets.merge ~amount ~ticket x)
+    ~none:(Tickets.singleton ~amount ~ticket)
+    t
+  |> Option.some
+
+let deposit t ~destination ~ticket ~amount =
+  Address_map.update destination (update_or_create ~amount ~ticket) t
+
+let update t ~sender ~submap =
+  if Tickets.is_empty submap then
+    Address_map.remove sender t
+  else
+    Address_map.add sender submap t
+
+let transfer t ~sender ~destination ~ticket ~amount =
+  let%ok map =
+    Address_map.find_opt sender t |> Option.to_result ~none:`Insufficient_funds
+  in
+  let%ok map = Tickets.get_and_remove ~ticket ~to_take:amount map in
+  let t = update t ~sender ~submap:map in
+  let t = Address_map.update destination (update_or_create ~amount ~ticket) t in
+  Ok t
+
+let withdraw t ~sender ~ticket ~amount =
+  let%ok map =
+    Address_map.find_opt sender t |> Option.to_result ~none:`Insufficient_funds
+  in
+  let%ok map = Tickets.get_and_remove ~ticket ~to_take:amount map in
+  let t = update t ~sender ~submap:map in
+  Ok t
+
+let take_tickets t ~sender ~tickets =
+  let%ok map =
+    Address_map.find_opt sender t |> Option.to_result ~none:`Insufficient_funds
+  in
+  let%ok tickets, map = Tickets.get_and_remove_many map tickets in
+  let t = update t ~sender ~submap:map in
+  Ok (tickets, t)
+
+let take_all_tickets t ~sender =
+  let map =
+    Address_map.find_opt sender t |> Option.value ~default:Tickets.empty in
+  let tickets = Tickets.to_seq map in
+  (tickets, Address_map.remove sender t)

--- a/src/core_deku/ticket_table.mli
+++ b/src/core_deku/ticket_table.mli
@@ -1,0 +1,35 @@
+type t [@@deriving yojson]
+
+val empty : t
+
+val balance : t -> sender:Address.t -> ticket:Ticket_id.t -> Amount.t option
+
+val deposit :
+  t -> destination:Address.t -> ticket:Ticket_id.t -> amount:Amount.t -> t
+
+val transfer :
+  t ->
+  sender:Address.t ->
+  destination:Address.t ->
+  ticket:Ticket_id.t ->
+  amount:Amount.t ->
+  (t, [> `Insufficient_funds]) result
+
+val withdraw :
+  t ->
+  sender:Address.t ->
+  ticket:Ticket_id.t ->
+  amount:Amount.t ->
+  (t, [> `Insufficient_funds]) result
+
+val take_tickets :
+  t ->
+  sender:Address.t ->
+  tickets:(Ticket_id.t * Amount.t) list ->
+  ((Ticket_id.t * Amount.t) Seq.t * t, [> `Insufficient_funds]) result
+
+val take_all_tickets :
+  t -> sender:Address.t -> (Ticket_id.t * Amount.t) Seq.t * t
+
+(* val update_tickets :
+   t -> sender:Address.t -> tickets:(Ticket_id.t * Amount.t) Seq.t -> t *)

--- a/src/core_deku/ticket_table.mli
+++ b/src/core_deku/ticket_table.mli
@@ -30,6 +30,3 @@ val take_tickets :
 
 val take_all_tickets :
   t -> sender:Address.t -> (Ticket_id.t * Amount.t) Seq.t * t
-
-(* val update_tickets :
-   t -> sender:Address.t -> tickets:(Ticket_id.t * Amount.t) Seq.t -> t *)

--- a/src/crypto/BLAKE2B.ml
+++ b/src/crypto/BLAKE2B.ml
@@ -19,6 +19,8 @@ end) : sig
 
   val hash : string -> t
 
+  val hash_v : string list -> t
+
   val verify : hash:t -> string -> bool
 
   val both : t -> t -> t
@@ -57,6 +59,8 @@ end = struct
   let compare = unsafe_compare
 
   let hash data = digest_string data
+
+  let hash_v lst = digestv_string lst
 
   let verify ~hash:expected_hash data = expected_hash = hash data
 

--- a/tests/test_ledger.ml
+++ b/tests/test_ledger.ml
@@ -33,6 +33,7 @@ let () =
         let open Tezos in
         let _key, address = Ed25519.generate () in
         let hash = Ed25519.Key_hash.of_key address in
+
         Address.Implicit (Ed25519 hash) in
       let setup_two () =
         let t1 = make_ticket () in
@@ -72,7 +73,9 @@ let () =
       test "transfer" (fun expect expect_balance ->
           let t, (t1, t2), (a, b) = setup_two () in
           let c = make_address () in
-          let t = transfer ~sender:a ~destination:b (Amount.of_int 1) t1 t in
+          let t =
+            transfer ~sender:(Address.of_key_hash a) ~destination:b
+              (Amount.of_int 1) t1 t in
           (expect.result t).toBeOk ();
           let t = Result.get_ok t in
           expect_balance a t1 99 t;
@@ -81,7 +84,9 @@ let () =
           expect_balance b t2 400 t;
           expect_balance c t1 0 t;
           expect_balance c t2 0 t;
-          let t = transfer ~sender:b ~destination:a (Amount.of_int 3) t2 t in
+          let t =
+            transfer ~sender:(Address.of_key_hash b) ~destination:a
+              (Amount.of_int 3) t2 t in
           (expect.result t).toBeOk ();
           let t = Result.get_ok t in
           expect_balance a t1 99 t;
@@ -90,7 +95,9 @@ let () =
           expect_balance b t2 397 t;
           expect_balance c t1 0 t;
           expect_balance c t2 0 t;
-          let t = transfer ~sender:b ~destination:c (Amount.of_int 5) t2 t in
+          let t =
+            transfer ~sender:(Address.of_key_hash b) ~destination:c
+              (Amount.of_int 5) t2 t in
           (expect.result t).toBeOk ();
           let t = Result.get_ok t in
           expect_balance a t1 99 t;
@@ -99,7 +106,9 @@ let () =
           expect_balance b t2 392 t;
           expect_balance c t1 0 t;
           expect_balance c t2 5 t;
-          let t = transfer ~sender:a ~destination:c (Amount.of_int 99) t1 t in
+          let t =
+            transfer ~sender:(Address.of_key_hash a) ~destination:c
+              (Amount.of_int 99) t1 t in
           (expect.result t).toBeOk ();
           let t = Result.get_ok t in
           expect_balance a t1 0 t;
@@ -108,17 +117,23 @@ let () =
           expect_balance b t2 392 t;
           expect_balance c t1 99 t;
           expect_balance c t2 5 t;
-          (let t = transfer ~sender:b ~destination:c (Amount.of_int 202) t1 t in
+          (let t =
+             transfer ~sender:(Address.of_key_hash b) ~destination:c
+               (Amount.of_int 202) t1 t in
            (expect.result t).toBeError ();
-           expect.equal (Result.get_error t) `Not_enough_funds);
+           expect.equal (Result.get_error t) `Insufficient_funds);
           (let d = make_address () in
-           let t = transfer ~sender:d ~destination:c (Amount.of_int 1) t2 t in
+           let t =
+             transfer ~sender:(Address.of_key_hash d) ~destination:c
+               (Amount.of_int 1) t2 t in
            (expect.result t).toBeError ();
-           expect.equal (Result.get_error t) `Not_enough_funds);
+           expect.equal (Result.get_error t) `Insufficient_funds);
           (let t3 = make_ticket () in
-           let t = transfer ~sender:a ~destination:b (Amount.of_int 1) t3 t in
+           let t =
+             transfer ~sender:(Address.of_key_hash a) ~destination:b
+               (Amount.of_int 1) t3 t in
            (expect.result t).toBeError ();
-           expect.equal (Result.get_error t) `Not_enough_funds);
+           expect.equal (Result.get_error t) `Insufficient_funds);
           ());
       test "deposit" (fun _ expect_balance ->
           let t, (t1, t2), (a, b) = setup_two () in
@@ -176,11 +191,15 @@ let () =
       test "compare" (fun expect _ ->
           let t, (t1, _), (a, b) = setup_two () in
           (let t1' = make_ticket ~data:t1.data () in
-           let t = transfer ~sender:a ~destination:b (Amount.of_int 1) t1' t in
+           let t =
+             transfer ~sender:(Address.of_key_hash a) ~destination:b
+               (Amount.of_int 1) t1' t in
            (expect.result t).toBeError ();
-           expect.equal (Result.get_error t) `Not_enough_funds);
+           expect.equal (Result.get_error t) `Insufficient_funds);
           (let t1' = make_ticket ~ticketer:t1.ticketer () in
-           let t = transfer ~sender:a ~destination:b (Amount.of_int 1) t1' t in
+           let t =
+             transfer ~sender:(Address.of_key_hash a) ~destination:b
+               (Amount.of_int 1) t1' t in
            (expect.result t).toBeError ();
-           expect.equal (Result.get_error t) `Not_enough_funds);
+           expect.equal (Result.get_error t) `Insufficient_funds);
           ()))


### PR DESCRIPTION
## Problem

Right now we use a simple Map of {deku_key_hash;ticket_id}  -> Amount.t to store information about ticket ownership on deku. 
## Solution
In this pr i change the representation of the ledger,  to:
```ocaml 
type t = Amount.t Map.M(Ticket_id).t Map.M(Address).t
```
This will greatly simplify ticket  ownership transfers when you pass them to and from contracts during execution or origination
### E.g: 
   passing 5 tickets from implicit account into originated contract's storage: 
   
   we only touch the senders submap of tickets when transferring them to the contract/changing the amounts, and this is nice because we don't need to manipulate the whole table at once.
   
   When executing the contract with tickets in it's storage we can just use the submap of said contract from the ticket_table to pass them to ticket_transition table alongside tickets passed in argument position by user, again touching only the submap of user and submap of contract
   
Also i added the Ticket_transition_table to be used by smart-contracts when operating on tickets to ensure their linearity during execution.

 