### PR TITLE
set networking_mode to "host"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,6 +130,7 @@ services:
     container_name: deku_prometheus
     restart: always
     image: prom/prometheus
+    network_mode: host
     ports:
       - "9090:9090"
     expose:


### PR DESCRIPTION
## Problem

The Prometheus server is broken when running in local mode
because it is configured to connect with the targets running
on localhost per prometheus.yml. By adding the
"network_mode: host" option to our docker-compose.yml
we can let prometheus talk to the targets in local mode as well as in the
Tilt configuration

## Related
Successor to 
- #635  