### PR TITLE
feat: add block pretty printer

### DIFF
--- a/src/protocol/block.ml
+++ b/src/protocol/block.ml
@@ -155,3 +155,8 @@ open Protocol_signature.Make (struct
 end)
 
 let sign ~key t = (sign ~key t).signature
+
+let pp fmt t =
+  let hash_str = BLAKE2B.to_string t.hash in
+  let short_hash = String.sub hash_str 0 8 in
+  Format.fprintf fmt "Block %s %Ld" short_hash t.block_height

--- a/src/protocol/block.mli
+++ b/src/protocol/block.mli
@@ -29,3 +29,5 @@ val produce :
   t
 
 val parse_user_operations : t -> Protocol_operation.Core_user.t list
+
+val pp : Format.formatter -> t -> unit


### PR DESCRIPTION
## Problem
We need to easily identify blocks in logs

## Solution
Add a pretty printer that prints a short hash along with the block level.
