### PR TITLE
Wasm-vm fix ticket_handle indexes on reloads

### DIFF
--- a/docs/smart-contracts/wasm_contracts/wasm_transfer.wat
+++ b/docs/smart-contracts/wasm_contracts/wasm_transfer.wat
@@ -1,31 +1,31 @@
-   (module
-           (import "env" "syscall" (func $syscall (param i64) (result i32)))
-           (memory (export "memory") 1)
-           (func (export "main")  (param i32) (result i64 i64 i64)
-             i32.const 46
-             i32.const 8
-             i32.store
-             i32.const 51
-             i32.const -1
-             i32.store
-             i32.const 56
-             i32.const 0
-             i32.store
-             i32.const 61
-             i64.const 10
-             i64.store
-             i32.const 70
-             i32.const 8
-             i32.store
-             i64.const 46
-             call $syscall
-             i64.extend_i32_s
-             (i64.const 0)
-             i32.const 92
-             i32.const 1
-             i32.store
-             i32.const 97
-             i32.const 1
-             i32.store
-             (i64.const 92)
-             ))
+              (module
+              (import "env" "syscall" (func $syscall (param i64) (result i32)))
+              (memory (export "memory") 1)
+              (func (export "main")  (param i32) (result i64 i64 i64)
+                i32.const 49
+                i32.const 8
+                i32.store
+                i32.const 54
+                i32.const -1
+                i32.store
+                i32.const 59
+                i32.const 0
+                i32.store
+                i32.const 64
+                i64.const 10
+                i64.store
+                i32.const 73
+                i32.const 4
+                i32.store
+                i64.const 49
+                call $syscall
+                i64.extend_i32_s
+                (i64.const 0)
+                i32.const 92
+                i32.const 1
+                i32.store
+                i32.const 97
+                i32.const 1
+                i32.store
+                (i64.const 92)
+                ))

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -389,7 +389,7 @@ test_wasm() {
   ARG=$(ticket_handle)
   echo "param: \"$ARG\""
   sleep 5
-  deku-cli create-transaction ./data/0 wallet.json "$CONTRACT_ADDRESS" 100 "Pair \"$DUMMY_TICKET\" 0x" --arg="$ARG" --vm_flavor="Wasm" --tickets="Pair \"$DUMMY_TICKET\" 0x":100
+  deku-cli create-transaction ./data/0 wallet.json "$CONTRACT_ADDRESS" 100 "Pair \"$DUMMY_TICKET\" 0x" --arg="$ARG" --vm_flavor="Wasm" --tickets="Pair \"$DUMMY_TICKET\" 0x":100=0:0
   sleep 5
   asserter_contract "$DATA_DIRECTORY/0" "$CONTRACT_ADDRESS" "Pair \"$DUMMY_TICKET\" 0x" 100
 }
@@ -410,7 +410,7 @@ test_wasm_full() {
 
   sleep 5
 
- deku-cli create-transaction ./data/0 wallet.json "$CONTRACT_ADDRESS" 100 "Pair \"$DUMMY_TICKET\" 0x" --arg="$ARG" --vm_flavor="Wasm" --tickets="Pair \"$DUMMY_TICKET\" 0x":100
+ deku-cli create-transaction ./data/0 wallet.json "$CONTRACT_ADDRESS" 100 "Pair \"$DUMMY_TICKET\" 0x" --arg="$ARG" --vm_flavor="Wasm" --tickets="Pair \"$DUMMY_TICKET\" 0x":100=0:0
 
   sleep 5
   

--- a/src/bin/deku_cli.ml
+++ b/src/bin/deku_cli.ml
@@ -118,6 +118,24 @@ let address =
   let open Arg in
   conv (parser, printer)
 
+let contract_argument_addr =
+  let parser string = Ok (Int64.of_string_opt string) in
+  let printer fmt wallet =
+    Format.fprintf fmt "%a"
+      (Format.pp_print_option (fun fmt x ->
+           Format.fprintf fmt "%s" (x |> Int64.to_string)))
+      wallet in
+  let open Arg in
+  conv (parser, printer)
+
+let contract_ticket_handle =
+  let parser string =
+    Int32.of_string_opt string
+    |> Option.to_result ~none:(`Msg "Expected a valid Deku address.") in
+  let printer fmt wallet = Format.fprintf fmt "%s" (wallet |> Int32.to_string) in
+  let open Arg in
+  conv (parser, printer)
+
 let amount =
   let parser string =
     let%ok int =
@@ -385,7 +403,12 @@ let originate_contract =
     let doc = "The string containing initial tickets for storage" in
     Arg.(
       Arg.value
-      & opt ~vopt:[] (list (pair ~sep:':' ticket amount)) []
+      & opt ~vopt:[]
+          (list
+             (pair ~sep:'='
+                (pair ~sep:':' ticket amount)
+                (pair ~sep:':' contract_ticket_handle contract_argument_addr)))
+          []
       & info ["tickets"] ~docv:"tickets" ~doc) in
 
   Term.(
@@ -417,7 +440,12 @@ let create_transaction =
     let doc = "The string containing tickets for vm argument" in
     Arg.(
       Arg.value
-      & opt ~vopt:[] (list (pair ~sep:':' ticket amount)) []
+      & opt ~vopt:[]
+          (list
+             (pair ~sep:'='
+                (pair ~sep:':' ticket amount)
+                (pair ~sep:':' contract_ticket_handle contract_argument_addr)))
+          []
       & info ["tickets"] ~docv:"tickets" ~doc) in
   let amount =
     let doc = "The amount to be transferred." in

--- a/src/core_deku/state.ml
+++ b/src/core_deku/state.ml
@@ -83,20 +83,25 @@ let rec apply_user_operation ?sender t operation_hash user_operation =
     let%ok contract_storage, ledger =
       Ledger.with_ticket_table ledger (fun ~get_table ~set_table ->
           let table = get_table () in
-          let%ok tickets, table =
-            Ticket_table.take_tickets table ~sender ~tickets in
+          let%ok tickets', table =
+            Ticket_table.take_tickets table ~sender
+              ~tickets:(List.map ~f:fst tickets) in
 
           let contract_address =
             Contract_address.of_user_operation_hash operation_hash in
           let address = Address.of_contract_hash contract_address in
 
           let table =
-            Ticket_table.update_tickets table ~sender:address ~tickets in
-
+            Ticket_table.update_tickets table ~sender:address ~tickets:tickets'
+          in
           (* TODO: Burn on storage size change, need CTEZ *)
           let%ok contract =
-            Contract_vm.Compiler.compile ~gas:initial_gas payload |> wrap_error
-          in
+            Contract_vm.Compiler.compile
+              ~tickets:
+                (List.map ~f:(fun (f, r) -> (f, fst r)) tickets
+                |> Stdlib.List.to_seq)
+              ~gas:initial_gas payload
+            |> wrap_error in
           let contract_storage =
             Contract_storage.originate_contract t.contract_storage
               ~address:contract_address ~contract in
@@ -125,30 +130,36 @@ let rec apply_user_operation ?sender t operation_hash user_operation =
           let table_tickets, table =
             Ticket_table.take_all_tickets table
               ~sender:(Address.of_contract_hash to_invoke) in
-          let%ok tickets, table =
-            Ticket_table.take_tickets table ~sender ~tickets in
-          let ctx =
+          let%ok _, table =
+            Ticket_table.take_tickets table ~sender
+              ~tickets:(List.map ~f:fst tickets) in
+          let ctx, to_replace =
             let source = Address.of_key_hash source in
             Context.make_state ~sender ~source
+              ~mapping:(Contract_vm.Contract.tickets_mapping contract)
               ~contract_owned_tickets:table_tickets
               ~self:(Address.of_contract_hash to_invoke)
-              ~provided_tickets:tickets ~get_contract_opt:(fun address ->
+              ~provided_tickets:(Stdlib.List.to_seq tickets)
+              ~get_contract_opt:(fun address ->
                 let address =
                   Address.to_contract_hash address |> Option.value_exn in
                 Contract_storage.get_contract contract_storage ~address
                 |> Option.map ~f:(Fn.const (Address.of_contract_hash address)))
           in
           let%ok contract, user_op_list =
-            Contract_vm.Interpreter.invoke ~ctx ~arg:argument ~gas:initial_gas
-              contract
+            Contract_vm.Interpreter.invoke ~to_replace ~ctx ~arg:argument
+              ~gas:initial_gas contract
             |> wrap_error in
-          let contract_storage =
-            Contract_storage.update_contract_storage contract_storage
-              ~address:to_invoke ~updated_contract:contract in
-          let%ok tickets, operations =
+
+          let%ok tickets_mapping, tickets, operations =
             ctx#finalize user_op_list
             |> Result.map_error ~f:(fun _ ->
                    `Invocation_error "execution error") in
+          let contract =
+            Contract_vm.Contract.update_tickets contract tickets_mapping in
+          let contract_storage =
+            Contract_storage.update_contract_storage contract_storage
+              ~address:to_invoke ~updated_contract:contract in
           let table =
             Ticket_table.update_tickets table
               ~sender:(Address.of_contract_hash to_invoke)

--- a/src/core_deku/user_operation.ml
+++ b/src/core_deku/user_operation.ml
@@ -11,11 +11,19 @@ type initial_operation =
   | Contract_invocation  of {
       to_invoke : Contract_address.t;
       argument : Contract_vm.Invocation_payload.t;
-      tickets : (Ticket_id.t * Amount.t) list;
+      (*TODO: remove tickets field when we will do normal parsing of arguments from the cli *)
+      tickets :
+        ((Ticket_id.t * Amount.t)
+        * (Smart_contracts.Ticket_handle.t * Int64.t option))
+        list;
     }
   | Contract_origination of {
       payload : Contract_vm.Origination_payload.t;
-      tickets : (Ticket_id.t * Amount.t) list;
+      (*TODO: remove tickets field when we will do normal parsing of initial storage from the cli *)
+      tickets :
+        ((Ticket_id.t * Amount.t)
+        * (Smart_contracts.Ticket_handle.t * Int64.t option))
+        list;
     }
   | Tezos_withdraw       of {
       owner : Tezos.Address.t;

--- a/src/core_deku/user_operation.mli
+++ b/src/core_deku/user_operation.mli
@@ -10,11 +10,17 @@ type initial_operation =
   | Contract_invocation  of {
       to_invoke : Contract_address.t;
       argument : Contract_vm.Invocation_payload.t;
-      tickets : (Ticket_id.t * Amount.t) list;
+      tickets :
+        ((Ticket_id.t * Amount.t)
+        * (Smart_contracts.Ticket_handle.t * Int64.t option))
+        list;
     }
   | Contract_origination of {
       payload : Contract_vm.Origination_payload.t;
-      tickets : (Ticket_id.t * Amount.t) list;
+      tickets :
+        ((Ticket_id.t * Amount.t)
+        * (Smart_contracts.Ticket_handle.t * Int64.t option))
+        list;
     }
   | Tezos_withdraw       of {
       owner : Tezos.Address.t;

--- a/src/smart_contracts/context.ml
+++ b/src/smart_contracts/context.ml
@@ -3,9 +3,9 @@ module type CTX = sig
 
   include
     State.S
-      with module Address := Address
-       and module Amount = Amount
-       and module Ticket_id = Ticket_id
+      with type Address.t = Address.t
+       and type Amount.t = Amount.t
+       and type Ticket_id.t = Ticket_id.t
 
   module Addressing : sig
     val sender : #State.addressing -> Address.t
@@ -47,7 +47,7 @@ module type CTX = sig
   module Operations : sig
     val transaction :
       < State.table_access ; State.with_operations ; State.addressing ; .. > ->
-      bytes * (Ticket_handle.t * Amount.t) * Address.t ->
+      bytes * (Ticket_handle.t * Amount.t * Int64.t option) * Address.t ->
       int
   end
 
@@ -55,8 +55,10 @@ module type CTX = sig
     get_contract_opt:(Address.t -> Address.t option) ->
     source:Address.t ->
     sender:Address.t ->
+    mapping:((Ticket_id.t * Amount.t) * Ticket_handle.t) list ->
     self:Address.t ->
     contract_owned_tickets:(Ticket_id.t * Amount.t) Seq.t ->
-    provided_tickets:(Ticket_id.t * Amount.t) Seq.t ->
-    State.full_state
+    provided_tickets:
+      ((Ticket_id.t * Amount.t) * (Ticket_handle.t * Int64.t option)) Seq.t ->
+    State.full_state * (Int64.t option * Ticket_handle.t) list option
 end

--- a/src/smart_contracts/context.mli
+++ b/src/smart_contracts/context.mli
@@ -3,9 +3,9 @@ module type CTX = sig
 
   include
     State.S
-      with module Address := Address
-       and module Amount = Amount
-       and module Ticket_id = Ticket_id
+      with type Address.t = Address.t
+       and type Amount.t = Amount.t
+       and type Ticket_id.t = Ticket_id.t
 
   module Addressing : sig
     val sender : #State.addressing -> Address.t
@@ -47,7 +47,7 @@ module type CTX = sig
   module Operations : sig
     val transaction :
       < State.table_access ; State.with_operations ; State.addressing ; .. > ->
-      bytes * (Ticket_handle.t * Amount.t) * Address.t ->
+      bytes * (Ticket_handle.t * Amount.t * Int64.t option) * Address.t ->
       int
   end
 
@@ -55,8 +55,10 @@ module type CTX = sig
     get_contract_opt:(Address.t -> Address.t option) ->
     source:Address.t ->
     sender:Address.t ->
+    mapping:((Ticket_id.t * Amount.t) * Ticket_handle.t) list ->
     self:Address.t ->
     contract_owned_tickets:(Ticket_id.t * Amount.t) Seq.t ->
-    provided_tickets:(Ticket_id.t * Amount.t) Seq.t ->
-    State.full_state
+    provided_tickets:
+      ((Ticket_id.t * Amount.t) * (Ticket_handle.t * Int64.t option)) Seq.t ->
+    State.full_state * (Int64.t option * Ticket_handle.t) list option
 end

--- a/src/smart_contracts/contract_ffi.mli
+++ b/src/smart_contracts/contract_ffi.mli
@@ -1,5 +1,5 @@
 module Make (CC : Conversions.S) :
   Context.CTX
-    with module Address = CC.Address
-     and module Ticket_id = CC.Ticket_id
-     and module Amount = CC.Amount
+    with type Address.t = CC.Address.t
+     and type Amount.t = CC.Amount.t
+     and type Ticket_id.t = CC.Ticket_id.t

--- a/src/smart_contracts/operation.ml
+++ b/src/smart_contracts/operation.ml
@@ -10,7 +10,8 @@ module type S = sig
     | Invoke   of {
         param : bytes;
         destination : Address.t;
-        tickets : (Ticket_id.t * Amount.t) list;
+        tickets :
+          ((Ticket_id.t * Amount.t) * (Ticket_handle.t * Int64.t option)) list;
       }
 end
 
@@ -26,6 +27,7 @@ module Make (CC : Conversions.S) = struct
     | Invoke   of {
         param : bytes;
         destination : Address.t;
-        tickets : (Ticket_id.t * Amount.t) list;
+        tickets :
+          ((Ticket_id.t * Amount.t) * (Ticket_handle.t * Int64.t option)) list;
       }
 end

--- a/src/smart_contracts/operation.mli
+++ b/src/smart_contracts/operation.mli
@@ -10,12 +10,14 @@ module type S = sig
     | Invoke   of {
         param : bytes;
         destination : Address.t;
-        tickets : (Ticket_id.t * Amount.t) list;
+        tickets :
+          ((Ticket_id.t * Amount.t) * (Ticket_handle.t * Int64.t option)) list;
+            (* TODO: CLEANUP, Int64.t is optional pointer in case of need to reassign handle *)
       }
 end
 
 module Make (CC : Conversions.S) :
   S
-    with module Address = CC.Address
-     and module Amount = CC.Amount
-     and module Ticket_id = CC.Ticket_id
+    with type Address.t = CC.Address.t
+     and type Amount.t = CC.Amount.t
+     and type Ticket_id.t = CC.Ticket_id.t

--- a/src/smart_contracts/smart_contracts.ml
+++ b/src/smart_contracts/smart_contracts.ml
@@ -4,3 +4,5 @@ module Contract_vm = Contract_vm
 module type CTX = Context.CTX
 
 module type Conversions = Conversions.S
+
+module Ticket_handle = Ticket_handle

--- a/src/smart_contracts/state.ml
+++ b/src/smart_contracts/state.ml
@@ -1,31 +1,28 @@
 module type S = sig
   include Conversions.S
 
-  module Ticket_handle :
-    Ticket_handle.S
-      with module Address = Address
-       and module Amount = Amount
-       and module Ticket_id = Ticket_id
+  module Ticket_handle = Ticket_handle
 
   module Ticket_transition_table :
     Ticket_transition_table.S
-      with module Address = Address
-       and module Amount = Amount
-       and module Ticket_id = Ticket_id
-       and module Ticket_handle = Ticket_handle
+      with type Address.t = Address.t
+       and type Amount.t = Amount.t
+       and type Ticket_id.t = Ticket_id.t
 
   module Operation :
     Operation.S
-      with module Address = Address
-       and module Amount = Amount
-       and module Ticket_id = Ticket_id
+      with type Address.t = Address.t
+       and type Amount.t = Amount.t
+       and type Ticket_id.t = Ticket_id.t
 
   module State : sig
     class virtual finalization :
       object
         method virtual finalize :
           int list ->
-          ( (Ticket_id.t * Amount.t) Seq.t * Operation.t list,
+          ( ((Ticket_id.t * Amount.t) * Ticket_handle.t) List.t
+            * (Ticket_id.t * Amount.t) Seq.t
+            * Operation.t list,
             [`Execution_error] )
           result
       end
@@ -70,9 +67,8 @@ module Make (CC : Conversions.S) :
      and module Ticket_id = CC.Ticket_id
      and module Amount = CC.Amount = struct
   include CC
-  module Ticket_handle = Ticket_handle.Make (CC)
-  module Ticket_transition_table =
-    Ticket_transition_table.Make (CC) (Ticket_handle)
+  module Ticket_handle = Ticket_handle
+  module Ticket_transition_table = Ticket_transition_table.Make (CC)
   module Operation = Operation.Make (CC)
 
   module State = struct
@@ -80,7 +76,9 @@ module Make (CC : Conversions.S) :
       object
         method virtual finalize
             : int list ->
-              ( (Ticket_id.t * Amount.t) Seq.t * Operation.t list,
+              ( ((Ticket_id.t * Amount.t) * Ticket_handle.t) List.t
+                * (Ticket_id.t * Amount.t) Seq.t
+                * Operation.t list,
                 [`Execution_error] )
               result
       end

--- a/src/smart_contracts/state.mli
+++ b/src/smart_contracts/state.mli
@@ -1,31 +1,28 @@
 module type S = sig
   include Conversions.S
 
-  module Ticket_handle :
-    Ticket_handle.S
-      with module Address = Address
-       and module Amount = Amount
-       and module Ticket_id = Ticket_id
+  module Ticket_handle = Ticket_handle
 
   module Ticket_transition_table :
     Ticket_transition_table.S
-      with module Address = Address
-       and module Amount = Amount
-       and module Ticket_id = Ticket_id
-       and module Ticket_handle = Ticket_handle
+      with type Address.t = Address.t
+       and type Amount.t = Amount.t
+       and type Ticket_id.t = Ticket_id.t
 
   module Operation :
     Operation.S
-      with module Address = Address
-       and module Amount = Amount
-       and module Ticket_id = Ticket_id
+      with type Address.t = Address.t
+       and type Amount.t = Amount.t
+       and type Ticket_id.t = Ticket_id.t
 
   module State : sig
     class virtual finalization :
       object
         method virtual finalize :
           int list ->
-          ( (Ticket_id.t * Amount.t) Seq.t * Operation.t list,
+          ( ((Ticket_id.t * Amount.t) * Ticket_handle.t) List.t
+            * (Ticket_id.t * Amount.t) Seq.t
+            * Operation.t list,
             [`Execution_error] )
           result
       end
@@ -66,6 +63,6 @@ end
 
 module Make (CC : Conversions.S) :
   S
-    with module Address = CC.Address
-     and module Ticket_id = CC.Ticket_id
-     and module Amount = CC.Amount
+    with type Address.t = CC.Address.t
+     and type Amount.t = CC.Amount.t
+     and type Ticket_id.t = CC.Ticket_id.t

--- a/src/smart_contracts/ticket_handle.ml
+++ b/src/smart_contracts/ticket_handle.ml
@@ -1,29 +1,20 @@
-module type S = sig
-  include Conversions.S
+include Int32
 
-  type t = Int64.t [@@deriving ord, eq]
-
-  val to_string : t -> string
-
-  val of_string : string -> t
-
-  val size : int
-
-  val to_bytes : t -> bytes
-
-  val of_bytes : bytes -> t
+module For_yojson = struct
+  type t = Int32.t [@@deriving yojson]
 end
 
-module Make (CC : Conversions.S) = struct
-  include CC
-  include Int64
+include For_yojson
 
-  let to_bytes t =
-    let buf = Bytes.create 8 in
-    Bytes.set_int64_le buf 0 t;
-    buf
+let to_bytes t =
+  let buf = Bytes.create 4 in
+  Bytes.set_int32_le buf 0 t;
+  buf
 
-  let of_bytes t = Bytes.get_int64_le t 0
+let of_bytes t = Bytes.get_int32_le t 0
 
-  let size = 8
-end
+let to_string t = to_bytes t |> Bytes.unsafe_to_string
+
+let of_string t = String.to_bytes t |> of_bytes
+
+let size = 4

--- a/src/smart_contracts/ticket_handle.mli
+++ b/src/smart_contracts/ticket_handle.mli
@@ -1,21 +1,11 @@
-module type S = sig
-  include Conversions.S
+type t = Int32.t [@@deriving ord, eq, yojson]
 
-  type t = Int64.t [@@deriving ord, eq]
+val to_string : t -> string
 
-  val to_string : t -> string
+val of_string : string -> t
 
-  val of_string : string -> t
+val size : int
 
-  val size : int
+val to_bytes : t -> bytes
 
-  val to_bytes : t -> bytes
-
-  val of_bytes : bytes -> t
-end
-
-module Make (CC : Conversions.S) :
-  S
-    with module Address = CC.Address
-     and module Amount = CC.Amount
-     and module Ticket_id = CC.Ticket_id
+val of_bytes : bytes -> t

--- a/src/smart_contracts/ticket_transition_table.mli
+++ b/src/smart_contracts/ticket_transition_table.mli
@@ -11,12 +11,6 @@ end
 module type S = sig
   include Conversions.S
 
-  module Ticket_handle :
-    Ticket_handle.S
-      with module Address = Address
-       and module Amount = Amount
-       and module Ticket_id = Ticket_id
-
   type t
 
   val own :
@@ -28,11 +22,7 @@ module type S = sig
     result
 
   val mint_ticket :
-    t ->
-    sender:Address.t ->
-    amount:Amount.t ->
-    bytes ->
-    Ticket_handle.t
+    t -> sender:Address.t -> amount:Amount.t -> bytes -> Ticket_handle.t
 
   val read_ticket :
     t ->
@@ -63,21 +53,17 @@ module type S = sig
 
   val init :
     self:Address.t ->
+    mapping:((Ticket_id.t * Amount.t) * Ticket_handle.t) list ->
     tickets:(Ticket_id.t * Amount.t) Seq.t ->
-    temporary_tickets:(Ticket_id.t * Amount.t) Seq.t ->
-    t
+    temporary_tickets:
+      ((Ticket_id.t * Amount.t) * (Ticket_handle.t * Int64.t option)) Seq.t ->
+    t * (Int64.t option * Ticket_handle.t) list option
 
-  val finalize : t -> (Ticket_id.t * Amount.t) Seq.t
+  val finalize : t -> (Ticket_handle.t * Ticket_id.t * Amount.t) Seq.t
 end
 
-module Make
-    (CC : Conversions.S)
-    (Ticket_handle : Ticket_handle.S
-                       with module Address = CC.Address
-                        and module Amount = CC.Amount
-                        and module Ticket_id = CC.Ticket_id) :
+module Make (CC : Conversions.S) :
   S
-    with module Address = CC.Address
-     and module Amount = CC.Amount
-     and module Ticket_id = CC.Ticket_id
-     and module Ticket_handle = Ticket_handle
+    with type Address.t = CC.Address.t
+     and type Amount.t = CC.Amount.t
+     and type Ticket_id.t = CC.Ticket_id.t

--- a/tests/contracts/test_invocation.ml
+++ b/tests/contracts/test_invocation.ml
@@ -190,7 +190,7 @@ let test_ok_wasm msg =
     user_op.hash |> Contract_address.of_user_operation_hash in
   let state, _ = State.apply_user_operation initial_state user_op.hash user_op in
   let init_storage = State.contract_storage state in
-  let arg = [%to_yojson: bytes] (Int64.zero |> Context.Ticket_handle.to_bytes) in
+  let arg = [%to_yojson: bytes] (Int32.zero |> Context.Ticket_handle.to_bytes) in
   let payload =
     Contract_vm.Invocation_payload.wasm_of_yojson ~arg |> Result.get_ok in
   let operation =
@@ -198,7 +198,7 @@ let test_ok_wasm msg =
       {
         to_invoke = contract_address;
         argument = payload;
-        tickets = [(ticket, Amount.of_int 55)];
+        tickets = [((ticket, Amount.of_int 55), (Int32.zero, Some Int64.zero))];
       } in
   let operation = User_operation.make ~source:address operation in
   let state, _ = State.apply_user_operation state user_op.hash operation in

--- a/tests/contracts/test_origination.ml
+++ b/tests/contracts/test_origination.ml
@@ -70,14 +70,18 @@ let test_wasm msg =
         ))
       |}
       |> Bytes.of_string in
-    let storage = Int64.zero |> Context.Ticket_handle.to_bytes in
+    let storage = Int32.zero |> Context.Ticket_handle.to_bytes in
 
     Contract_vm.Origination_payload.wasm_of_yojson ~code ~storage
     |> Result.get_ok in
 
   let operation =
     User_operation.Contract_origination
-      { payload; tickets = [(ticket, Amount.of_int 10000)] } in
+      {
+        payload;
+        tickets =
+          [((ticket, Amount.of_int 10000), (Int32.zero, Some Int64.zero))];
+      } in
   let user_op = User_operation.make ~source:address operation in
 
   let state, _ = State.apply_user_operation initial_state user_op.hash user_op in
@@ -115,14 +119,17 @@ let test_wasm_fail msg =
           ))
         |}
       |> Bytes.of_string in
-    let storage = Int64.one |> Context.Ticket_handle.to_bytes in
+    let storage = Int32.one |> Context.Ticket_handle.to_bytes in
 
     Contract_vm.Origination_payload.wasm_of_yojson ~code ~storage
     |> Result.get_ok in
 
   let operation =
     User_operation.Contract_origination
-      { payload; tickets = [(t1, Amount.of_int 10000)] } in
+      {
+        payload;
+        tickets = [((t1, Amount.of_int 10000), (Int32.one, Some Int64.zero))];
+      } in
   let user_op = User_operation.make ~source:address operation in
 
   let state, _ = State.apply_user_operation initial_state user_op.hash user_op in

--- a/tests/e2e/dune
+++ b/tests/e2e/dune
@@ -3,6 +3,7 @@
  (public_name check-liveness)
  (modules check_liveness)
  (libraries bin_common lwt cmdliner feather))
+
 (executable
  (name asserter_contract)
  (public_name asserter_contract)

--- a/tests/e2e/ticket_handle.ml
+++ b/tests/e2e/ticket_handle.ml
@@ -3,7 +3,7 @@ open Cmdliner
 let create_handle =
   let open Core_deku in
   let open Contracts in
-  let arg = [%to_yojson: bytes] (Int64.zero |> Context.Ticket_handle.to_bytes) in
+  let arg = [%to_yojson: bytes] (Int32.zero |> Context.Ticket_handle.to_bytes) in
   Format.printf "%s\n%!" (Yojson.Safe.to_string arg)
 
 let args =

--- a/tests/e2e/ticket_transfer.ml
+++ b/tests/e2e/ticket_transfer.ml
@@ -4,7 +4,7 @@ let create_arg addr =
   let open Core_deku in
   let open Contracts in
   let addr = Address.of_string addr |> Option.get in
-  let arg = Int64.zero |> Context.Ticket_handle.to_bytes in
+  let arg = Int32.zero |> Context.Ticket_handle.to_bytes in
   let args =
     [%to_yojson: bytes]
       (Bytes.concat Bytes.empty

--- a/tests/wasm/dune
+++ b/tests/wasm/dune
@@ -1,5 +1,5 @@
 (test
  (name test_wasm)
- (libraries wasm_vm alcotest helpers tezos core_deku crypto)
+ (libraries wasm_vm yojson alcotest helpers tezos core_deku crypto)
  (preprocess
-  (pps ppx_let_binding)))
+  (pps ppx_let_binding ppx_deriving_yojson)))

--- a/tests/wasm/test_runtime.ml
+++ b/tests/wasm/test_runtime.ml
@@ -26,8 +26,8 @@ let test_simple_invocation () =
   let storage = i64 1L in
   let argument = i64 42L in
   let addr = make_address () in
-  let ctx =
-    Context.make_state ~source:addr ~sender:addr
+  let ctx, _ =
+    Context.make_state ~mapping:[] ~source:addr ~sender:addr
       ~contract_owned_tickets:Seq.empty
       ~get_contract_opt:(fun _ -> None)
       ~self:(Address.of_contract_hash (make_contract_address "test"))
@@ -62,7 +62,7 @@ let test_ticket_own () =
   let storage = Bytes.empty in
   let addr = make_address () in
   let ticket = make_ticket () in
-  let argument = Int64.zero |> Context.Ticket_handle.to_bytes in
+  let argument = Int32.zero |> Context.Ticket_handle.to_bytes in
   let table = Ticket_table.empty in
   let table =
     Ticket_table.deposit table ~ticket ~destination:addr
@@ -70,14 +70,16 @@ let test_ticket_own () =
   let tickets_table, _table =
     Ticket_table.take_all_tickets table
       ~sender:(Address.of_contract_hash (make_contract_address "test")) in
-  let ctx =
-    Context.make_state ~source:addr ~sender:addr
+  let ctx, _ =
+    Context.make_state ~source:addr ~sender:addr ~mapping:[]
       ~contract_owned_tickets:tickets_table
       ~get_contract_opt:(fun _ -> None)
       ~self:(Address.of_contract_hash (make_contract_address "test"))
-      ~provided_tickets:([(ticket, Amount.of_int 10)] |> List.to_seq) in
-  let _, _ = invoke ~ctx ~storage ~argument code in
-  let tickets, _ = ctx#finalize [] |> Result.get_ok in
+      ~provided_tickets:
+        ([((ticket, Amount.of_int 10), (Int32.zero, Some Int64.zero))]
+        |> List.to_seq) in
+  let _storage, _ = invoke ~ctx ~storage ~argument code in
+  let _, tickets, _ = ctx#finalize [] |> Result.get_ok in
   let contract_addr = Address.of_contract_hash (make_contract_address "test") in
   let final = Ticket_table.update_tickets ~sender:contract_addr table ~tickets in
   let final = Ticket_table.balance final ~sender:contract_addr ~ticket in
@@ -97,25 +99,25 @@ let test_ticket_join () =
                     (import "env" "syscall" (func $syscall (param i64) (result i32)))
                     (memory (export "memory") 1)
                     (func (export "main")  (param i32) (result i64 i64 i64)
-                      i32.const 17
+                      i32.const 10
                       i32.const 6
                       i32.store
-                      i32.const 22
+                      i32.const 15
                       i32.const 0
                       i32.store
-                      i32.const 27
-                      i32.const 8
+                      i32.const 20
+                      i32.const 4
                       i32.store
-                      i64.const 17
+                      i64.const 10
                       call $syscall
-                      i32.const 8
+                      i32.const 5
                       i32.add
                       i32.const 5 
                       i32.store
-                      i32.const 30
-                      i32.const 17
+                      i32.const 20
+                      i32.const 10
                       i32.store
-                      i64.const 25
+                      i64.const 15
                       call $syscall
                       i64.extend_i32_s
                       (i64.const 8)
@@ -126,10 +128,10 @@ let test_ticket_join () =
   let storage = Bytes.empty in
   let addr = make_address () in
   let ticket = make_ticket () in
-  let handle = Int64.zero |> Context.Ticket_handle.to_bytes in
+  let handle = Int32.zero |> Context.Ticket_handle.to_bytes in
   let self = make_contract_address "test" in
   let contract_addr = Core_deku.Address.of_contract_hash self in
-  let handle2 = Int64.one |> Context.Ticket_handle.to_bytes in
+  let handle2 = Int32.one |> Context.Ticket_handle.to_bytes in
   let argument = Bytes.concat Bytes.empty [handle; handle2] in
   let table = Ticket_table.empty in
   let table =
@@ -143,13 +145,14 @@ let test_ticket_join () =
       ~sender:
         (Core_deku.Address.of_contract_hash (make_contract_address "test"))
   in
-  let ctx =
+  let ctx, _ =
     make_custom ~tickets_table
-      ~tickets:(Seq.return (ticket, Amount.of_int 10))
+      ~mapping:[((ticket, Amount.of_int 10), Int32.zero)]
+      ~tickets:(Seq.return ((ticket, Amount.of_int 10), (Int32.one, Some 5L)))
       ~self:(Core_deku.Address.of_contract_hash self)
       ~sender:addr ~source:addr in
   let _, _ = invoke ~ctx ~storage ~argument code in
-  let tickets, _ = ctx#finalize [] |> Result.get_ok in
+  let _, tickets, _ = ctx#finalize [] |> Result.get_ok in
   let final = Ticket_table.update_tickets ~sender:contract_addr table ~tickets in
   let final = Ticket_table.balance final ~sender:contract_addr ~ticket in
   let table =
@@ -164,55 +167,55 @@ let test_ticket_split () =
   let open Context in
   let code =
     {|
-                            (module
-                              (import "env" "syscall" (func $syscall (param i64) (result i32)))
-                              (memory (export "memory") 1)
-                              (func (export "main")  (param i32) (result i64 i64 i64)
-                                i32.const 9
-                                i32.const 4
-                                i32.store
-                                i32.const 14
-                                i32.const 0
-                                i32.store
-                                i32.const 19
-                                i64.const 5
-                                i64.store
-                                i32.const 28
-                                i64.const 5
-                                i64.store
-                                i64.const 9
-                                call $syscall
-                                i32.const 91
-                                i32.add
-                                i32.const 5
-                                i32.store
-                                i32.const 105
-                                i32.const 9
-                                i32.store
-                                i64.const 100
-                                call $syscall
-                                i32.const 9
-                                i32.add
-                                i32.const 5
-                                i32.store
-                                i32.const 114
-                                i32.const 17
-                                i32.store
-                                i64.const 109
-                                call $syscall
-                                i32.const 9
-                                i32.sub
-                                i64.extend_i32_s
-                                (i64.const 17)
-                                (i64.const 555)
-                                ))
-                          |}
+                               (module
+                                 (import "env" "syscall" (func $syscall (param i64) (result i32)))
+                                 (memory (export "memory") 1)
+                                 (func (export "main")  (param i32) (result i64 i64 i64)
+                                   i32.const 5
+                                   i32.const 4
+                                   i32.store
+                                   i32.const 10
+                                   i32.const 0
+                                   i32.store
+                                   i32.const 15
+                                   i64.const 5
+                                   i64.store
+                                   i32.const 24
+                                   i64.const 5
+                                   i64.store
+                                   i64.const 5
+                                   call $syscall
+                                   i32.const 95
+                                   i32.add
+                                   i32.const 5
+                                   i32.store
+                                   i32.const 105
+                                   i32.const 5
+                                   i32.store
+                                   i64.const 100
+                                   call $syscall
+                                   i32.const 6
+                                   i32.add
+                                   i32.const 5
+                                   i32.store
+                                   i32.const 111
+                                   i32.const 9
+                                   i32.store
+                                   i64.const 106
+                                   call $syscall
+                                   i32.const 5
+                                   i32.sub
+                                   i64.extend_i32_s
+                                   (i64.const 10)
+                                   (i64.const 555)
+                                   ))
+                             |}
   in
 
   let storage = Bytes.empty in
   let addr = make_address () in
   let ticket = make_ticket () in
-  let argument = Int64.zero |> Ticket_handle.to_bytes in
+  let argument = Int32.zero |> Ticket_handle.to_bytes in
   let self = make_contract_address "test" in
   let make_custom' =
     make_custom
@@ -225,11 +228,12 @@ let test_ticket_split () =
   let tickets_table, _table =
     Ticket_table.take_all_tickets table
       ~sender:(Core_deku.Address.of_contract_hash self) in
-  let ctx =
-    make_custom' ~tickets:(Seq.return (ticket, Amount.of_int 10)) ~tickets_table
-  in
+  let ctx, _ =
+    make_custom' ~mapping:[]
+      ~tickets:(Seq.return ((ticket, Amount.of_int 10), (Int32.zero, Some 0L)))
+      ~tickets_table in
   let _, _ = invoke ~ctx ~storage ~argument code in
-  let tickets, _ = ctx#finalize [] |> Result.get_ok in
+  let _, tickets, _ = ctx#finalize [] |> Result.get_ok in
   let tickets = List.of_seq tickets in
   let imit_hanlde = [(ticket, Amount.of_int 5); (ticket, Amount.of_int 5)] in
   Alcotest.(check @@ list @@ pair Testables.ticket_id Testables.amount)
@@ -241,70 +245,70 @@ let test_ticket_send_twice () =
   let open Context in
   let code =
     {|
-                               (module
-                                 (import "env" "syscall" (func $syscall (param i64) (result i32)))
-                                 (memory (export "memory") 1)
-                                 (func (export "main")  (param i32) (result i64 i64 i64)
-                                   i32.const 52
-                                   i32.const 8
-                                   i32.store
-                                   i32.const 57
-                                   i32.const 0
-                                   i32.store
-                                   i32.const 62
-                                   i32.const 8
-                                   i32.store
-                                   i32.const 67
-                                   i64.const 10
-                                   i64.store
-                                   i32.const 76
-                                   i32.const 16
-                                   i32.store
-                                   i64.const 52
-                                   call $syscall
-                                   i64.extend_i32_s
-                                   (i64.const 0)
-                                   i32.const 102
-                                   i32.const 1
-                                   i32.store
-                                   i32.const 107
-                                   i32.const 1
-                                   i32.store
-                                   (i64.const 102)
-                                   ))
-                             |}
+                                  (module
+                                    (import "env" "syscall" (func $syscall (param i64) (result i32)))
+                                    (memory (export "memory") 1)
+                                    (func (export "main")  (param i32) (result i64 i64 i64)
+                                      i32.const 57
+                                      i32.const 8
+                                      i32.store
+                                      i32.const 62
+                                      i32.const 0
+                                      i32.store
+                                      i32.const 67
+                                      i32.const 8
+                                      i32.store
+                                      i32.const 72
+                                      i64.const 10
+                                      i64.store
+                                      i32.const 81
+                                      i32.const 12
+                                      i32.store
+                                      i64.const 57
+                                      call $syscall
+                                      i64.extend_i32_s
+                                      (i64.const 0)
+                                      i32.const 102
+                                      i32.const 1
+                                      i32.store
+                                      i32.const 107
+                                      i32.const 1
+                                      i32.store
+                                      (i64.const 102)
+                                      ))
+                                |}
   in
   let code2 =
     {|
-                               (module
-                                 (import "env" "syscall" (func $syscall (param i64) (result i32)))
-                                 (memory (export "memory") 1)
-                                 (func (export "main")  (param i32) (result i64 i64 i64)
-                                   i32.const 41
-                                   i32.const 5
-                                   i32.store
-                                   i32.const 46
-                                   i32.const 0
-                                   i32.store
-                                   i64.const 41
-                                   call $syscall
-                                   i64.extend_i32_s
-                                   (i64.const 40)
-                                   (i64.const 99)
-                                   ))
-                             |}
+                                  (module
+                                    (import "env" "syscall" (func $syscall (param i64) (result i32)))
+                                    (memory (export "memory") 1)
+                                    (func (export "main")  (param i32) (result i64 i64 i64)
+                                      i32.const 41
+                                      i32.const 5
+                                      i32.store
+                                      i32.const 46
+                                      i32.const 0
+                                      i32.store
+                                      i64.const 41
+                                      call $syscall
+                                      i64.extend_i32_s
+                                      (i64.const 40)
+                                      (i64.const 99)
+                                      ))
+                                |}
   in
   let storage = Bytes.empty in
   let addr = make_address () in
   let ticket = make_ticket () in
-  let handle = Int64.zero in
+  let handle = Int32.zero in
   let contract_address1 = make_contract_address "test" in
   let contract_address2 = make_contract_address "test2" in
   let table = Ticket_table.empty in
   let argument =
     Bytes.concat Bytes.empty
       [
-        i64 8L;
+        i64 4L;
         Ticket_handle.to_bytes handle;
         Address.to_string (Core_deku.Address.of_contract_hash contract_address2)
         |> Bytes.of_string;
@@ -318,23 +322,26 @@ let test_ticket_send_twice () =
       ~sender:
         (Core_deku.Address.of_contract_hash (make_contract_address "test"))
   in
-  let ctx =
+  let ctx, _ =
     make_state ~source:addr ~sender:addr ~contract_owned_tickets:tickets_table
       ~get_contract_opt:(fun _ -> None)
+      ~mapping:[]
       ~self:(Core_deku.Address.of_contract_hash contract_address1)
-      ~provided_tickets:(Seq.return (ticket, Amount.of_int 10)) in
+      ~provided_tickets:
+        (Seq.return ((ticket, Amount.of_int 10), (Int32.zero, Some 4L))) in
   let _, ops = invoke ~ctx ~storage ~argument code in
-  let tickets, ops = ctx#finalize ops |> Result.get_ok in
+  let _, tickets, ops = ctx#finalize ops |> Result.get_ok in
   let ops = ops |> List.hd in
   Alcotest.(check Testables.contract_operation)
     "Same Ops"
     (Operation.Invoke
        {
-         tickets = [(ticket, Amount.of_int 10)];
+         tickets = [((ticket, Amount.of_int 10), (Int32.zero, Some 0L))];
          destination = Core_deku.Address.of_contract_hash contract_address2;
-         param = Ticket_handle.to_bytes Int64.zero;
+         param = Ticket_handle.to_bytes Int32.zero;
        })
     ops;
+
   let table =
     Ticket_table.update_tickets table
       ~sender:
@@ -349,8 +356,8 @@ let test_ticket_send_twice () =
       ~sender:
         (Core_deku.Address.of_contract_hash (make_contract_address "test"))
   in
-  let ctx =
-    make_state
+  let ctx, _ =
+    make_state ~mapping:[]
       ~sender:(Core_deku.Address.of_contract_hash contract_address1)
       ~contract_owned_tickets:tickets_table
       ~self:(Core_deku.Address.of_contract_hash contract_address2)
@@ -361,7 +368,7 @@ let test_ticket_send_twice () =
       ~source:addr
       ~get_contract_opt:(fun _ -> None) in
   let _, _ = invoke ~ctx ~storage ~argument:param code2 in
-  let tickets, _ = ctx#finalize [] |> Result.get_ok in
+  let _, tickets, _ = ctx#finalize [] |> Result.get_ok in
   let tickets = List.of_seq tickets in
   let imit_hanlde = [(ticket, Amount.of_int 10)] in
   Alcotest.(check @@ list @@ pair Testables.ticket_id Testables.amount)
@@ -372,44 +379,43 @@ let test_ticket_send_implicit () =
   let open Contracts in
   let code =
     {|
-           (module
-           (import "env" "syscall" (func $syscall (param i64) (result i32)))
-           (memory (export "memory") 1)
-           (func (export "main")  (param i32) (result i64 i64 i64)
-             i32.const 46
-             i32.const 8
-             i32.store
-             i32.const 51
-             i32.const -1
-             i32.store
-             i32.const 56
-             i32.const 0
-             i32.store
-             i32.const 61
-             i64.const 10
-             i64.store
-             i32.const 70
-             i32.const 8
-             i32.store
-             i64.const 46
-             call $syscall
-             i64.extend_i32_s
-             (i64.const 0)
-             i32.const 92
-             i32.const 1
-             i32.store
-             i32.const 97
-             i32.const 1
-             i32.store
-             (i64.const 92)
-             ))
-
-                                 |}
+              (module
+              (import "env" "syscall" (func $syscall (param i64) (result i32)))
+              (memory (export "memory") 1)
+              (func (export "main")  (param i32) (result i64 i64 i64)
+                i32.const 49
+                i32.const 8
+                i32.store
+                i32.const 54
+                i32.const -1
+                i32.store
+                i32.const 59
+                i32.const 0
+                i32.store
+                i32.const 64
+                i64.const 10
+                i64.store
+                i32.const 73
+                i32.const 4
+                i32.store
+                i64.const 49
+                call $syscall
+                i64.extend_i32_s
+                (i64.const 0)
+                i32.const 92
+                i32.const 1
+                i32.store
+                i32.const 97
+                i32.const 1
+                i32.store
+                (i64.const 92)
+                ))
+                                    |}
   in
   let storage = Bytes.empty in
   let addr = make_address () in
   let ticket = make_ticket () in
-  let handle = Int64.zero in
+  let handle = Int32.zero in
   let contract_address1 = make_contract_address "test" in
   let table = Ticket_table.empty in
   let argument =
@@ -424,14 +430,15 @@ let test_ticket_send_implicit () =
   let tickets_table, _table =
     Ticket_table.take_all_tickets table
       ~sender:(Address.of_contract_hash (make_contract_address "test")) in
-  let ctx =
-    Context.make_state ~source:addr ~sender:addr
+  let ctx, _ =
+    Context.make_state ~source:addr ~sender:addr ~mapping:[]
       ~contract_owned_tickets:tickets_table
       ~get_contract_opt:(fun _ -> None)
       ~self:(Address.of_contract_hash contract_address1)
-      ~provided_tickets:(Seq.return (ticket, Amount.of_int 10)) in
+      ~provided_tickets:
+        (Seq.return ((ticket, Amount.of_int 10), (Int32.zero, Some 0L))) in
   let _, ops = invoke ~ctx ~storage ~argument code in
-  let x = ctx#finalize ops |> Result.get_ok |> snd |> List.hd in
+  let x = ctx#finalize ops |> Result.get_ok |> (fun (_, _, x) -> x) |> List.hd in
   Alcotest.(check Testables.contract_operation)
     "Same"
     (Context.Operation.Transfer
@@ -444,36 +451,36 @@ let test_ticket_own_dup () =
   let open Context in
   let code =
     {|
-                         (module
-                           (import "env" "syscall" (func $syscall (param i64) (result i32)))
-                           (memory (export "memory") 1)
-                           (func (export "main")  (param i32) (result i64 i64 i64)
-                             i32.const 41
-                             i32.const 5
-                             i32.store
-                             i32.const 46
-                             i32.const 0
-                             i32.store
-                             i64.const 41
-                             call $syscall
-                             i32.const 5
-                             i32.store
-                             i32.const 46
-                             i32.const 0
-                             i32.store
-                             i64.const 41
-                             call $syscall
-                             i64.extend_i32_s
-                             (i64.const 40)
-                             (i64.const 8)
+                            (module
+                              (import "env" "syscall" (func $syscall (param i64) (result i32)))
+                              (memory (export "memory") 1)
+                              (func (export "main")  (param i32) (result i64 i64 i64)
+                                i32.const 41
+                                i32.const 5
+                                i32.store
+                                i32.const 46
+                                i32.const 0
+                                i32.store
+                                i64.const 41
+                                call $syscall
+                                i32.const 5
+                                i32.store
+                                i32.const 46
+                                i32.const 0
+                                i32.store
+                                i64.const 41
+                                call $syscall
+                                i64.extend_i32_s
+                                (i64.const 40)
+                                (i64.const 8)
 
-                             ))
-                       |}
+                                ))
+                          |}
   in
   let storage = Bytes.empty in
   let addr = make_address () in
   let ticket = make_ticket () in
-  let handle = Int64.zero in
+  let handle = Int32.zero in
   let argument = handle |> Ticket_handle.to_bytes in
   let table = Ticket_table.empty in
   let table =
@@ -484,11 +491,13 @@ let test_ticket_own_dup () =
       ~sender:
         (Core_deku.Address.of_contract_hash (make_contract_address "test"))
   in
-  let ctx =
+  let ctx, _ =
     make_state ~source:addr ~sender:addr ~contract_owned_tickets:tickets_table
+      ~mapping:[]
       ~get_contract_opt:(fun _ -> None)
       ~self:(make_contract_address "test" |> Core_deku.Address.of_contract_hash)
-      ~provided_tickets:(Seq.return (ticket, Amount.of_int 10)) in
+      ~provided_tickets:
+        (Seq.return ((ticket, Amount.of_int 10), (Int32.zero, None))) in
   Alcotest.check_raises "Invocation error" Invocation_error (fun () ->
       ignore
         (invoke ~ctx ~storage ~argument code |> fst |> Ticket_handle.of_bytes))
@@ -499,11 +508,11 @@ let test =
     [
       test_case "Simple invocation" `Quick test_simple_invocation;
       test_case "Tickets join" `Quick test_ticket_join;
-      test_case "Tickets split" `Quick test_ticket_split;
+      test_case "Tickets ownership dup fails" `Quick test_ticket_own_dup;
       test_case "Tickets ownership" `Quick test_ticket_own;
+      test_case "Tickets split" `Quick test_ticket_split;
       test_case "Tickets transfer: implicit -> originated -> invoke originated"
         `Quick test_ticket_send_twice;
-      test_case "Tickets ownership dup fails" `Quick test_ticket_own_dup;
       test_case "Tickets transfer: implicit -> originated -> implicit" `Quick
         test_ticket_send_implicit;
     ] )


### PR DESCRIPTION
## Depends

<!--- All PR or issues that are required to be closed / merged before this can be merged --->
- [x] #700
- [x] #707
- [x] #724 

## Problem

We don't update ticket handles in serialized storage when saving new contract state, and that leads to invalid contract state on next execution
## Solution

Fix it

 