### PR TITLE
Add proxy contract for deku

### DIFF
--- a/proxy-contract/errors.mligo
+++ b/proxy-contract/errors.mligo
@@ -1,0 +1,1 @@
+let invalid_signature : string = "invalid signature"

--- a/proxy-contract/main.mligo
+++ b/proxy-contract/main.mligo
@@ -1,0 +1,13 @@
+#import "errors.mligo" "Errors"
+#import "parameter.mligo" "Parameter"
+#import "storage.mligo" "Storage"
+
+type address_update = Parameter.Types.t
+type storage = Storage.Types.t 
+
+let main (address_update, storage : address_update * storage) = 
+  let { key; address; signature } = address_update in 
+  let key_hash = Crypto.hash_key key in 
+  let () = Storage.Utils.check_signature key address signature in 
+  let storage = Big_map.add key_hash address storage in 
+  (([] : operation list), storage)

--- a/proxy-contract/parameter.mligo
+++ b/proxy-contract/parameter.mligo
@@ -1,0 +1,8 @@
+module Types = struct
+  (* The updated contract info for the proxy contract *)
+  type t = {
+    key : key; (* The public key of the validator or bridge address *)
+    address : address;
+    signature : signature;
+  }
+end

--- a/proxy-contract/storage.mligo
+++ b/proxy-contract/storage.mligo
@@ -1,0 +1,11 @@
+#import "errors.mligo" "Errors"
+
+module Types = struct
+  type t = (key_hash, address) big_map
+end
+
+module Utils = struct 
+  let check_signature (key : key) (address : address) (signature : signature) =
+    let packed_address = Bytes.pack address in
+    assert_with_error (Crypto.check key signature packed_address) Errors.invalid_signature
+end


### PR DESCRIPTION
## Problem

The proxy contract is the bridge between the Tezos devs and the internal contracts in Deku. Specifically, it is a simple contract with map storage where the key is the validator or bridge address and the value is the corresponding contract. There are some problems related to creating this contract

- How to safely deploy and update the map storage
- How to detect the latest contract and update the value in the proxy contract

## Solution
- For safely deploying and updating, I locally generate the validator and bridge account, sign the updated contract, and include this signature in the payload. In the internal contract, I use **Crypto.check** in the `ligo codebase` to authenticate the correctness of this newly-submitted signature. 
- For detection of the latest contract, I include the scripts for deploying and updating in **create_new_deku_environment** function in `sandbox.sh`