### PR TITLE
sandbox.sh to ocaml initialization

### DIFF
--- a/nix/deku.nix
+++ b/nix/deku.nix
@@ -65,6 +65,7 @@ in ocamlPackages.buildDunePackage rec {
       memtrace
       benchmark
       json-logs-reporter
+      feather
     ]
     # checkInputs are here because when cross compiling dune needs test dependencies
     # but they are not available for the build phase. The issue can be seen by adding strictDeps = true;.

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -40,6 +40,16 @@ in {
         else
           o.src;
       });
+      feather = osuper.buildDunePackage {
+        pname = "feather";
+        version = "0.3.0";
+        src = builtins.fetchurl {
+          url =
+            "https://github.com/charlesetc/feather/archive/refs/tags/0.3.0.tar.gz";
+          sha256 = "0mkycpkpq9jrlaf3zc367l6m88521zg0zpsd5g93c72azp7gj7zg";
+        };
+        propagatedBuildInputs = with osuper; [ ppx_expect spawn ];
+      };
 
       # Fix packages that don't have checkInputs as buildInputs (bug in nixpkgs)
       # This is a problem for static builds mainly

--- a/src/bin/deku_sandbox.ml
+++ b/src/bin/deku_sandbox.ml
@@ -1,0 +1,133 @@
+open Cmdliner
+open Feather
+
+let exits =
+  Cmd.Exit.defaults
+  @ [Cmd.Exit.info 1 ~doc:"expected failure (might not be a bug)"]
+
+let man = [`S Manpage.s_bugs; `P "Email bug reports to <contact@marigold.dev>."]
+
+let run_ret cmd =
+  match collect status cmd with
+  | 0 -> `Ok 0
+  | status ->
+    `Error
+      (false, Format.sprintf "Exited with status %d. See output above." status)
+
+(* start *)
+let start () = process "./sandbox.sh" ["start"] |> run_ret
+
+let start =
+  let open Term in
+  const start $ const () |> ret
+
+let info_start =
+  let doc = "Starts a Deku cluster configured with this script" in
+  Cmd.info "start" ~version:"%\226\128\140%VERSION%%" ~doc ~exits ~man
+
+(* tear-down *)
+let tear_down () = process "./sandbox.sh" ["tear-down"] |> run_ret
+
+let tear_down =
+  let open Term in
+  const tear_down $ const () |> ret
+
+let info_tear_down =
+  let doc = "Stops the Tezos node and destroys the Deku state." in
+  Cmd.info "tear-down" ~version:"%\226\128\140%VERSION%%" ~doc ~exits ~man
+
+(* setup *)
+let setup () = process "./sandbox.sh" ["setup"] |> run_ret
+
+let setup =
+  let open Term in
+  const setup $ const () |> ret
+
+let info_setup =
+  let doc =
+    "Does the following: it starts a Tezos sandbox network with Flextesa, then \
+     it generates a new validator indentities and it deploys a new contract to \
+     the Tezos sandbox configured to use these validators." in
+  Cmd.info "setup" ~version:"%\226\128\140%VERSION%%" ~doc ~exits ~man
+
+(* smoke test *)
+let smoke_test () = process "./sandbox.sh" ["smoke-test"] |> run_ret
+
+let smoke_test =
+  let open Term in
+  const smoke_test $ const () |> ret
+
+let info_smoke_test =
+  let doc =
+    "Starts a Deku cluster and performs some simple checks that its working."
+  in
+  Cmd.info "smoke-test" ~version:"%\226\128\140%VERSION%%" ~doc ~exits ~man
+
+(* deposit-withdraw-test *)
+let deposit_withdraw_test () =
+  process "./sandbox.sh" ["deposit-withdraw-test"] |> run_ret
+
+let deposit_withdraw_test =
+  let open Term in
+  const deposit_withdraw_test $ const () |> ret
+
+let info_deposit_withdraw_test =
+  let doc =
+    "Start a Deku cluster and originate a dummy tickets and performs a deposit \
+     and a withdraw." in
+  Cmd.info "deposit-withdraw-test" ~version:"%\226\128\140%VERSION%%" ~doc
+    ~exits ~man
+
+(* deploy-dummy-ticket *)
+let deploy_dummy_ticket () =
+  process "./sandbox.sh" ["deploy-dummy-ticket"] |> run_ret
+
+let deploy_dummy_ticket =
+  let open Term in
+  const deploy_dummy_ticket $ const () |> ret
+
+let info_deploy_dummy_ticket =
+  let doc =
+    "Deploys a contract that forges dummy tickets and deposits to Deku." in
+  Cmd.info "deploy-dummy-ticket" ~version:"%\226\128\140%VERSION%%" ~doc ~exits
+    ~man
+
+(* deposit-dummy-ticket *)
+let deposit_dummy_ticket () =
+  process "./sandbox.sh" ["deposit-dummy-ticket"] |> run_ret
+
+let deposit_dummy_ticket =
+  let open Term in
+  const deposit_dummy_ticket $ const () |> ret
+
+let info_deposit_dummy_ticket =
+  let doc = "Executes a deposit of a dummy ticket to Deku." in
+  Cmd.info "deposit-dummy-ticket" ~version:"%\226\128\140%VERSION%%" ~doc ~exits
+    ~man
+
+(* TODO: https://github.com/ocaml/ocaml/issues/11090 *)
+let () = Domain.set_name "deku-sandbox"
+
+let default_info =
+  let doc =
+    "creates, deploys, and starts Deku clusters in a sandbox mode suitable for \
+     local development and testnets. BE ADVISED: some of the configuration \
+     options used by deku-sandbox are unsafe for production environments. \
+     Refer to the production deployment guide." in
+  let sdocs = Manpage.s_common_options in
+  let exits = Cmd.Exit.defaults in
+  Cmd.info "deku-sandbox" ~version:"%\226\128\140%VERSION%%" ~doc ~sdocs ~exits
+
+let _ =
+  exit
+  @@ Cmd.eval'
+  @@ Cmd.group default_info
+       [
+         Cmd.v info_start start;
+         Cmd.v info_setup setup;
+         Cmd.v info_smoke_test smoke_test;
+         Cmd.v info_tear_down tear_down;
+         Cmd.v info_deposit_withdraw_test deposit_withdraw_test;
+         Cmd.v info_deploy_dummy_ticket deploy_dummy_ticket;
+         Cmd.v info_deposit_dummy_ticket deposit_dummy_ticket;
+       ]

--- a/src/bin/dune
+++ b/src/bin/dune
@@ -14,6 +14,14 @@
  (preprocess
   (pps ppx_deriving_yojson ppx_let_binding)))
 
+(executable
+ (name deku_sandbox)
+ (libraries feather bin_common cmdliner)
+ (modules deku_sandbox)
+ (public_name deku-sandbox)
+ (preprocess
+  (pps ppx_deriving_yojson ppx_let_binding)))
+
 (library
  (name bin_common)
  (modules Files Node_state)


### PR DESCRIPTION
# Problem 

We want to have a more robust and testable sandbox script. 

# Solution

Rewrite it in ocaml.
There are 8 PRs to do so. Each one of them replace one feature of the sandbox.sh script.

This first PR is just the setup with nix and feather.

| PR           | Description   |
|--------------|------------------|
|  [PR#708](https://github.com/marigold-dev/deku/pull/708)  | sandbox start  |
|  [PR#709](https://github.com/marigold-dev/deku/pull/709)  | sandbox tear-down  |
|  [PR#710](https://github.com/marigold-dev/deku/pull/710)  | sandbox deploy-dummy-ticket/deposit-dummy-ticket  |
|  [PR#711](https://github.com/marigold-dev/deku/pull/711)  | sandbox smoke-test  |
|  [PR#712](https://github.com/marigold-dev/deku/pull/712)  | sandbox deposit-withdraw-test  |
|  [PR#713](https://github.com/marigold-dev/deku/pull/713)  | sandbox setup  |
|  [PR#714](https://github.com/marigold-dev/deku/pull/714)  | ci & tilt  |