### PR TITLE
Refactor and change the place of consensus.mligo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ result
 data/
 wallet.json
 
+# Vscode-history
+.history
+
 # Others
 node_modules
 *.install

--- a/layer1/bridge/consensus/assert.mligo
+++ b/layer1/bridge/consensus/assert.mligo
@@ -1,0 +1,4 @@
+
+let assert_msg ((message, condition): (string * bool)) =
+if not condition then
+  failwith message

--- a/layer1/bridge/consensus/deposit.mligo
+++ b/layer1/bridge/consensus/deposit.mligo
@@ -1,0 +1,29 @@
+#import "errors.mligo" "Errors"
+#import "parameter.mligo" "Parameter"
+
+type vault = Parameter.Types.vault
+type vault_deposit = Parameter.Types.vault_deposit
+type vault_storage = Parameter.Types.vault_storage
+
+let vault_deposit (deposit: vault_deposit) (storage: vault_storage) =
+  let { known_handles_hash; used_handles; vault } = storage in
+  let (content, ticket) =  Tezos.read_ticket deposit.ticket in
+  let (ticketer, (data, _)) = content in
+  let (ticket, vault) =
+    match
+      Big_map.get_and_update
+        (ticketer, data)
+        (None: bytes ticket option)
+        vault
+    with
+    | (None, vault) -> (ticket, vault)
+    | (Some old_ticket, vault) ->
+      (match Tezos.join_tickets (old_ticket, ticket) with
+      | Some ticket -> (ticket, vault)
+      | None -> ((failwith Errors.unreachable): (bytes ticket * vault))) in
+  let vault = Big_map.add (ticketer, data) ticket vault in
+  {
+    known_handles_hash = known_handles_hash;
+    used_handles = used_handles;
+    vault = vault;
+  }

--- a/layer1/bridge/consensus/errors.mligo
+++ b/layer1/bridge/consensus/errors.mligo
@@ -1,0 +1,25 @@
+let old_block_hash : string = "old block height"
+
+let not_enough_keys : string = "not enough keys"
+
+let mismatch_key_hash : string = "validator_key does not match validator hash"
+
+let different_size_keys_validators : string = "validator_keys and validators have different size"
+
+let not_enough_key_signature_matches : string = "not enough key-signature matches"
+
+let bad_signature : string = "bad signature"
+
+let different_size_validators_signatures : string = "validators and signatures have different size"
+
+let unreachable : string = "unreachable"
+
+let invalid_handle_data : string = "invalid handle data"
+
+let invalid_proof_hash : string = "invalid proof hash"
+
+let unknown_handle_hash : string = "unknown handles hash"
+
+let used_hash : string = "already used handle"
+
+let owner_withdraw_handle : string = "only the owner can withdraw a handle"

--- a/layer1/bridge/consensus/main.mligo
+++ b/layer1/bridge/consensus/main.mligo
@@ -1,0 +1,33 @@
+#import "errors.mligo" "Error"
+#import "parameter.mligo" "Parameter"
+#import "update_root_hash.mligo" "Update_root_hash"
+#import "deposit.mligo" "Deposit"
+#import "withdraw.mligo" "Withdraw"
+
+type storage = {
+    root_hash: Parameter.Types.root_hash_storage;
+    vault: Parameter.Types.vault_storage;
+  }
+
+type action =
+| Update_root_hash of Parameter.Types.root_hash_action
+| Deposit of Parameter.Types.vault_deposit
+| Withdraw of Parameter.Types.vault_withdraw
+
+let main (action, storage : action * storage) =
+  let { root_hash; vault } = storage in
+  match action with
+  | Update_root_hash root_hash_update ->
+    let root_hash = Update_root_hash.root_hash_main root_hash_update root_hash in
+    let vault =
+      Update_root_hash.vault_add_handles_hash
+        root_hash.current_handles_hash
+        vault in
+    (([] : operation list), { root_hash = root_hash; vault = vault })
+  | Deposit deposit ->
+      let vault = Deposit.vault_deposit deposit vault in
+      (([] : operation list), { root_hash = root_hash; vault = vault; })
+  | Withdraw withdraw ->
+    let (operations, vault) = Withdraw.vault_withdraw withdraw vault in
+    (operations, { root_hash = root_hash; vault = vault; })
+

--- a/layer1/bridge/consensus/parameter.mligo
+++ b/layer1/bridge/consensus/parameter.mligo
@@ -1,0 +1,83 @@
+module Types = struct
+  type blake2b = bytes
+
+  (* Store hash *)
+  type validator = key_hash
+  type validators = validator list
+  type validator_key = key
+  type validator_keys = validator_key option list
+
+  (* Root_hash_update contract *)
+  type root_hash_storage = {
+    (* TODO: is having current_block_hash even useful? *)
+    (* consensus proof *)
+    current_block_hash: blake2b;
+    current_block_height: int;
+    current_state_hash: blake2b;
+    current_handles_hash: blake2b;
+    current_validators: validators;
+  }
+
+  type signatures = signature option list
+
+  type root_hash_action = {
+    block_height: int;
+    block_payload_hash: blake2b;
+
+    state_hash: blake2b;
+    handles_hash: blake2b;
+    (* TODO: performance, can this blown up? *)
+    validators: validators;
+
+    current_validator_keys: validator_keys;
+    signatures: signatures;
+  }
+
+  (* (pair (pair int bytes) (pair bytes validators)) *)
+  (* TODO: performance, put this structures in an optimized way *)
+  type block_hash_structure = {
+    block_height: int;
+    block_payload_hash: blake2b;
+    state_hash: blake2b;
+    handles_hash: blake2b;
+    validators_hash: blake2b;
+  }
+
+  (* vault contract *)
+  type vault_ticket = bytes ticket
+  type vault = (address * bytes, vault_ticket) big_map
+  type vault_handle_id = nat
+  type vault_used_handle_set = (vault_handle_id, unit) big_map
+  type vault_known_handles_hash_set = (blake2b, unit) big_map
+  type vault_storage = {
+    known_handles_hash: (blake2b, unit) big_map;
+    used_handles: vault_used_handle_set;
+    vault: vault;
+  }
+
+  (* deposit entrypoint *)
+  type vault_deposit = {
+    ticket: vault_ticket;
+    (* WARNING: deposit address should be a valid sidechain address *)
+    address: address
+  }
+
+  (* TODO: this could be variable in size *)
+  type vault_handle_structure = {
+    (* having the id is really important to change the hash,
+      otherwise people would be able to craft handles using old proofs *)
+    id: vault_handle_id;
+    owner: address;
+    amount: nat;
+    ticketer: address;
+    (* TODO: probably data_hash *)
+    data: bytes;
+  }
+  type vault_handle_proof = (blake2b * blake2b) list
+  type vault_withdraw = {
+    handles_hash: blake2b;
+    handle: vault_handle_structure;
+    proof: vault_handle_proof;
+    callback: vault_ticket contract;
+  }
+end

--- a/layer1/bridge/consensus/update_root_hash.mligo
+++ b/layer1/bridge/consensus/update_root_hash.mligo
@@ -1,0 +1,126 @@
+#import "assert.mligo" "Assert"
+#import "errors.mligo" "Errors"
+#import "parameter.mligo" "Parameter"
+
+type blake2b = Parameter.Types.blake2b
+type root_hash_action = Parameter.Types.root_hash_action
+type validator_keys = Parameter.Types.validator_keys
+type signatures = Parameter.Types.signatures
+type root_hash_storage = Parameter.Types.root_hash_storage
+type validators = Parameter.Types.validators
+type vault_storage = Parameter.Types.vault_storage
+
+let root_hash_block_hash (root_hash_update: root_hash_action) =
+    let block_hash_structure = {
+      block_height = root_hash_update.block_height;
+      block_payload_hash = root_hash_update.block_payload_hash;
+      state_hash = root_hash_update.state_hash;
+      handles_hash = root_hash_update.handles_hash;
+      (* TODO: should we do pack of list? *)
+      validators_hash = Crypto.blake2b (Bytes.pack root_hash_update.validators)
+    } in
+    Crypto.blake2b (Bytes.pack block_hash_structure)
+
+let root_hash_check_block_height
+  (storage: root_hash_storage)
+  (block_height: int) =
+    Assert.assert_msg (
+      Errors.old_block_hash,
+      block_height > storage.current_block_height
+    )
+
+let rec root_hash_check_signatures
+  (validator_keys, signatures, block_hash, remaining:
+    validator_keys * signatures * blake2b * int) : unit =
+    match (validator_keys, signatures) with
+    (* already signed *)
+    | ([], []) ->
+      (* TODO: this can be short circuited *)
+      if remaining > 0 then
+        failwith Errors.not_enough_key_signature_matches
+    | ((Some validator_key :: vk_tl), (Some signature :: sig_tl)) ->
+      if Crypto.check validator_key signature block_hash
+      then
+        root_hash_check_signatures (vk_tl, sig_tl, block_hash, (remaining - 1))
+      else failwith Errors.bad_signature
+    | ((_ :: vk_tl), (None :: sig_tl)) ->
+      root_hash_check_signatures (vk_tl, sig_tl, block_hash, remaining)
+    | ((None :: vk_tl), (_ :: sig_tl)) ->
+      root_hash_check_signatures (vk_tl, sig_tl, block_hash, remaining)
+    | (_, _) ->
+      failwith Errors.different_size_validators_signatures
+
+let root_hash_check_signatures
+  (action: root_hash_action)
+  (storage: root_hash_storage)
+  (signatures: signatures)
+  (block_hash: blake2b) =
+    let validators_length = (int (List.length storage.current_validators)) in
+    let required_validators = (validators_length * 2) / 3 in
+    root_hash_check_signatures (
+      action.current_validator_keys,
+      signatures,
+      block_hash,
+      required_validators
+    )
+
+let rec root_hash_check_keys
+  (validator_keys, validators, block_hash, remaining:
+    validator_keys * validators * blake2b * int) : unit =
+    match (validator_keys, validators) with
+    | ([], []) ->
+      if remaining > 0 then
+        failwith Errors.not_enough_keys
+    | ((Some validator_key :: vk_tl), (validator :: v_tl)) ->
+      if (Crypto.hash_key validator_key) = validator then
+        root_hash_check_keys (vk_tl, v_tl, block_hash, (remaining - 1))
+      else failwith Errors.mismatch_key_hash
+    | ((None :: vk_tl), (_ :: v_tl)) ->
+      root_hash_check_keys (vk_tl, v_tl, block_hash, remaining)
+    | (_, _) ->
+      failwith Errors.different_size_keys_validators
+
+let root_hash_check_keys
+  (action: root_hash_action)
+  (storage: root_hash_storage)
+  (block_hash: blake2b) =
+    let validators_length = (int (List.length storage.current_validators)) in
+    let required_validators = (validators_length * 2) / 3 in
+    root_hash_check_keys (
+      action.current_validator_keys,
+      storage.current_validators,
+      block_hash,
+      required_validators
+    )
+
+let root_hash_main
+  (root_hash_update: root_hash_action)
+  (storage: root_hash_storage) =
+    let block_hash = root_hash_block_hash root_hash_update in
+    let block_height = root_hash_update.block_height in
+    let state_hash = root_hash_update.state_hash in
+    let handles_hash = root_hash_update.handles_hash in
+    let validators = root_hash_update.validators in
+    let signatures = root_hash_update.signatures in
+
+    let () = root_hash_check_block_height storage block_height in
+    let () = root_hash_check_signatures root_hash_update storage signatures block_hash in
+    let () = root_hash_check_keys root_hash_update storage block_hash in
+
+    {
+      current_block_hash = block_hash;
+      current_block_height = block_height;
+      current_state_hash = state_hash;
+      current_handles_hash = handles_hash;
+      current_validators = validators;
+    }
+
+(* bridge between root_hash and vault *)
+let vault_add_handles_hash (handles_hash: blake2b) (storage: vault_storage) =
+  let { known_handles_hash; used_handles; vault } = storage in
+  let known_handles_hash = Big_map.add handles_hash () known_handles_hash in
+  {
+    known_handles_hash = known_handles_hash;
+    used_handles = used_handles;
+    vault = vault;
+  }

--- a/layer1/bridge/consensus/withdraw.mligo
+++ b/layer1/bridge/consensus/withdraw.mligo
@@ -1,0 +1,85 @@
+#import "errors.mligo" "Errors"
+#import "parameter.mligo" "Parameter"
+#import "assert.mligo" "Assert"
+
+type blake2b = Parameter.Types.blake2b
+type vault = Parameter.Types.vault
+type vault_handle_proof = Parameter.Types.vault_handle_proof
+type vault_handle_structure = Parameter.Types.vault_handle_structure
+type vault_withdraw = Parameter.Types.vault_withdraw
+type vault_storage = Parameter.Types.vault_storage
+
+let vault_check_handle_proof
+  (proof: vault_handle_proof)
+  (root: blake2b)
+  (handle: vault_handle_structure) =
+    let bit_is_set (bit: int) =
+      Bitwise.and (Bitwise.shift_left 1n (abs bit)) handle.id <> 0n in
+    let rec verify
+      (bit, proof, parent: int * vault_handle_proof * blake2b): unit =
+        match proof with
+        | [] -> 
+          let calculated_hash = Crypto.blake2b (Bytes.pack handle) in
+          Assert.assert_msg (Errors.invalid_handle_data, parent = calculated_hash)
+        | (left, right) :: tl ->
+          let () = 
+            let calculated_hash = Crypto.blake2b (Bytes.concat left right) in
+            Assert.assert_msg (Errors.invalid_proof_hash, parent = calculated_hash) in
+          verify (bit - 1, tl, (if bit_is_set bit then right else left)) in
+    (* each bit in the handle_id indicates if we should go left or right in
+        the proof, but the first bit to check is the MSB, so we use the length
+        of the proof to know what is the MSB *)
+    let most_significant_bit = int (List.length proof) - 1 in
+    verify (most_significant_bit, proof, root)
+
+
+  let vault_withdraw (withdraw: vault_withdraw) (storage: vault_storage) =
+    let handles_hash = withdraw.handles_hash in
+    let handle = withdraw.handle in
+    let proof = withdraw.proof in
+
+    let { known_handles_hash; used_handles; vault } = storage in
+
+    let () = Assert.assert_msg (
+      Errors.unknown_handle_hash,
+      Big_map.mem handles_hash known_handles_hash
+    ) in
+    let () = Assert.assert_msg (
+      Errors.used_hash,
+      not Big_map.mem handle.id used_handles
+    ) in
+    let () = Assert.assert_msg (
+      Errors.owner_withdraw_handle,
+      handle.owner = Tezos.sender
+    ) in
+    let () = vault_check_handle_proof proof handles_hash handle in
+
+    (* start transfer *)
+    let used_handles = Big_map.add handle.id () used_handles in
+
+    let (fragment, vault) =
+      let (old_ticket, vault) =
+        match 
+          Big_map.get_and_update
+            (handle.ticketer, handle.data)
+            (None: bytes ticket option)
+            vault
+        with
+        | (Some old_ticket, vault) -> (old_ticket, vault)
+        | (None, _) -> (failwith Errors.unreachable : bytes ticket * vault) in
+      let ((_, (_, total)), old_ticket) = Tezos.read_ticket old_ticket in
+      let (fragment, remaining) =
+        match
+          Tezos.split_ticket
+            old_ticket
+            (handle.amount, abs (total - handle.amount))
+        with
+        | Some (fragment, remaining) -> (fragment, remaining)
+        | None -> (failwith Errors.unreachable : bytes ticket * bytes ticket) in
+      (fragment, Big_map.add (handle.ticketer, handle.data) remaining vault) in
+    let transaction = Tezos.transaction fragment 0tz withdraw.callback in
+    ([transaction], {
+      known_handles_hash = known_handles_hash;
+      used_handles = used_handles;
+      vault = vault;
+    })

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -188,9 +188,9 @@ EOF
     ];
   };
   vault = {
-    known_handles_hash = (Big_map.empty : vault_known_handles_hash_set);
-    used_handles = (Big_map.empty : vault_used_handle_set);
-    vault = (Big_map.empty : vault);
+    known_handles_hash = (Big_map.empty : Parameter.Types.vault_known_handles_hash_set);
+    used_handles = (Big_map.empty : Parameter.Types.vault_used_handle_set);
+    vault = (Big_map.empty : Parameter.Types.vault);
   }
 }
 EOF
@@ -198,7 +198,7 @@ EOF
 )
 
   # Step 4: deploying the consensus and validators discovery contracts
-  consensus="./src/tezos_interop/consensus.mligo"
+  consensus="./layer1/bridge/consensus/main.mligo"
   discovery="./src/tezos_interop/discovery.mligo"
   deploy_contract "consensus" "$consensus" "$consensus_storage"
   deploy_contract "discovery" "$discovery" "$(discovery_storage)"


### PR DESCRIPTION
## Depends
- [ ] #729 
## Problem
The contract `consensus.mligo` includes a lot of stuff so it is difficult to maintain in the future.
## Solution
I refactor this contract, which is based on the cameligo architecture of `advisor` contract in [Github](https://github.com/ligolang/advisor-cameligo). Besides, I put this implementation in `layer1/bridge/consensus` to separate this from the layer2 code base.


 