### PR TITLE
Cluster bootstrapper

### DIFF
--- a/sandbox.sh
+++ b/sandbox.sh
@@ -28,7 +28,7 @@ VALIDATORS=( $(seq 0 "$((NUMBER_OF_NODES - 1))") )
 
 # Bootstrapper secret
 # If you want your own you can generate own with "deku-bootstrapper setup-identity"
-BOOTSTRAPPER_SECRET="edsk3CRD8RNhoTPV74p8t9pEvW3zEH2ZZzVD8zns2dyZyY49nbjoiG"
+DEKU_BOOTSTRAPPER_SECRET="edsk3CRD8RNhoTPV74p8t9pEvW3zEH2ZZzVD8zns2dyZyY49nbjoiG"
 
 # =======================
 # Running environments
@@ -151,7 +151,7 @@ create_new_deku_environment() {
 
   # Step 0: create the bootstrapper identity
   message "Create the bootstrapper identity"
-  bootstrapper_key=$(deku-bootstrapper derive-secret --secret $BOOTSTRAPPER_SECRET | grep Key: | awk '{ print $2 }')
+  bootstrapper_key=$(deku-bootstrapper derive-key --secret $DEKU_BOOTSTRAPPER_SECRET | grep Key: | awk '{ print $2 }')
   
   # Step 1: Set up validator identities for each node
   message "Creating validator identities"
@@ -266,7 +266,7 @@ start_deku_cluster() {
   sleep 1.0 # Wait to start deku-node to start its dream server
   
   producer=$(jq -r .t <"$DATA_DIRECTORY/0/identity.json")
-  deku-bootstrapper bootstrap "$producer" --secret "$BOOTSTRAPPER_SECRET"
+  deku-bootstrapper bootstrap "$producer" --secret "$DEKU_BOOTSTRAPPER_SECRET"
 }
 
 wait_for_servers() {

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -26,6 +26,10 @@ DATA_DIRECTORY="data"
 # shellcheck disable=SC2207
 VALIDATORS=( $(seq 0 "$((NUMBER_OF_NODES - 1))") )
 
+# Bootstrapper secret
+# If you want your own you can generate own with "deku-bootstrapper setup-identity"
+BOOTSTRAPPER_SECRET="edsk3CRD8RNhoTPV74p8t9pEvW3zEH2ZZzVD8zns2dyZyY49nbjoiG"
+
 # =======================
 # Running environments
 # Docker mode is to run Deku nodes from docker-compose file
@@ -145,6 +149,10 @@ deploy_contract () {
 # writes Tezos identity files in $DATA_DIRECTORY subfolders
 create_new_deku_environment() {
 
+  # Step 0: create the bootstrapper identity
+  message "Create the bootstrapper identity"
+  bootstrapper_key=$(deku-bootstrapper derive-secret --secret $BOOTSTRAPPER_SECRET | grep Key: | awk '{ print $2 }')
+  
   # Step 1: Set up validator identities for each node
   message "Creating validator identities"
   for i in "${VALIDATORS[@]}"; do
@@ -161,6 +169,10 @@ create_new_deku_environment() {
     else
       deku-node setup-identity "$FOLDER" --uri "http://localhost:444$i"
     fi
+
+    # Setup the bootstrapper identity
+    echo "\"$bootstrapper_key\"" > "$FOLDER/bootstrapper.json"
+    
     KEY=$(deku-node self "$FOLDER" | grep "key:" | awk '{ print $2 }')
     ADDRESS=$(deku-node self "$FOLDER" | grep "address:" | awk '{ print $2 }')
     URI=$(deku-node self "$FOLDER" | grep "uri:" | awk '{ print $2 }')
@@ -251,37 +263,10 @@ start_deku_cluster() {
       SERVERS+=($!)
     fi
   done
-
-  sleep 1
-
-  # Step 4: Manually produce the block
-  # Produce a block using `deku-cli produce-block`
-  # See deku-cli produce-block --help
-  echo "Producing a block"
-  if [ "$mode" = "docker" ]; then
-    HASH=$(docker exec -t deku-node-0 /bin/deku-node produce-block /app/data | sed -n 's/block.hash: \([a-f0-9]*\)/\1/p' | tr -d " \t\n\r")
-  else
-    HASH=$(deku-node produce-block "$DATA_DIRECTORY/0" | sed -n 's/block.hash: \([a-f0-9]*\)/\1/p')
-  fi
-
-  sleep 0.1
-
-  # Step 5: Manually sign the block with 2/3rd of the nodes
-  # Sign the previously produced block using `deku-cli sign-block`
-  # See ./src/bin/deku_cli.ml:sign_block
-  echo "Signing"
-  for i in "${VALIDATORS[@]}"; do
-    if [ "$mode" = "docker" ]; then
-      echo "hash: $HASH"
-      echo "deku-node-$i"
-      docker exec -t "deku-node-$i" deku-node sign-block /app/data "$HASH"
-    else
-      echo "hash: $HASH"
-      echo "deku-node-$i"
-      deku-node sign-block "$DATA_DIRECTORY/$i" "$HASH"
-    fi
-  done
-
+  sleep 1.0 # Wait to start deku-node to start its dream server
+  
+  producer=$(jq -r .t <"$DATA_DIRECTORY/0/identity.json")
+  deku-bootstrapper bootstrap "$producer" --secret "$BOOTSTRAPPER_SECRET"
 }
 
 wait_for_servers() {

--- a/src/bin/deku_bootstrapper.ml
+++ b/src/bin/deku_bootstrapper.ml
@@ -18,7 +18,8 @@ let secret =
   let secret = conv (parser, printer) in
   let docv = "secret" in
   let doc = "Secret key of the bootstrapper" in
-  required & opt (some secret) None & info ["secret"] ~docv ~doc
+  let env = Cmd.Env.info "DEKU_BOOTSTRAPPER_SECRET" in
+  required & opt (some secret) None & info ["secret"] ~docv ~doc ~env
 
 module Bootstrap = struct
   (* TODO: should this be 2/3rd's plus 1? *)
@@ -69,7 +70,8 @@ module Bootstrap = struct
     let doc =
       "The address of a validator which will produce a block to bootstrap the \
        cluster." in
-    required & pos 0 (some producer) None & info [] ~docv ~doc
+    let env = Cmd.Env.info "DEKU_NEXT_PRODUCER" in
+    required & pos 0 (some producer) None & info [] ~docv ~doc ~env
 
   let node_uris =
     let parser string =
@@ -89,7 +91,8 @@ module Bootstrap = struct
           Uri.of_string "http://localhost:4441";
           Uri.of_string "http://localhost:4442";
         ] in
-    required & opt (some node_uris) default & info ["node-uris"] ~docv ~doc
+    let env = Cmd.Env.info "DEKU_VALIDTAOR_URIS" in
+    required & opt (some node_uris) default & info ["node-uris"] ~docv ~doc ~env
 
   let run =
     let open Term in
@@ -118,8 +121,8 @@ module Setup_identity = struct
     Cmd.info "setup-identity" ~version:"%\226\128\140%VERSION%%" ~doc
 end
 
-module Derive_secret = struct
-  let derive_secret secret =
+module Derive_key = struct
+  let derive_key secret =
     let key = Key.of_secret secret in
     (* TODO: use Logs everywhere *)
     Format.printf "Key: %s\n" (Key.to_string key);
@@ -127,11 +130,11 @@ module Derive_secret = struct
 
   let run =
     let open Term in
-    lwt_ret (const derive_secret $ secret)
+    lwt_ret (const derive_key $ secret)
 
   let info =
     let doc = "Derive the public key from the given secret" in
-    Cmd.info "derive-secret" ~version:"%\226\128\140%VERSION%%" ~doc
+    Cmd.info "derive-key" ~version:"%\226\128\140%VERSION%%" ~doc
 end
 
 let default_info =
@@ -146,5 +149,5 @@ let _ =
        [
          Cmd.v Bootstrap.info Bootstrap.run;
          Cmd.v Setup_identity.info Setup_identity.run;
-         Cmd.v Derive_secret.info Derive_secret.run;
+         Cmd.v Derive_key.info Derive_key.run;
        ]

--- a/src/bin/deku_bootstrapper.ml
+++ b/src/bin/deku_bootstrapper.ml
@@ -1,0 +1,150 @@
+open Cmdliner
+open Helpers
+open Network
+open Crypto
+
+(* TODO: creates bin/common.ml, this code appears in three different places, deku_cli, deku_node, here *)
+let lwt_ret p =
+  let open Term in
+  ret (const Lwt_main.run $ p)
+
+let secret =
+  let parser string =
+    Secret.of_string string
+    |> Option.to_result ~none:(`Msg "Cannot parse the bootstrapper secret")
+  in
+  let printer fmt secret = Format.fprintf fmt "%s" (Secret.to_string secret) in
+  let open Arg in
+  let secret = conv (parser, printer) in
+  let docv = "secret" in
+  let doc = "Secret key of the bootstrapper" in
+  required & opt (some secret) None & info ["secret"] ~docv ~doc
+
+module Bootstrap = struct
+  (* TODO: should this be 2/3rd's plus 1? *)
+  (* Check if at least 2/3 of the cluster is in sync *)
+  let are_nodes_in_sync node_uris =
+    let%await response =
+      node_uris |> Lwt_list.map_p (fun node_uri -> request_in_sync () node_uri)
+    in
+    let number_of_nodes_in_sync =
+      response
+      |> List.filter (fun In_sync.{ in_sync } -> in_sync)
+      |> List.length
+      |> float_of_int in
+    number_of_nodes_in_sync
+    >= float_of_int (List.length node_uris) *. (2.0 /. 3.0)
+    |> await
+
+  let broadcast_bootstrap_signal node_uris msg =
+    node_uris
+    |> Lwt_list.iter_p (fun node_uri -> request_bootstrap_signal msg node_uri)
+
+  let bootstrap node_uris producer secret =
+    let%await in_sync = are_nodes_in_sync node_uris in
+    match in_sync with
+    | true ->
+      (* TODO: use Logs everywhere. *)
+      Format.printf "Nodes are in sync. Doing nothing.\n%!";
+      Lwt.return (`Ok ())
+    | false ->
+      let signature =
+        BLAKE2B.hash (Key_hash.to_string producer)
+        |> Protocol.Signature.sign ~key:secret in
+      let%await () =
+        broadcast_bootstrap_signal node_uris
+          { producer = { address = producer }; signature } in
+      Lwt.return (`Ok ())
+
+  let producer =
+    let parser string =
+      Crypto.Key_hash.of_string string
+      |> Option.to_result
+           ~none:(`Msg "can't parse the key hash of the producer") in
+    let printer fmt address =
+      Format.fprintf fmt "%s" (Crypto.Key_hash.to_string address) in
+    let open Arg in
+    let producer = conv (parser, printer) in
+    let docv = "producer" in
+    let doc =
+      "The address of a validator which will produce a block to bootstrap the \
+       cluster." in
+    required & pos 0 (some producer) None & info [] ~docv ~doc
+
+  let node_uris =
+    let parser string =
+      String.split_on_char ';' string |> List.map Uri.of_string |> Result.ok
+    in
+    let printer fmt node_uris =
+      Format.fprintf fmt "%s"
+        (String.concat ";" (node_uris |> List.map Uri.to_string)) in
+    let open Arg in
+    let node_uris = conv (parser, printer) in
+    let docv = "identity" in
+    let doc = "List of uri separated by ';'" in
+    let default =
+      Some
+        [
+          Uri.of_string "http://localhost:4440";
+          Uri.of_string "http://localhost:4441";
+          Uri.of_string "http://localhost:4442";
+        ] in
+    required & opt (some node_uris) default & info ["node-uris"] ~docv ~doc
+
+  let run =
+    let open Term in
+    lwt_ret (const bootstrap $ node_uris $ producer $ secret)
+
+  let info =
+    let doc = "Create the bootstrapper identity" in
+    Cmd.info "bootstrap" ~version:"%\226\128\140%VERSION%%" ~doc
+end
+
+module Setup_identity = struct
+  let setup_identity () =
+    let secret, key = Crypto.Ed25519.generate () in
+    let secret, key = (Secret.Ed25519 secret, Key.Ed25519 key) in
+    (* TODO: use Logs everywhere *)
+    Format.printf "Key: %s\nSecret: %s\n%!" (Key.to_string key)
+      (Secret.to_string secret);
+    await (`Ok ())
+
+  let run =
+    let open Term in
+    lwt_ret (const setup_identity $ const ())
+
+  let info =
+    let doc = "Create the bootstrapper identity" in
+    Cmd.info "setup-identity" ~version:"%\226\128\140%VERSION%%" ~doc
+end
+
+module Derive_secret = struct
+  let derive_secret secret =
+    let key = Key.of_secret secret in
+    (* TODO: use Logs everywhere *)
+    Format.printf "Key: %s\n" (Key.to_string key);
+    await (`Ok ())
+
+  let run =
+    let open Term in
+    lwt_ret (const derive_secret $ secret)
+
+  let info =
+    let doc = "Derive the public key from the given secret" in
+    Cmd.info "derive-secret" ~version:"%\226\128\140%VERSION%%" ~doc
+end
+
+let default_info =
+  let doc = "Deku bootstrapper" in
+  let sdocs = Manpage.s_common_options in
+  let exits = Cmd.Exit.defaults in
+  Cmd.info "side-cli" ~version:"%\226\128\140%VERSION%%" ~doc ~sdocs ~exits
+
+let _ =
+  Cmd.eval
+  @@ Cmd.group default_info
+       [
+         Cmd.v Bootstrap.info Bootstrap.run;
+         Cmd.v Setup_identity.info Setup_identity.run;
+         Cmd.v Derive_secret.info Derive_secret.run;
+       ]

--- a/src/bin/deku_bootstrapper.ml
+++ b/src/bin/deku_bootstrapper.ml
@@ -65,6 +65,8 @@ module Bootstrap = struct
 
   let bootstrap node_uris producer secret retries =
     let%await () = wait_for_quorum retries node_uris in
+    (* TODO: if the chosen producer is not part of the quorum,
+       bootstrapping will fail silently*)
     let signature =
       BLAKE2B.hash (Key_hash.to_string producer)
       |> Protocol.Signature.sign ~key:secret in

--- a/src/bin/deku_node.ml
+++ b/src/bin/deku_node.ml
@@ -380,6 +380,15 @@ let handle_ticket_balance =
           ~address:(Core_deku.Address.of_key_hash address) in
       Ok { amount })
 
+(* POST /in-sync *)
+let handle_in_sync =
+  handle_request
+    (module Network.In_sync)
+    (fun () ->
+      let state = Server.get_state () in
+      let in_sync = Flows.request_in_sync state in
+      Ok { in_sync })
+
 let node folder port minimum_block_delay prometheus_port =
   let node =
     Node_state.get_initial_state ~folder ~minimum_block_delay |> Lwt_main.run
@@ -412,6 +421,7 @@ let node folder port minimum_block_delay prometheus_port =
              handle_withdraw_proof;
              handle_ticket_balance;
              handle_trusted_validators_membership;
+             handle_in_sync;
            ];
       Prometheus_dream.serve prometheus_port;
     ]

--- a/src/bin/deku_node.ml
+++ b/src/bin/deku_node.ml
@@ -389,6 +389,14 @@ let handle_in_sync =
       let in_sync = Flows.request_in_sync state in
       Ok { in_sync })
 
+(* POST /in-sync *)
+let handle_bootstrap_signal =
+  handle_request
+    (module Network.Bootstrapper_signal)
+    (fun { producer; signature } ->
+      let%ok payload = Consensus.Bootstrapper_signal.make ~producer ~signature in
+      Flows.handle_bootstrap_signal ~payload |> ok)
+
 let node folder port minimum_block_delay prometheus_port =
   let node =
     Node_state.get_initial_state ~folder ~minimum_block_delay |> Lwt_main.run
@@ -422,6 +430,7 @@ let node folder port minimum_block_delay prometheus_port =
              handle_ticket_balance;
              handle_trusted_validators_membership;
              handle_in_sync;
+             handle_bootstrap_signal;
            ];
       Prometheus_dream.serve prometheus_port;
     ]

--- a/src/bin/dune
+++ b/src/bin/dune
@@ -22,6 +22,14 @@
  (preprocess
   (pps ppx_deriving_yojson ppx_let_binding)))
 
+(executable
+ (name deku_bootstrapper)
+ (libraries feather files cmdliner)
+ (modules deku_bootstrapper)
+ (public_name deku-bootstrapper)
+ (preprocess
+  (pps ppx_deriving_yojson ppx_let_binding)))
+
 (env
  (static
   (ocamlopt_flags

--- a/src/consensus/bootstrapper_signal.ml
+++ b/src/consensus/bootstrapper_signal.ml
@@ -1,0 +1,14 @@
+open Helpers
+open Crypto
+open Protocol
+
+type t = {
+  producer : Validators.validator;
+  signature : Signature.t;
+}
+
+let make ~producer ~signature =
+  let hash = Key_hash.to_string producer.Validators.address |> BLAKE2B.hash in
+  let%assert () =
+    (`Invalid_bootstrapper_signature, Signature.verify ~signature hash) in
+  Ok { producer; signature }

--- a/src/consensus/bootstrapper_signal.mli
+++ b/src/consensus/bootstrapper_signal.mli
@@ -1,0 +1,9 @@
+type t = private {
+  producer : Protocol.Validators.validator;
+  signature : Protocol.Signature.t;
+}
+
+val make :
+  producer:Protocol.Validators.validator ->
+  signature:Protocol.Signature.t ->
+  (t, [> `Invalid_bootstrapper_signature]) Result.t

--- a/src/consensus/consensus.ml
+++ b/src/consensus/consensus.ml
@@ -29,6 +29,9 @@ let with_operation effect operation state =
 let with_trusted_validators_membership_change effect ~payload ~signature state =
   Dispatch.dispatch effect (Check_validator_change { payload; signature }) state
 
+let with_bootstrap_signal effect ~payload state =
+  Dispatch.dispatch effect (Check_bootstrap_signal { payload }) state
+
 let in_sync = State.in_sync
 
 module Snapshots = Snapshots
@@ -36,3 +39,4 @@ module Trusted_validators_membership_change =
   Trusted_validators_membership_change
 module Block_pool = Block_pool
 module Signatures = Signatures
+module Bootstrapper_signal = Bootstrapper_signal

--- a/src/consensus/consensus.ml
+++ b/src/consensus/consensus.ml
@@ -29,6 +29,8 @@ let with_operation effect operation state =
 let with_trusted_validators_membership_change effect ~payload ~signature state =
   Dispatch.dispatch effect (Check_validator_change { payload; signature }) state
 
+let in_sync = State.in_sync
+
 module Snapshots = Snapshots
 module Trusted_validators_membership_change =
   Trusted_validators_membership_change

--- a/src/consensus/consensus.mli
+++ b/src/consensus/consensus.mli
@@ -104,6 +104,8 @@ val block_matches_current_state_root_hash : state -> Block.t -> bool
 
 val block_matches_next_state_root_hash : state -> Block.t -> bool
 
+val in_sync : state -> bool
+
 module Snapshots = Snapshots
 module Trusted_validators_membership_change =
   Trusted_validators_membership_change

--- a/src/consensus/consensus.mli
+++ b/src/consensus/consensus.mli
@@ -23,6 +23,7 @@ type state = {
   block_pool : Block_pool.t;
   protocol : Protocol.t;
   snapshots : Snapshots.t;
+  bootstrapper : Key.t;
 }
 
 type t = state
@@ -30,6 +31,7 @@ type t = state
 val make :
   identity:identity ->
   trusted_validator_membership_change:Trusted_validators_membership_change.Set.t ->
+  bootstrapper:Key.t ->
   t
 
 type effect = private
@@ -86,6 +88,12 @@ val with_trusted_validators_membership_change :
   t ->
   t * [> error] list
 
+val with_bootstrap_signal :
+  (effect -> t -> unit) ->
+  payload:Bootstrapper_signal.t ->
+  t ->
+  t * [> error] list
+
 val load_snapshot :
   snapshot:Snapshots.snapshot ->
   additional_blocks:Block.t list ->
@@ -111,3 +119,4 @@ module Trusted_validators_membership_change =
   Trusted_validators_membership_change
 module Block_pool = Block_pool
 module Signatures = Signatures
+module Bootstrapper_signal = Bootstrapper_signal

--- a/src/consensus/dispatch.ml
+++ b/src/consensus/dispatch.ml
@@ -35,6 +35,10 @@ let rec dispatch effect step state =
     allow_to_add_validator ~key_hash effect state
   | Allow_to_remove_validator { key_hash } ->
     allow_to_remove_validator ~key_hash effect state
+  | Check_bootstrap_signal { payload : Bootstrapper_signal.t } ->
+    check_bootstrap_signal ~payload effect state
+  | Apply_bootstrap_signal bootstrap_signal ->
+    apply_bootstrap_signal ~bootstrap_signal effect state
 
 and check_operation ~operation effect state =
   let step = Steps.check_operation ~operation state in
@@ -110,4 +114,12 @@ and allow_to_add_validator ~key_hash effect state =
 
 and allow_to_remove_validator ~key_hash effect state =
   let state, step = Steps.allow_to_remove_validator ~key_hash state in
+  dispatch effect step state
+
+and check_bootstrap_signal ~payload effect state =
+  let state, step = Steps.check_bootstrap_signal ~payload state in
+  dispatch effect step state
+
+and apply_bootstrap_signal ~bootstrap_signal effect state =
+  let state, step = Steps.apply_bootstrap_signal bootstrap_signal state in
   dispatch effect step state

--- a/src/consensus/state.ml
+++ b/src/consensus/state.ml
@@ -23,11 +23,12 @@ type state = {
   block_pool : Block_pool.t;
   protocol : Protocol.t;
   snapshots : Snapshots.t;
+  bootstrapper : Key.t;
 }
 
 type t = state
 
-let make ~identity ~trusted_validator_membership_change =
+let make ~identity ~trusted_validator_membership_change ~bootstrapper =
   let initial_block = Block.genesis in
   let initial_protocol = Protocol.make ~initial_block in
   let initial_signatures =
@@ -48,6 +49,7 @@ let make ~identity ~trusted_validator_membership_change =
     block_pool = initial_block_pool;
     protocol = initial_protocol;
     snapshots = initial_snapshots;
+    bootstrapper;
   }
 
 let is_next block state = Protocol.is_next state.protocol block

--- a/src/files/config_files.ml
+++ b/src/files/config_files.ml
@@ -73,3 +73,11 @@ module Trusted_validators_membership_change = struct
 
   let write = write_json [%to_yojson: t list]
 end
+
+module Bootstrapper = struct
+  type t = Crypto.Key.t [@@deriving yojson]
+
+  let read = read_json of_yojson
+
+  let write = write_json to_yojson
+end

--- a/src/files/config_files.mli
+++ b/src/files/config_files.mli
@@ -57,3 +57,11 @@ module Trusted_validators_membership_change : sig
 
   val write : t list -> file:string -> unit Lwt.t
 end
+
+module Bootstrapper : sig
+  type t = Crypto.Key.t
+
+  val read : file:string -> t Lwt.t
+
+  val write : t -> file:string -> unit Lwt.t
+end

--- a/src/network/network.ml
+++ b/src/network/network.ml
@@ -33,3 +33,7 @@ let request_trusted_validator_membership =
   request (module Trusted_validators_membership_change)
 
 let request_ticket_balance = request (module Ticket_balance)
+
+let request_in_sync = request (module In_sync)
+
+let request_bootstrap_signal = request (module Bootstrapper_signal)

--- a/src/network/network_packet.ml
+++ b/src/network/network_packet.ml
@@ -181,3 +181,15 @@ module In_sync = struct
 
   let path = "/in-sync"
 end
+
+module Bootstrapper_signal = struct
+  type request = {
+    producer : Validators.validator;
+    signature : Signature.t;
+  }
+  [@@deriving yojson]
+
+  type response = unit [@@deriving yojson]
+
+  let path = "/bootstrapper-signal"
+end

--- a/src/network/network_packet.ml
+++ b/src/network/network_packet.ml
@@ -173,3 +173,11 @@ module Trusted_validators_membership_change = struct
 
   let path = "/trusted-validators-membership"
 end
+
+module In_sync = struct
+  type request = unit [@@deriving yojson]
+
+  type response = { in_sync : bool } [@@deriving yojson]
+
+  let path = "/in-sync"
+end

--- a/src/node/config.ml
+++ b/src/node/config.ml
@@ -1,10 +1,13 @@
+open Crypto
+
 type t = {
   identity : Consensus.identity;
   minimum_block_delay : float;
+  bootstrapper : Key.t;
 }
 [@@deriving yojson]
 
-let make ~identity ~minimum_block_delay =
+let make ~identity ~minimum_block_delay ~bootstrapper =
   if minimum_block_delay < 0. then
     failwith "Minimum block delay must be positive";
-  { identity; minimum_block_delay }
+  { identity; minimum_block_delay; bootstrapper }

--- a/src/node/config.mli
+++ b/src/node/config.mli
@@ -1,7 +1,14 @@
+open Crypto
+
 type t = private {
   identity : Consensus.identity;
   minimum_block_delay : float;
+  bootstrapper : Key.t;
 }
 [@@deriving yojson]
 
-val make : identity:Consensus.identity -> minimum_block_delay:float -> t
+val make :
+  identity:Consensus.identity ->
+  minimum_block_delay:float ->
+  bootstrapper:Key.t ->
+  t

--- a/src/node/flows.ml
+++ b/src/node/flows.ml
@@ -44,6 +44,7 @@ let string_of_error = function
   | `Snapshots_with_invalid_hash -> "Snapshots_with_invalid_hash"
   | `Node_not_yet_initialized -> "Node_not_yet_initialized"
   | `Not_a_validator -> "Not_a_validator"
+  | `Invalid_bootstrapper_signature -> "Invalid_bootstrapper_signal"
 
 let print_error err = Log.error "%s" (string_of_error err)
 
@@ -396,3 +397,7 @@ let trusted_validators_membership ~payload ~signature =
 let request_in_sync state =
   let state = state.Node.consensus in
   Consensus.in_sync state
+
+let handle_bootstrap_signal ~payload =
+  handle_consensus_operation (fun handler consensus ->
+      Consensus.with_bootstrap_signal handler ~payload consensus)

--- a/src/node/flows.ml
+++ b/src/node/flows.ml
@@ -392,3 +392,7 @@ let trusted_validators_membership ~payload ~signature =
   handle_consensus_operation (fun handler consensus ->
       Consensus.with_trusted_validators_membership_change handler ~payload
         ~signature consensus)
+
+let request_in_sync state =
+  let state = state.Node.consensus in
+  Consensus.in_sync state

--- a/src/node/state.ml
+++ b/src/node/state.ml
@@ -27,8 +27,8 @@ let make ~config ~trusted_validator_membership_change
     ~initial_validators_uri =
   let consensus =
     Consensus.make ~identity:config.Config.identity
-      ~trusted_validator_membership_change in
-
+      ~trusted_validator_membership_change
+      ~bootstrapper:config.Config.bootstrapper in
   {
     config;
     consensus;

--- a/src/protocol/protocol.ml
+++ b/src/protocol/protocol.ml
@@ -157,10 +157,12 @@ let apply_block state block =
       (state, [], []) in
   Ok (state, user_operations, result)
 
+let block_producer_timeout = 10.0
+
 let get_current_block_producer state =
   if state.last_applied_block_timestamp = 0.0 then
     None
   else
     let diff = Unix.time () -. state.last_applied_block_timestamp in
-    let skips = Float.to_int (diff /. 10.0) in
+    let skips = Float.to_int (diff /. block_producer_timeout) in
     Validators.after_current skips state.validators


### PR DESCRIPTION
# Problem
To start a deku cluster you have to access the data folder of each nodes.

# Solution
Add a bootstrapper message in the consensus steps to start the cluster.