### PR TITLE
protocol: stop checking height on apply_block_data

### DIFF
--- a/src/consensus/apply_block.ml
+++ b/src/consensus/apply_block.ml
@@ -14,7 +14,7 @@ let apply_block_header ~block state =
 
 let apply_block_data ~previous_protocol ~block state =
   (* TODO: handle this errors here *)
-  let%ok protocol, user_operations, receipts =
+  let protocol, user_operations, receipts =
     apply_block_data state.protocol block in
   Metrics.Blocks.inc_operations_processed
     ~operation_count:(List.length user_operations);

--- a/src/protocol/protocol.ml
+++ b/src/protocol/protocol.ml
@@ -146,11 +146,6 @@ let apply_block_header state block =
   let state = apply_block_header state block in
   Ok state
 
-let apply_block_data state block =
-  let%assert () = (`Invalid_block_when_applying, is_next state block) in
-  let state, user_operations, result = apply_block_data state block in
-  Ok (state, user_operations, result)
-
 let get_current_block_producer state =
   if state.last_applied_block_timestamp = 0.0 then
     None


### PR DESCRIPTION
<!---
  if some of the following sections doesn't apply,
  delete the section.

  Also feel free to delete the comments.
--->

## Depends

<!--- All PR or issues that are required to be closed / merged before this can be merged --->
- [ ] #756

## Problem

There's no need to check block heheight in the protocol layer - it's already checked 
in the consensus layer

## Solution

Remove check from the protocol layer.
