### PR TITLE
fix: add ocamlformat back to shell.nix

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -24,6 +24,7 @@ pkgs.mkShell {
       # formatters
       nixfmt
       nodePackages.prettier
+      ocamlformat_0_20_1
     ] ++ (pkgs.lib.optional (system != "x86_64-darwin") tilt)
     ++ (with pkgs.ocaml-ng.ocamlPackages_5_00; [
       # OCaml developer tooling


### PR DESCRIPTION
## Problem

We accidentally removed `ocamlformat` from our shell environment
in PR #662, breaking a bunch of stuff.

## Solution

Add it back. We have to specify that we want 0.20.1 specifically, because nixpkgs has moved on.
