### PR TITLE
[d4hines] fix: fix prometheus with tilt

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -27,16 +27,15 @@ deku_yaml = make_deku_yaml(no_of_deku_nodes)
 # Run docker-compose
 docker_compose(["./docker-compose.yml", deku_yaml])
 
-dc_resource("db", labels=["database"], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
-dc_resource("elastic", labels=["database"], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
-
+dc_resource("db", labels=["tezos"])
+dc_resource("elastic", labels=["tezos"])
 dc_resource("flextesa", labels=["tezos"])
-dc_resource("gui", labels=["tezos"], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
-dc_resource("api", labels=["tezos"], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
+dc_resource("gui", labels=["tezos"])
+dc_resource("api", labels=["tezos"])
+dc_resource("metrics", labels=["tezos"])
+dc_resource("indexer", labels=["tezos"])
 
-dc_resource("metrics", labels=["infra"], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
-dc_resource("indexer", labels=["infra"], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
-dc_resource("prometheus", labels=["infra"], trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
+dc_resource("prometheus", labels=["infra"])
 
 load_deku_services(deku_yaml)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,9 +130,10 @@ services:
     container_name: deku_prometheus
     restart: always
     image: prom/prometheus
+    # "host" network mode is used so that the Prometheus container
+    # can still communicate with the deku nodes when running in
+    # local mode.
     network_mode: host
-    ports:
-      - "9090:9090"
     expose:
       - 9090/tcp
     volumes:

--- a/src/bin/deku_node.ml
+++ b/src/bin/deku_node.ml
@@ -19,6 +19,9 @@ let handle_request (type req res)
   let handler request =
     let%await body = Dream.body request in
     let%await request = Parallel.decode E.request_of_yojson body in
+    Metrics.Networking.inc_network_messages_received E.path;
+    Metrics.Networking.measure_network_received_message_size E.path
+      (String.length body);
     match request with
     | Ok request -> (
       let response = handler update_state request in

--- a/src/metrics/blocks.ml
+++ b/src/metrics/blocks.ml
@@ -12,3 +12,10 @@ let blocks_signed_total =
 let inc_block_produced () = Prometheus.Counter.inc_one blocks_produced_total
 
 let inc_block_signed () = Prometheus.Counter.inc_one blocks_signed_total
+
+let operations_processed_total =
+  let help = "The total number of operations processed by the node" in
+  Counter.v ~help ~namespace ~subsystem "operations_processed_total"
+
+let inc_operations_processed ~operation_count =
+  Counter.inc operations_processed_total (Float.of_int operation_count)

--- a/src/metrics/blocks.mli
+++ b/src/metrics/blocks.mli
@@ -1,3 +1,5 @@
 val inc_block_produced : unit -> unit
 
 val inc_block_signed : unit -> unit
+
+val inc_operations_processed : operation_count:int -> unit

--- a/src/metrics/metrics.ml
+++ b/src/metrics/metrics.ml
@@ -1,2 +1,8 @@
+(* Note: By not depending on the Protocol or Node
+   libraries, we make it harder to leak sensitive data via
+   this module. Although we advise node operators not to expose
+   the port metrics are scraped from, we still don't want sensitive
+   data leaking into the metrics. *)
 module Config = Config
 module Blocks = Blocks
+module Networking = Networking

--- a/src/metrics/networking.ml
+++ b/src/metrics/networking.ml
@@ -1,0 +1,33 @@
+open Prometheus
+open Config
+
+let network_received_message_size =
+  let help = "Size of received message in bytes" in
+  Gauge.v_label ~label_name:"route" ~help ~namespace ~subsystem
+    "network_received_message_size"
+
+let measure_network_received_message_size route size =
+  Gauge.set (network_received_message_size route) (Float.of_int size)
+
+let network_response_message_size =
+  let help = "Size of response message in bytes" in
+  Gauge.v ~help ~namespace ~subsystem "network_response_message_size"
+
+let measure_network_response_message_size size =
+  Gauge.set network_response_message_size (Float.of_int size)
+
+let network_received_message_count =
+  let help = "Count of total messages received" in
+  Counter.v_label ~label_name:"route" ~help ~namespace ~subsystem
+    "network_received_message_count"
+
+let inc_network_messages_received route =
+  Counter.inc_one (network_received_message_count route)
+
+let network_response_message_count =
+  let help = "Count of total response messages sent" in
+  Counter.v_label ~label_name:"route" ~help ~namespace ~subsystem
+    "network_response_message_count"
+
+let inc_network_messages_response route =
+  Counter.inc_one (network_response_message_count route)

--- a/src/node/flows.ml
+++ b/src/node/flows.ml
@@ -258,6 +258,8 @@ let rec try_to_apply_block state update_state block =
     not (BLAKE2B.equal state.protocol.state_root_hash block.state_root_hash)
   in
   let%ok state, user_operations = apply_block state update_state block in
+  Metrics.Blocks.inc_operations_processed
+    ~operation_count:(List.length user_operations);
   write_state_to_file (state.Node.data_folder ^ "/state.bin") state.protocol;
   !reset_timeout ();
   let state = clean state update_state user_operations block in


### PR DESCRIPTION
Fixes Prometheus in docker-compose by removing
the 'ports' setting, which is incompatible with
the host network mode.

Also removes fixes the grouping and removes the
'autoinit=false' config our Tiltfile for several
services. These services are integral to Deku
development, so they should start every time.
<!---GHSTACKOPEN-->
### Stacked PR Chain: d4hines
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#691|👉fix: fix prometheus with tilt|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/691?label=Pending)|-|
|#647|feat: block rate and transaction rate metrics  d4hines/block-rate-and-tps|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/647?label=Approved)|#691|
|#658|chore: refactor cli terms                      d4hines/batch-operations|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/658?label=Pending)|#647|
|#681|chore: refactor config out of node state|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/681?label=Pending)|#658|
|#668|make minimum block time configurable|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/668?label=Pending)|#658|
|#539|Benchmarking: ticket transfers                 d4hines/ticket-transfer-benchmarking|![](https://img.shields.io/github/pulls/detail/state/marigold-dev/deku/539?label=Approved)|#658|
<!---GHSTACKCLOSE-->
