### PR TITLE
consensus: handle out of order block arrival

### DIFF
--- a/src/consensus/apply_block.ml
+++ b/src/consensus/apply_block.ml
@@ -102,4 +102,7 @@ let apply_block_data ~previous_protocol ~block state =
     Both
       ( Effect applied_block_effect,
         Effect persist_trusted_membership_change_effect ) in
-  Ok (state, snapshot_ref, Both (Post_apply_block, effects))
+  Ok
+    ( state,
+      snapshot_ref,
+      Both (Post_apply_block { applied_block = block }, effects) )

--- a/src/consensus/block_pool.mli
+++ b/src/consensus/block_pool.mli
@@ -24,5 +24,7 @@ val find_signatures : hash:BLAKE2B.t -> t -> Signatures.t option
 
 val find_next_block_to_apply : hash:BLAKE2B.t -> t -> Block.t option
 
+val find_all_next_blocks : hash:BLAKE2B.t -> t -> Block.t list
+
 val find_all_signed_blocks_above :
   Block.t * Signatures.t -> t -> Block.t list * (Block.t * Signatures.t)

--- a/src/consensus/dispatch.ml
+++ b/src/consensus/dispatch.ml
@@ -28,7 +28,8 @@ let rec dispatch effect step state =
   | Apply_block_header { block } -> apply_block_header ~block effect state
   | Apply_block_data { block; previous_protocol } ->
     apply_block_data ~previous_protocol ~block effect state
-  | Post_apply_block -> post_apply_block effect state
+  | Post_apply_block { applied_block } ->
+    post_apply_block ~applied_block effect state
   | Can_produce_block -> can_produce_block effect state
   | Produce_block -> produce_block effect state
   | Check_validator_change { payload; signature } ->
@@ -94,8 +95,8 @@ and apply_block_data ~previous_protocol ~block effect state =
   | Ok (state, _snapshot_ref, step) -> dispatch effect step state
   | Error err -> (state, [err])
 
-and post_apply_block effect state =
-  let step = Steps.post_apply_block state in
+and post_apply_block ~applied_block effect state =
+  let step = Steps.post_apply_block ~applied_block state in
   dispatch effect step state
 
 and can_produce_block effect state =


### PR DESCRIPTION
<!---
  if some of the following sections doesn't apply,
  delete the section.

  Also feel free to delete the comments.
--->

## Depends

- [ ] #757

## Problem

Right now, a a node does not check to see if he has the next block
after applying the current one. This causes him to needlessly wait if
blocks arrive out of order for any reason.

## Solution

Check for the next block after applying the current one.

 