### PR TITLE
chore(ci): Speed up CI by consolidating builds

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,11 +1,11 @@
-name: "Test in nix"
+name: "Build and test"
 on:
   pull_request:
   push:
     branches:
       - main
 jobs:
-  build:
+  native:
     strategy:
       fail-fast: false
       matrix:
@@ -30,19 +30,8 @@ jobs:
         run: nix develop -c dune build @check @runtest --force --no-buffer
       - name: "Build deku via flakes"
         run: nix build --verbose .#deku
-  # Includes all our e2e tests
-  tilt_ci:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/checkout@v2
-      
-      - uses: cachix/install-nix-action@v16
-      - uses: cachix/cachix-action@v10
-        with:
-          name: deku
-          authToken: "${{ secrets.CACHIX_SIGNING_KEY }}"
 
+      # Includes all our e2e tests
       - name: "tilt ci"
         run: "nix develop -c tilt ci"
 
@@ -61,26 +50,12 @@ jobs:
       - name: "Build static deku via flakes"
         run: nix build --verbose .#deku-static
 
-  docker:
-    runs-on: ubuntu-latest
-    needs: static # static should add things to cache for docker build
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: cachix/install-nix-action@v16
-      - uses: cachix/cachix-action@v10
-        with:
-          name: deku
-          authToken: "${{ secrets.CACHIX_SIGNING_KEY }}"
 
       - name: Set outputs
         id: vars


### PR DESCRIPTION
## Problem

<!--- Restate the problem addressed by the PR here --->

We currently pull the cache multiple times which is kind of slow

## Solution

<!--- Restate the basic ideas behind your solution --->
<!--- Here it is also a good space to put details of your implementation --->

Since our e2e tests needs the same thing as our standard (native) build we can run them just after.
Docker needs our static builds so we can do the same here.

## Depends

#701 should be merged first since it fixes `tilt ci`