### PR TITLE
[Nix] add landmarks and landmarks ppx to nix

### DIFF
--- a/nix/deku.nix
+++ b/nix/deku.nix
@@ -64,6 +64,8 @@ in ocamlPackages.buildDunePackage rec {
       core_bench
       memtrace
       benchmark
+      landmarks
+      landmarks-ppx
       json-logs-reporter
     ]
     # checkInputs are here because when cross compiling dune needs test dependencies


### PR DESCRIPTION
Adding `landmarks` and `landmarks-ppx` to nix.

**Purpose**
`landmarks` is a small profiling tool for OCAML. I want to use it to profile Deku. 