### PR TITLE
Use deku-cli without data folder

### DIFF
--- a/sandbox.sh
+++ b/sandbox.sh
@@ -360,7 +360,7 @@ deposit_withdraw_test() {
   fi
 
   # # We can withdraw 10 tickets from deku
-  OPERATION_HASH=$(deku-cli withdraw data/0 ./wallet.json "$DUMMY_TICKET" 10 "Pair \"$DUMMY_TICKET\" 0x" | awk '{ print $2 }' | tr -d '\t\n\r')
+  OPERATION_HASH=$(deku-cli withdraw ./wallet.json "$DUMMY_TICKET" 10 "Pair \"$DUMMY_TICKET\" 0x" | awk '{ print $2 }' | tr -d '\t\n\r')
   sleep 20
 
   WITHDRAW_PROOF=$(deku-cli withdraw-proof data/0 "$OPERATION_HASH" "$DUMMY_TICKET%burn_callback" | tr -d '\t\n\r')

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -363,7 +363,7 @@ deposit_withdraw_test() {
   OPERATION_HASH=$(deku-cli withdraw ./wallet.json "$DUMMY_TICKET" 10 "Pair \"$DUMMY_TICKET\" 0x" | awk '{ print $2 }' | tr -d '\t\n\r')
   sleep 20
 
-  WITHDRAW_PROOF=$(deku-cli withdraw-proof data/0 "$OPERATION_HASH" "$DUMMY_TICKET%burn_callback" | tr -d '\t\n\r')
+  WITHDRAW_PROOF=$(deku-cli withdraw-proof "$OPERATION_HASH" "$DUMMY_TICKET%burn_callback" | tr -d '\t\n\r')
   if [ -z "$WITHDRAW_PROOF" ]; then
     echo Withdraw failed!
     exit 1

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -352,7 +352,7 @@ deposit_withdraw_test() {
   DUMMY_TICKET=$(tezos-client show known contract dummy_ticket | tr -d '\t\n\r')
 
   # Check that the ticket has been deposited on deku
-  BALANCE=$(deku-cli get-balance data/0 $DEKU_ADDRESS "(Pair \"$DUMMY_TICKET\" 0x)" | sed -n "s/Balance: \([0-9]*\)/\1/p")
+  BALANCE=$(deku-cli get-balance $DEKU_ADDRESS "(Pair \"$DUMMY_TICKET\" 0x)" | sed -n "s/Balance: \([0-9]*\)/\1/p")
   if ((BALANCE == 0))
   then
     echo "error: Balance for ticket $DUMMY_TICKET is \"$BALANCE\"! Did the deposit fail?"

--- a/src/bin/deku_cli.ml
+++ b/src/bin/deku_cli.ml
@@ -1,14 +1,10 @@
 open Helpers
 open Crypto
-open Protocol
 open Cmdliner
 open Core_deku
 open Bin_common
 
 let () = Printexc.record_backtrace true
-
-let read_identity ~node_folder =
-  Files.Identity.read ~file:(node_folder ^ "/identity.json")
 
 let man = [`S Manpage.s_bugs; `P "Email bug reports to <contact@marigold.dev>."]
 
@@ -263,21 +259,6 @@ let originate_contract node_uri contract_json initial_storage sender_wallet_file
     (BLAKE2B.to_string originate_contract_op.hash);
 
   Lwt.return (`Ok ())
-
-let folder_node position =
-  let docv = "folder_node" in
-  let doc = "The folder where the node lives." in
-  let open Arg in
-  required & pos position (some string) None & info [] ~doc ~docv
-
-let address_from position =
-  let doc =
-    "The sending address, or a path to a wallet% If a bare sending address is \
-     provided, the corresponding wallet is assumed to be in the working \
-     directory." in
-  let env = Cmd.Env.info "SENDER" ~doc in
-  let open Arg in
-  required & pos position (some wallet) None & info [] ~env ~docv:"sender" ~doc
 
 let node_uri =
   let doc = "Uri of a trusted node." in
@@ -535,19 +516,16 @@ let show_help =
       ~man )
 
 let info_self =
-  let doc = "Shows identity key and address of the node." in
+  let doc = "Shows address of the node." in
   Cmd.info "self" ~version:"%\226\128\140%VERSION%%" ~doc ~exits ~man
 
-let self node_folder =
-  let%await identity = read_identity ~node_folder in
-  Format.printf "key: %s\n" (Wallet.to_string identity.key);
-  Format.printf "address: %s\n" (Key_hash.to_string identity.t);
-  Format.printf "uri: %s\n" (Uri.to_string identity.uri);
-  await (`Ok ())
+let self node_uri =
+  Format.printf "uri: %s\n" (Uri.to_string node_uri);
+  `Ok ()
 
 let self =
   let open Term in
-  lwt_ret (const self $ folder_node 0)
+  ret (const self $ node_uri)
 
 let default_info =
   let doc = "Deku cli" in

--- a/src/bin/deku_cli.ml
+++ b/src/bin/deku_cli.ml
@@ -448,10 +448,9 @@ let withdraw =
   lwt_ret
     (const withdraw $ node_uri $ address_from $ tezos_address $ amount $ ticket)
 
-let withdraw_proof node_folder operation_hash callback =
+let withdraw_proof node_uri operation_hash callback =
   let open Network in
-  let%await identity = read_identity ~node_folder in
-  let%await result = request_withdraw_proof { operation_hash } identity.uri in
+  let%await result = request_withdraw_proof { operation_hash } node_uri in
   match result with
   | Unknown_operation ->
     let message = BLAKE2B.to_string operation_hash ^ " is unknown" in
@@ -492,16 +491,15 @@ let withdraw_proof =
     let docv = "operation_hash" in
     let doc = "The operation hash used on the withdraw." in
     let open Arg in
-    required & pos 1 (some hash) None & info [] ~doc ~docv in
+    required & pos 0 (some hash) None & info [] ~doc ~docv in
   let contract_callback =
     let docv = "contract_callback" in
     let doc = "Contract callback to be used on the withdraw" in
     let open Arg in
-    required & pos 2 (some address_tezos_interop) None & info [] ~doc ~docv
+    required & pos 1 (some address_tezos_interop) None & info [] ~doc ~docv
   in
   let open Term in
-  lwt_ret
-    (const withdraw_proof $ folder_node 0 $ operation_hash $ contract_callback)
+  lwt_ret (const withdraw_proof $ node_uri $ operation_hash $ contract_callback)
 
 let info_get_ticket_balance =
   let doc = "Get balance of a ticket for an account." in

--- a/src/bin/deku_cli.ml
+++ b/src/bin/deku_cli.ml
@@ -505,31 +505,25 @@ let info_get_ticket_balance =
   let doc = "Get balance of a ticket for an account." in
   Cmd.info "get-balance" ~version:"%\226\128\140%VERSION%%" ~doc ~exits ~man
 
-let get_ticket_balance node_folder address ticket =
+let get_ticket_balance node_uri address ticket =
   let open Network in
-  let%await identity = read_identity ~node_folder in
-  let%await result = request_ticket_balance { address; ticket } identity.uri in
+  let%await result = request_ticket_balance { address; ticket } node_uri in
   Format.printf "Balance: %i\n%!" (Amount.to_int result.amount);
   await (`Ok ())
 
 let get_ticket_balance =
   let open Term in
-  let folder_node =
-    let docv = "folder_node" in
-    let doc = "The folder where the node lives." in
-    let open Arg in
-    required & pos 0 (some string) None & info [] ~doc ~docv in
   let address =
     let docv = "address" in
     let doc = "The account address to get the balance." in
     let open Arg in
-    required & pos 1 (some address_implicit) None & info [] ~docv ~doc in
+    required & pos 0 (some address_implicit) None & info [] ~docv ~doc in
   let ticket =
     let docv = "ticket" in
     let doc = "The ticket to get the balance." in
     let open Arg in
-    required & pos 2 (some ticket) None & info [] ~docv ~doc in
-  lwt_ret (const get_ticket_balance $ folder_node $ address $ ticket)
+    required & pos 1 (some ticket) None & info [] ~docv ~doc in
+  lwt_ret (const get_ticket_balance $ node_uri $ address $ ticket)
 
 let show_help =
   let doc = "a tool for interacting with the WIP Tezos Sidechain" in


### PR DESCRIPTION
# Problem

The `deku-cli` can only be used if you have a running Deku cluster on your machine. 

# Solution
Remove the access to the data folder of each node.

# Depends

[PR#732](https://github.com/marigold-dev/deku/pull/732)

