### PR TITLE
Tilt fixes to make `tilt ci` better

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -44,7 +44,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_SIGNING_KEY }}"
 
       - name: "tilt ci"
-        run: "nix develop -c tilt ci -- --mode=local"
+        run: "nix develop -c tilt ci"
 
   # Static and docker are linked because we're using the static build in docker
   static:

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,7 +1,6 @@
 # Setup configurations
 config.define_string("nodes", False, "specify number of deku nodes to run")
 config.define_string("mode", False, "specify what mode to run in, 'local' (default) or 'docker'")
-config.define_bool("all-services", False, "flag for running all services")
 
 if config.tilt_subcommand == "down":
   local("nix run .#sandbox tear-down")
@@ -10,7 +9,7 @@ cfg = config.parse()
 
 no_of_deku_nodes = int(cfg.get('nodes', "3"))
 mode = cfg.get('mode', 'local')
-all_services = cfg.get('all-services', False)
+is_not_ci = config.tilt_subcommand != "ci"
 
 def load_config ():
   if mode == "docker" :
@@ -29,13 +28,13 @@ deku_yaml = make_deku_yaml(no_of_deku_nodes)
 # Run docker-compose
 docker_compose(["./docker-compose.yml", deku_yaml])
 
-dc_resource("db", labels=["tezos"], auto_init=all_services)
-dc_resource("elastic", labels=["tezos"], auto_init=all_services)
+dc_resource("db", labels=["tezos"], auto_init=is_not_ci)
+dc_resource("elastic", labels=["tezos"], auto_init=is_not_ci)
 dc_resource("flextesa", labels=["tezos"])
-dc_resource("gui", labels=["tezos"], auto_init=all_services)
-dc_resource("api", labels=["tezos"], auto_init=all_services)
-dc_resource("metrics", labels=["tezos"], auto_init=all_services)
-dc_resource("indexer", labels=["tezos"], auto_init=all_services)
+dc_resource("gui", labels=["tezos"], auto_init=is_not_ci)
+dc_resource("api", labels=["tezos"], auto_init=is_not_ci)
+dc_resource("metrics", labels=["tezos"], auto_init=is_not_ci)
+dc_resource("indexer", labels=["tezos"], auto_init=is_not_ci)
 
 dc_resource("prometheus", labels=["infra"])
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,6 +1,6 @@
 # Setup configurations
 config.define_string("nodes", False, "specify number of deku nodes to run")
-config.define_string("mode", False, "specify what mode to run in, 'docker' (default) or 'local'")
+config.define_string("mode", False, "specify what mode to run in, 'local' (default) or 'docker'")
 
 if config.tilt_subcommand == "down":
   local("nix run .#sandbox tear-down")
@@ -8,7 +8,7 @@ if config.tilt_subcommand == "down":
 cfg = config.parse()
 
 no_of_deku_nodes = int(cfg.get('nodes', "3"))
-mode = cfg.get('mode', 'docker')
+mode = cfg.get('mode', 'local')
 
 def load_config ():
   if mode == "docker" :

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,6 +1,7 @@
 # Setup configurations
 config.define_string("nodes", False, "specify number of deku nodes to run")
 config.define_string("mode", False, "specify what mode to run in, 'local' (default) or 'docker'")
+config.define_bool("all-services", False, "flag for running all services")
 
 if config.tilt_subcommand == "down":
   local("nix run .#sandbox tear-down")
@@ -9,6 +10,7 @@ cfg = config.parse()
 
 no_of_deku_nodes = int(cfg.get('nodes', "3"))
 mode = cfg.get('mode', 'local')
+all_services = cfg.get('all-services', False)
 
 def load_config ():
   if mode == "docker" :
@@ -27,13 +29,13 @@ deku_yaml = make_deku_yaml(no_of_deku_nodes)
 # Run docker-compose
 docker_compose(["./docker-compose.yml", deku_yaml])
 
-dc_resource("db", labels=["tezos"])
-dc_resource("elastic", labels=["tezos"])
+dc_resource("db", labels=["tezos"], auto_init=all_services)
+dc_resource("elastic", labels=["tezos"], auto_init=all_services)
 dc_resource("flextesa", labels=["tezos"])
-dc_resource("gui", labels=["tezos"])
-dc_resource("api", labels=["tezos"])
-dc_resource("metrics", labels=["tezos"])
-dc_resource("indexer", labels=["tezos"])
+dc_resource("gui", labels=["tezos"], auto_init=all_services)
+dc_resource("api", labels=["tezos"], auto_init=all_services)
+dc_resource("metrics", labels=["tezos"], auto_init=all_services)
+dc_resource("indexer", labels=["tezos"], auto_init=all_services)
 
 dc_resource("prometheus", labels=["infra"])
 


### PR DESCRIPTION
## Problem

<!--- Restate the problem addressed by the PR here --->

We are usually running tilt in local mode while docker is the default
We are running a bunch of resources that we don't need when just running the CI

## Solution

<!--- Restate the basic ideas behind your solution --->
<!--- Here it is also a good space to put details of your implementation --->

Flip the mode configuration to have `local` as default
Add a flag to start all services which defaults to `false`, use it as `tilt up -- --all-services` to start indexer etc