### PR TITLE
Improve logging of operation errors

### DIFF
--- a/sandbox.sh
+++ b/sandbox.sh
@@ -247,7 +247,7 @@ start_deku_cluster() {
   echo "Starting nodes."
   for i in "${VALIDATORS[@]}"; do
     if [ "$mode" = "local" ]; then
-      deku-node "$DATA_DIRECTORY/$i" --verbosity="${DEKU_LOG_VERBOSITY:-debug}" --listen-prometheus="900$i" &
+      deku-node "$DATA_DIRECTORY/$i" --verbosity="${DEKU_LOG_VERBOSITY:-debug}" --color="${DEKU_LOG_COLOR:-auto}" --listen-prometheus="900$i" &
       SERVERS+=($!)
     fi
   done

--- a/src/core_deku/state.ml
+++ b/src/core_deku/state.ml
@@ -100,8 +100,15 @@ let apply_user_operation t operation_hash user_operation =
     Ok ({ ledger; contract_storage }, None)
 
 let apply_user_operation t hash user_operation =
+  let report_error error =
+    let message =
+      match error with
+      | `Origination_error msg -> "Origination error: " ^ msg
+      | `Invocation_error msg -> "Invocation error: " ^ msg
+      | `Insufficient_funds -> "Insufficient funds" in
+    Log.error "Operation %a - %s" BLAKE2B.pp hash message in
   match apply_user_operation t hash user_operation with
   | Ok (t, receipt) -> (t, receipt)
-  (* TODO: use this erros for something *)
-  | Error (`Origination_error _ | `Invocation_error _) -> (t, None)
-  | Error `Insufficient_funds -> (t, None)
+  | Error error ->
+    report_error error;
+    (t, None)

--- a/src/crypto/BLAKE2B.ml
+++ b/src/crypto/BLAKE2B.ml
@@ -27,6 +27,8 @@ end) : sig
 
   val size : int
 
+  val pp : Format.formatter -> t -> unit
+
   module Map : Map.S with type key = t
 
   val encoding : t Data_encoding.t
@@ -65,6 +67,8 @@ end = struct
   let verify ~hash:expected_hash data = expected_hash = hash data
 
   let both a b = hash (to_raw_string a ^ to_raw_string b)
+
+  let pp fmt t = Format.fprintf fmt "%s" (to_string t)
 
   module Map = Map.Make (struct
     type nonrec t = t


### PR DESCRIPTION
<!---
  if some of the following sections doesn't apply,
  delete the section.

  Also feel free to delete the comments.
--->


## Problem

I had issues with operations that failed silently and also looking for errors on the logs, which can become difficult sometimes because of the amount of information displayed.

## Solution

* Use environment variable to configure color on the output
  of deku-node
* Log error messages from operation errors, like insufficient
  funds and smart contract errors.
* Add simple pretty printing to BLAKE2B module.

 