### PR TITLE
Remove the CLI's dependency on the node

### DIFF
--- a/src/bin/deku_cli.ml
+++ b/src/bin/deku_cli.ml
@@ -7,10 +7,6 @@ open Bin_common
 let () = Printexc.record_backtrace true
 
 let man = [`S Manpage.s_bugs; `P "Email bug reports to <contact@marigold.dev>."]
-
-let make_filename_from_address wallet_addr_str =
-  Printf.sprintf "%s.tzsidewallet" wallet_addr_str
-
 let exits =
   Cmd.Exit.defaults
   @ [Cmd.Exit.info 1 ~doc:"expected failure (might not be a bug)"]
@@ -18,6 +14,9 @@ let exits =
 let lwt_ret p =
   let open Term in
   ret (const Lwt_main.run $ p)
+
+let make_filename_from_address wallet_addr_str =
+  Printf.sprintf "%s.tzsidewallet" wallet_addr_str
 
 let wallet =
   let parser file =

--- a/src/bin/deku_cli.ml
+++ b/src/bin/deku_cli.ml
@@ -555,70 +555,6 @@ let get_ticket_balance =
     required & pos 2 (some ticket) None & info [] ~docv ~doc in
   lwt_ret (const get_ticket_balance $ folder_node $ address $ ticket)
 
-let info_sign_block =
-  let doc =
-    "Sign a block hash and broadcast to the network manually, useful when the \
-     chain is stale." in
-  Cmd.info "sign-block" ~version:"%\226\128\140%VERSION%%" ~doc ~exits ~man
-
-let sign_block node_folder block_hash =
-  let%await identity = read_identity ~node_folder in
-  let signature = Signature.sign ~key:identity.secret block_hash in
-  let%await interop_context = interop_context node_folder in
-  let%await validator_uris = validator_uris ~interop_context in
-  match validator_uris with
-  | Error err -> Lwt.return (`Error (false, err))
-  | Ok validator_uris ->
-    let validator_uris = List.map snd validator_uris |> List.somes in
-    let%await () =
-      let open Network in
-      broadcast_to_list
-        (module Signature_spec)
-        validator_uris
-        { hash = block_hash; signature } in
-    Lwt.return (`Ok ())
-
-let sign_block_term =
-  let block_hash =
-    let doc = "The block hash to be signed." in
-    let open Arg in
-    required & pos 1 (some hash) None & info [] ~doc in
-  let open Term in
-  lwt_ret (const sign_block $ folder_node $ block_hash)
-
-let info_produce_block =
-  let doc =
-    "Produce and sign a block and broadcast to the network manually, useful \
-     when the chain is stale." in
-  Cmd.info "produce-block" ~version:"%\226\128\140%VERSION%%" ~doc ~exits ~man
-
-let produce_block node_folder =
-  let%await identity = read_identity ~node_folder in
-  let%await state = Node_state.get_initial_state ~folder:node_folder in
-  let address = identity.t in
-  let block =
-    Block.produce ~state:state.protocol ~next_state_root_hash:None
-      ~author:address ~consensus_operations:[] ~tezos_operations:[]
-      ~user_operations:[] in
-  let signature = Block.sign ~key:identity.secret block in
-  let%await interop_context = interop_context node_folder in
-  let%await validator_uris = validator_uris ~interop_context in
-  match validator_uris with
-  | Error err -> Lwt.return (`Error (false, err))
-  | Ok validator_uris ->
-    let validator_uris = List.map snd validator_uris |> List.somes in
-    let%await () =
-      let open Network in
-      broadcast_to_list
-        (module Block_and_signature_spec)
-        validator_uris { block; signature } in
-    Format.printf "block.hash: %s\n%!" (BLAKE2B.to_string block.hash);
-    Lwt.return (`Ok ())
-
-let produce_block =
-  let open Term in
-  lwt_ret (const produce_block $ folder_node)
-
 let ensure_folder folder =
   let%await exists = Lwt_unix.file_exists folder in
   if exists then
@@ -822,8 +758,6 @@ let _ =
          Cmd.v info_originate_contract originate_contract;
          Cmd.v info_withdraw withdraw;
          Cmd.v info_withdraw_proof withdraw_proof;
-         Cmd.v info_sign_block sign_block_term;
-         Cmd.v info_produce_block produce_block;
          Cmd.v info_setup_identity setup_identity;
          Cmd.v info_setup_tezos setup_tezos;
          Cmd.v info_add_trusted_validator add_trusted_validator;

--- a/src/bin/deku_cli.ml
+++ b/src/bin/deku_cli.ml
@@ -12,20 +12,7 @@ let () = Printexc.record_backtrace true
 let read_identity ~node_folder =
   Files.Identity.read ~file:(node_folder ^ "/identity.json")
 
-
 let man = [`S Manpage.s_bugs; `P "Email bug reports to <contact@marigold.dev>."]
-
-let interop_context node_folder =
-  let%await context =
-    Files.Interop_context.read ~file:(node_folder ^ "/tezos.json") in
-  Lwt.return
-    (Tezos_interop.make ~rpc_node:context.rpc_node ~secret:context.secret
-       ~consensus_contract:context.consensus_contract
-       ~discovery_contract:context.discovery_contract
-       ~required_confirmations:context.required_confirmations)
-
-let validator_uris ~interop_context =
-  Tezos_interop.Consensus.fetch_validators interop_context
 
 let make_filename_from_address wallet_addr_str =
   Printf.sprintf "%s.tzsidewallet" wallet_addr_str
@@ -202,58 +189,43 @@ let info_create_transaction =
 let create_transaction node_folder sender_wallet_file received_address amount
     ticket argument vm_flavor =
   let open Network in
-  let%await interop_context = interop_context node_folder in
-  let%await validator_uris = validator_uris ~interop_context in
-  match validator_uris with
-  | Error err -> Lwt.return (`Error (false, err))
-  | Ok validator_uris -> (
-    let validator_uris =
-      List.filter_map
-        (function
-          | key_hash, Some uri -> Some (key_hash, uri)
-          | _ -> None)
-        validator_uris in
-    match validator_uris with
-    | [] -> Lwt.return (`Error (false, "No validators found"))
-    | (_, validator_uri) :: _ ->
-      let%await block_level_response = request_block_level () validator_uri in
-      let block_level = block_level_response.level in
-      let%await wallet = Files.Wallet.read ~file:sender_wallet_file in
-      let operation =
-        match (Address.to_key_hash received_address, argument) with
-        | Some addr, None ->
-          Core_deku.User_operation.make ~source:wallet.address
-            (Transaction { destination = addr; amount; ticket })
-        | Some _, Some _ ->
-          failwith "can't pass an argument to implicit account"
-        | None, None -> failwith "Invalid transaction"
-        | None, Some arg ->
-          let payload =
-            match vm_flavor with
-            | `Lambda -> Contract_vm.Invocation_payload.lambda_of_yojson ~arg
-            | `Dummy -> Contract_vm.Invocation_payload.dummy_of_yojson ~arg
-          in
-          let arg = payload |> Result.get_ok in
-          Core_deku.User_operation.make ~source:wallet.address
-            (Contract_invocation
-               {
-                 to_invoke =
-                   Address.to_contract_hash received_address |> Option.get;
-                 argument = arg;
-               }) in
-      let transaction =
-        Protocol.Operation.Core_user.sign ~secret:wallet.priv_key
-          ~nonce:(Crypto.Random.int32 Int32.max_int)
-          ~block_height:block_level ~data:operation in
+  let%await { uri; _ } = read_identity ~node_folder in
+  (* TODO: remove *)
+  let node_uri = uri in
+  let%await block_level_response = request_block_level () node_uri in
+  let block_level = block_level_response.level in
+  let%await wallet = Files.Wallet.read ~file:sender_wallet_file in
+  let operation =
+    match (Address.to_key_hash received_address, argument) with
+    | Some addr, None ->
+      Core_deku.User_operation.make ~source:wallet.address
+        (Transaction { destination = addr; amount; ticket })
+    | Some _, Some _ -> failwith "can't pass an argument to implicit account"
+    | None, None -> failwith "Invalid transaction"
+    | None, Some arg ->
+      let payload =
+        match vm_flavor with
+        | `Lambda -> Contract_vm.Invocation_payload.lambda_of_yojson ~arg
+        | `Dummy -> Contract_vm.Invocation_payload.dummy_of_yojson ~arg in
+      let arg = payload |> Result.get_ok in
+      Core_deku.User_operation.make ~source:wallet.address
+        (Contract_invocation
+           {
+             to_invoke = Address.to_contract_hash received_address |> Option.get;
+             argument = arg;
+           }) in
+  let transaction =
+    Protocol.Operation.Core_user.sign ~secret:wallet.priv_key
+      ~nonce:(Crypto.Random.int32 Int32.max_int)
+      ~block_height:block_level ~data:operation in
 
-      let%await identity = read_identity ~node_folder in
-      let%await () =
-        Network.request_user_operation_gossip
-          { user_operation = transaction }
-          identity.uri in
-      Format.printf "operation.hash: %s\n%!"
-        (BLAKE2B.to_string transaction.hash);
-      Lwt.return (`Ok ()))
+  let%await identity = read_identity ~node_folder in
+  let%await () =
+    Network.request_user_operation_gossip
+      { user_operation = transaction }
+      identity.uri in
+  Format.printf "operation.hash: %s\n%!" (BLAKE2B.to_string transaction.hash);
+  Lwt.return (`Ok ())
 
 let info_originate_contract =
   let doc =
@@ -265,56 +237,42 @@ let info_originate_contract =
 let originate_contract node_folder contract_json initial_storage
     sender_wallet_file (vm_flavor : [`Dummy | `Lambda]) =
   let open Network in
-  let%await interop_context = interop_context node_folder in
-  let%await validator_uris = validator_uris ~interop_context in
-  match validator_uris with
-  | Error err -> Lwt.return (`Error (false, err))
-  | Ok validator_uris -> (
-    let validator_uris =
-      List.filter_map
-        (function
-          | key_hash, Some uri -> Some (key_hash, uri)
-          | _ -> None)
-        validator_uris in
-    match validator_uris with
-    | [] -> Lwt.return (`Error (false, "No validators found"))
-    | (_, validator_uri) :: _ ->
-      let%await block_level_response = request_block_level () validator_uri in
-      let block_level = block_level_response.level in
-      let%await wallet = Files.Wallet.read ~file:sender_wallet_file in
-      let contract_program = Yojson.Safe.from_file contract_json in
-      let initial_storage = Yojson.Safe.from_file initial_storage in
-      let payload =
-        match vm_flavor with
-        | `Lambda ->
-          Contract_vm.Origination_payload.lambda_of_yojson
-            ~code:contract_program ~storage:initial_storage
-          |> Result.get_ok
-        | `Dummy ->
-          let int =
-            try Yojson.Safe.Util.to_int initial_storage with
-            | _ -> failwith "Invalid storage fro contract" in
-          Contract_vm.Origination_payload.dummy_of_yojson ~storage:int in
-      let origination_op = User_operation.Contract_origination payload in
-      let originate_contract_op =
-        Protocol.Operation.Core_user.sign ~secret:wallet.priv_key
-          ~nonce:(Crypto.Random.int32 Int32.max_int)
-          ~block_height:block_level
-          ~data:(User_operation.make ~source:wallet.address origination_op)
-      in
-      let%await identity = read_identity ~node_folder in
-      let%await () =
-        Network.request_user_operation_gossip
-          {
-            Network.User_operation_gossip.user_operation = originate_contract_op;
-          }
-          identity.uri in
-      Format.printf "operation_hash: %s\n%!"
-        (BLAKE2B.to_string originate_contract_op.hash);
-      Format.printf "contract_address: %s\n%!"
-        (Contract_address.of_user_operation_hash originate_contract_op.hash
-        |> Contract_address.to_string);
-      Lwt.return (`Ok ()))
+  let%await { uri; _ } = read_identity ~node_folder in
+  (* TODO: remove *)
+  let node_uri = uri in
+  let%await block_level_response = request_block_level () node_uri in
+  let block_level = block_level_response.level in
+  let%await wallet = Files.Wallet.read ~file:sender_wallet_file in
+  let contract_program = Yojson.Safe.from_file contract_json in
+  let initial_storage = Yojson.Safe.from_file initial_storage in
+  let payload =
+    match vm_flavor with
+    | `Lambda ->
+      Contract_vm.Origination_payload.lambda_of_yojson ~code:contract_program
+        ~storage:initial_storage
+      |> Result.get_ok
+    | `Dummy ->
+      let int =
+        try Yojson.Safe.Util.to_int initial_storage with
+        | _ -> failwith "Invalid storage fro contract" in
+      Contract_vm.Origination_payload.dummy_of_yojson ~storage:int in
+  let origination_op = User_operation.Contract_origination payload in
+  let originate_contract_op =
+    Protocol.Operation.Core_user.sign ~secret:wallet.priv_key
+      ~nonce:(Crypto.Random.int32 Int32.max_int)
+      ~block_height:block_level
+      ~data:(User_operation.make ~source:wallet.address origination_op) in
+  let%await identity = read_identity ~node_folder in
+  let%await () =
+    Network.request_user_operation_gossip
+      { Network.User_operation_gossip.user_operation = originate_contract_op }
+      identity.uri in
+  Format.printf "operation_hash: %s\n%!"
+    (BLAKE2B.to_string originate_contract_op.hash);
+  Format.printf "contract_address: %s\n%!"
+    (Contract_address.of_user_operation_hash originate_contract_op.hash
+    |> Contract_address.to_string);
+  Lwt.return (`Ok ())
 
 let folder_node =
   let docv = "folder_node" in

--- a/src/bin/deku_cli.ml
+++ b/src/bin/deku_cli.ml
@@ -501,15 +501,6 @@ let ensure_folder folder =
   else
     Lwt_unix.mkdir folder 0o700
 
-let show_help =
-  let doc = "a tool for interacting with the WIP Tezos Sidechain" in
-  let sdocs = Manpage.s_common_options in
-  let exits = Cmd.Exit.defaults in
-  ( (let open Term in
-    ret (const (`Help (`Pager, None)))),
-    Cmd.info "deku-cli" ~version:"%\226\128\140%VERSION%%" ~doc ~sdocs ~exits
-      ~man )
-
 let default_info =
   let doc = "Deku cli" in
   let sdocs = Manpage.s_common_options in

--- a/src/bin/deku_cli.ml
+++ b/src/bin/deku_cli.ml
@@ -6,7 +6,9 @@ open Bin_common
 
 let () = Printexc.record_backtrace true
 
+(* TODO: move into a helper module *)
 let man = [`S Manpage.s_bugs; `P "Email bug reports to <contact@marigold.dev>."]
+
 let exits =
   Cmd.Exit.defaults
   @ [Cmd.Exit.info 1 ~doc:"expected failure (might not be a bug)"]
@@ -488,17 +490,6 @@ let get_ticket_balance =
     let open Arg in
     required & pos 2 (some ticket) None & info [] ~docv ~doc in
   lwt_ret (const get_ticket_balance $ node_uri $ address $ ticket)
-
-let ensure_folder folder =
-  let%await exists = Lwt_unix.file_exists folder in
-  if exists then
-    let%await stat = Lwt_unix.stat folder in
-    if stat.st_kind = Lwt_unix.S_DIR then
-      await ()
-    else
-      raise (Invalid_argument (folder ^ " is not a folder"))
-  else
-    Lwt_unix.mkdir folder 0o700
 
 let default_info =
   let doc = "Deku cli" in

--- a/src/bin/deku_cli.ml
+++ b/src/bin/deku_cli.ml
@@ -12,11 +12,6 @@ let () = Printexc.record_backtrace true
 let read_identity ~node_folder =
   Files.Identity.read ~file:(node_folder ^ "/identity.json")
 
-let write_identity ~node_folder =
-  Files.Identity.write ~file:(node_folder ^ "/identity.json")
-
-let write_interop_context ~node_folder =
-  Files.Interop_context.write ~file:(node_folder ^ "/tezos.json")
 
 let man = [`S Manpage.s_bugs; `P "Email bug reports to <contact@marigold.dev>."]
 
@@ -566,92 +561,6 @@ let ensure_folder folder =
   else
     Lwt_unix.mkdir folder 0o700
 
-let setup_identity node_folder uri =
-  let%await () = ensure_folder node_folder in
-  let identity =
-    let secret, key = Crypto.Ed25519.generate () in
-    let t = Key_hash.of_key (Ed25519 key) in
-    { uri; t; key = Ed25519 key; secret = Ed25519 secret } in
-  let%await () = write_identity ~node_folder identity in
-  await (`Ok ())
-
-let info_setup_identity =
-  let doc = "Create a validator identity" in
-  Cmd.info "setup-identity" ~version:"%\226\128\140%VERSION%%" ~doc ~exits ~man
-
-let setup_identity =
-  let self_uri =
-    let docv = "self_uri" in
-    let doc = "The uri that other nodes should use to connect to this node." in
-    let open Arg in
-    required & opt (some uri) None & info ["uri"] ~doc ~docv in
-  let open Term in
-  lwt_ret (const setup_identity $ folder_node $ self_uri)
-
-let info_setup_tezos =
-  let doc = "Setup Tezos identity" in
-  Cmd.info "setup-tezos" ~version:"%%VERSION%%" ~doc ~exits ~man
-
-let setup_tezos node_folder rpc_node secret consensus_contract
-    discovery_contract required_confirmations =
-  let%await () = ensure_folder node_folder in
-  let%await () =
-    write_interop_context ~node_folder
-      {
-        rpc_node;
-        secret;
-        consensus_contract;
-        discovery_contract;
-        required_confirmations;
-      } in
-  await (`Ok ())
-
-let setup_tezos =
-  let tezos_node_uri =
-    let docv = "tezos_node_uri" in
-    let doc = "The uri of the tezos node." in
-    let open Arg in
-    required & opt (some uri) None & info ["tezos_rpc_node"] ~doc ~docv in
-  let tezos_secret =
-    let docv = "tezos_secret" in
-    let doc = "The Tezos secret key." in
-    let open Arg in
-    required
-    & opt (some edsk_secret_key) None
-    & info ["tezos_secret"] ~doc ~docv in
-  let tezos_consensus_contract_address =
-    let docv = "tezos_consensus_contract_address" in
-    let doc = "The address of the Tezos consensus contract." in
-    let open Arg in
-    required
-    & opt (some address_tezos_interop) None
-    & info ["tezos_consensus_contract"] ~doc ~docv in
-  let tezos_discovery_contract_address =
-    let docv = "tezos_discovery_contract_address" in
-    let doc = "The address of the Tezos discovery contract." in
-    let open Arg in
-    required
-    & opt (some address_tezos_interop) None
-    & info ["tezos_discovery_contract"] ~doc ~docv in
-  let tezos_required_confirmations =
-    let docv = "int" in
-    let doc =
-      "Set the required confirmations. WARNING: Setting below default of 10 \
-       can compromise security of the Deku chain." in
-    let open Arg in
-    value
-    & opt tezos_required_confirmations 10
-    & info ["unsafe_tezos_required_confirmations"] ~doc ~docv in
-  let open Term in
-  lwt_ret
-    (const setup_tezos
-    $ folder_node
-    $ tezos_node_uri
-    $ tezos_secret
-    $ tezos_consensus_contract_address
-    $ tezos_discovery_contract_address
-    $ tezos_required_confirmations)
-
 let show_help =
   let doc = "a tool for interacting with the WIP Tezos Sidechain" in
   let sdocs = Manpage.s_common_options in
@@ -758,8 +667,6 @@ let _ =
          Cmd.v info_originate_contract originate_contract;
          Cmd.v info_withdraw withdraw;
          Cmd.v info_withdraw_proof withdraw_proof;
-         Cmd.v info_setup_identity setup_identity;
-         Cmd.v info_setup_tezos setup_tezos;
          Cmd.v info_add_trusted_validator add_trusted_validator;
          Cmd.v info_remove_trusted_validator remove_trusted_validator;
          Cmd.v info_get_ticket_balance get_ticket_balance;

--- a/src/bin/deku_cli.ml
+++ b/src/bin/deku_cli.ml
@@ -528,21 +528,6 @@ let show_help =
     Cmd.info "deku-cli" ~version:"%\226\128\140%VERSION%%" ~doc ~sdocs ~exits
       ~man )
 
-let info_self =
-  let doc = "Shows identity key and address of the node." in
-  Cmd.info "self" ~version:"%\226\128\140%VERSION%%" ~doc ~exits ~man
-
-let self node_folder =
-  let%await identity = read_identity ~node_folder in
-  Format.printf "key: %s\n" (Wallet.to_string identity.key);
-  Format.printf "address: %s\n" (Key_hash.to_string identity.t);
-  Format.printf "uri: %s\n" (Uri.to_string identity.uri);
-  await (`Ok ())
-
-let self =
-  let open Term in
-  lwt_ret (const self $ folder_node)
-
 let info_add_trusted_validator =
   let doc =
     "Helps node operators maintain a list of trusted validators they verified \
@@ -628,5 +613,4 @@ let _ =
          Cmd.v info_add_trusted_validator add_trusted_validator;
          Cmd.v info_remove_trusted_validator remove_trusted_validator;
          Cmd.v info_get_ticket_balance get_ticket_balance;
-         Cmd.v info_self self;
        ]

--- a/src/bin/deku_node.ml
+++ b/src/bin/deku_node.ml
@@ -258,7 +258,7 @@ let node json_logs style_renderer level folder prometheus_port =
     (Logs.Src.list ());
   node folder prometheus_port
 
-let node =
+let start_node =
   let folder_node =
     let docv = "folder_node" in
     let doc = "Path to the folder containing the node configuration data." in
@@ -277,4 +277,14 @@ let node =
   $ folder_node
   $ Prometheus_dream.opts
 
-let _ = Cmd.eval @@ Cmd.v (Cmd.info "deku-node") node
+let info_start_node =
+  let doc = "Starts the deku node." in
+  Cmd.info "start" ~version:"%\226\128\140%VERSION%%" ~doc ~exits ~man
+
+let default_info =
+  let doc = "Deku cli" in
+  let sdocs = Manpage.s_common_options in
+  let exits = Cmd.Exit.defaults in
+  Cmd.info "side-cli" ~version:"%\226\128\140%VERSION%%" ~doc ~sdocs ~exits
+
+let _ = Cmd.eval @@ Cmd.group default_info [Cmd.v info_start_node start_node]

--- a/src/bin/deku_node.ml
+++ b/src/bin/deku_node.ml
@@ -4,6 +4,29 @@ open Node
 open Consensus
 open Bin_common
 
+(* TODO: move into a helper module *)
+let man = [`S Manpage.s_bugs; `P "Email bug reports to <contact@marigold.dev>."]
+
+let exits =
+  Cmd.Exit.defaults
+  @ [Cmd.Exit.info 1 ~doc:"expected failure (might not be a bug)"]
+
+(* We will need these later *)
+let _lwt_ret p =
+  let open Term in
+  ret (const Lwt_main.run $ p)
+
+let _ensure_folder folder =
+  let%await exists = Lwt_unix.file_exists folder in
+  if exists then
+    let%await stat = Lwt_unix.stat folder in
+    if stat.st_kind = Lwt_unix.S_DIR then
+      await ()
+    else
+      raise (Invalid_argument (folder ^ " is not a folder"))
+  else
+    Lwt_unix.mkdir folder 0o700
+
 let ignore_some_errors = function
   | Error #Flows.ignore -> Ok ()
   | v -> v


### PR DESCRIPTION
## Problem

One day, we'll want to have the CLI work with a node running remotely, instead of a node running on the same machine. That's currently not possible, because the CLI reads the node state for many of its functions. 

## Solution

For the commands where it makes sense, we want to have the CLI just take a URI of a node running remotely. Otherwise, we'll want to move those functions to `deku_node.ml`.