### PR TITLE
chore: check types in ci

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -27,7 +27,7 @@ jobs:
       - name: "Check shell formatting"
         run: nix develop -c shellcheck *.sh
       - name: "Run tests"
-        run: nix develop -c dune runtest --force --no-buffer
+        run: nix develop -c dune build @check @runtest --force --no-buffer
       - name: "Build deku via flakes"
         run: nix build --verbose .#deku
   # Includes all our e2e tests


### PR DESCRIPTION
We run `dune build @runtest` but not `@check` in the CI. This makes it possible
to have code that fails to build and miss it in CI.

<!---
  if some of the following sections doesn't apply,
  delete the section.

  Also feel free to delete the comments.
--->
