### PR TITLE
Restrict critical files permissions for Deku nodes

### DIFF
--- a/sandbox.sh
+++ b/sandbox.sh
@@ -151,6 +151,9 @@ create_new_deku_environment() {
     FOLDER="$DATA_DIRECTORY/$i"
     mkdir -p "$FOLDER"
 
+    # TODO: Remove this once 732 is merged
+    umask 066
+
     if [ $mode = "docker" ]; then
       # Using the deku-cli to generate identities for each node
       # It is important to decide the URI of each node with the `--uri` flag

--- a/src/bin/deku_node.ml
+++ b/src/bin/deku_node.ml
@@ -222,6 +222,8 @@ let () =
   Dream.initialize_log ~enable:false ()
 
 let node json_logs style_renderer level folder prometheus_port =
+  let _ = Unix.umask 0o066 in
+
   (match style_renderer with
   | Some style_renderer -> Fmt_tty.setup_std_outputs ~style_renderer ()
   | None -> Fmt_tty.setup_std_outputs ());


### PR DESCRIPTION
<!---
  if some of the following sections doesn't apply,
  delete the section.

  Also feel free to delete the comments.
--->
## Problem

Any unprivileged user can read identity files and other sensitive information, which could be targeted as privileged escalation attack or could leak the node private's keys.

## Solution

<!--- Restate the basic ideas behind your solution --->
<!--- Here it is also a good space to put details of your implementation --->
Change umask to restrict the access to those files.