### PR TITLE
use 5 seconds for the confirmation polling

### DIFF
--- a/src/tezos_interop/tezos_js_bridge.js
+++ b/src/tezos_interop/tezos_js_bridge.js
@@ -82,6 +82,8 @@ const { inspect } = require("util");
  * @property {TransactionResponse | StorageResponse | TransactionMessage | ErrorResponse} content
  */
 
+const devMode = process.env.NODE_ENV === "development";
+
 const failure = (err) => {
   console.error(err);
   process.exit(1);
@@ -145,7 +147,7 @@ const read = (callback) => {
 const config = {
   shouldObservableSubscriptionRetry: true,
   streamerPollingIntervalMilliseconds: 1000,
-  confirmationPollingIntervalSecond: 1,
+  confirmationPollingIntervalSecond: devMode ? 1 : 5,
 };
 
 /** @param {TransactionRequest} content */


### PR DESCRIPTION
<!---
  if some of the following sections doesn't apply,
  delete the section.

  Also feel free to delete the comments.
--->

## Problem

This error happened in production nodes:

```
 Failure("os [MissedBlockDuringConfirmationError]: Taquito missed a block while waiting for operation confirmation and was not able to find the operation\n    at e._tapNext (/tmp/tezos_js_bridge0f65f0.js:2:231069)\n    at e._next (/tmp/tezos_js_bridge0f65f0.js:2:86684)\n    at e.next (/tmp/tezos_js_bridge0f65f0.js:2:60925)\n    at e.notifyNext (/tmp/tezos_js_bridge0f65f0.js:2:82470)\n    at e._next (/tmp/tezos_js_bridge0f65f0.js:2:80638)\n    at e.next (/tmp/tezos_js_bridge0f65f0.js:2:60925)\n    at e.next (/tmp/tezos_js_bridge0f65f0.js:2:66424)\n    at e.nextInfiniteTimeWindow (/tmp/tezos_js_bridge0f65f0.js:2:73767)\n    at Object.next (/tmp/tezos_js_bridge0f65f0.js:2:88967)\n    at e.__tryOrUnsub (/tmp/tezos_js_bridge0f65f0.js:2:62981)")
```

## Solution

When building Deku for non-dev mode, we will use 5 seconds for the confirmation polling.

## Related

<!--- add here all the related issues to your PR --->
- https://github.com/ecadlabs/taquito/issues/276#issuecomment-942726844
 