### PR TITLE
Use key_hash instead of address in contracts + deku

### DIFF
--- a/src/core_deku/state.ml
+++ b/src/core_deku/state.ml
@@ -57,11 +57,8 @@ let apply_tezos_operation t tezos_operation =
         |> Result.ok_or_failwith
         (* TODO: verify that its not possible to fail *) in
       let ledger =
-        match destination with
-        | Implicit key_hash ->
-          let destination = key_hash in
-          Ledger.deposit (Address.of_key_hash destination) amount ticket ledger
-        | Originated _ -> failwith "not implemented" in
+        Ledger.deposit (Address.of_key_hash destination) amount ticket ledger
+      in
       { ledger; contract_storage } in
   let { hash = _; payload } = tezos_operation in
   let { tezos_operation_hash = _; internal_operations } = payload in

--- a/src/core_deku/tezos_operation.ml
+++ b/src/core_deku/tezos_operation.ml
@@ -3,7 +3,7 @@ open Crypto
 
 type internal_operation =
   | Tezos_deposit of {
-      destination : Tezos.Address.t;
+      destination : Key_hash.t;
       amount : Amount.t;
       ticket : Tezos.Ticket_id.t;
     }

--- a/src/core_deku/tezos_operation.mli
+++ b/src/core_deku/tezos_operation.mli
@@ -2,7 +2,7 @@ open Crypto
 
 type internal_operation =
   | Tezos_deposit of {
-      destination : Tezos.Address.t;
+      destination : Key_hash.t;
       amount : Amount.t;
       ticket : Tezos.Ticket_id.t;
     }

--- a/src/tezos_interop/consensus.mligo
+++ b/src/tezos_interop/consensus.mligo
@@ -169,7 +169,7 @@ type vault_storage = {
 type vault_deposit = {
   ticket: vault_ticket;
   (* WARNING: deposit address should be a valid sidechain address *)
-  address: address
+  address: key_hash
 }
 let vault_deposit (deposit: vault_deposit) (storage: vault_storage) =
   let { known_handles_hash; used_handles; vault } = storage in
@@ -236,11 +236,11 @@ let vault_check_handle_proof
     let rec verify
       (bit, proof, parent: int * vault_handle_proof * blake2b): unit =
         match proof with
-        | [] -> 
+        | [] ->
           let calculated_hash = Crypto.blake2b (Bytes.pack handle) in
           assert_msg ("invalid handle data", parent = calculated_hash)
         | (left, right) :: tl ->
-          let () = 
+          let () =
             let calculated_hash = Crypto.blake2b (Bytes.concat left right) in
             assert_msg ("invalid proof hash", parent = calculated_hash) in
           verify (bit - 1, tl, (if bit_is_set bit then right else left)) in
@@ -276,7 +276,7 @@ let vault_withdraw (withdraw: vault_withdraw) (storage: vault_storage) =
 
   let (fragment, vault) =
     let (old_ticket, vault) =
-      match 
+      match
         Big_map.get_and_update
           (handle.ticketer, handle.data)
           (None: bytes ticket option)

--- a/src/tezos_interop/tezos_interop.ml
+++ b/src/tezos_interop/tezos_interop.ml
@@ -125,7 +125,7 @@ module Consensus = struct
     | Deposit          of {
         ticket : Ticket_id.t;
         amount : Z.t;
-        destination : Address.t;
+        destination : Key_hash.t;
       }
     | Update_root_hash of BLAKE2B.t
 
@@ -190,7 +190,7 @@ module Consensus = struct
             ],
             _ ) ) ->
       let%some destination =
-        Data_encoding.Binary.of_bytes_opt Address.encoding destination in
+        Data_encoding.Binary.of_bytes_opt Key_hash.encoding destination in
       let%some ticketer =
         Data_encoding.Binary.of_bytes_opt Address.encoding ticketer in
       let ticket =

--- a/src/tezos_interop/tezos_interop.mli
+++ b/src/tezos_interop/tezos_interop.mli
@@ -28,7 +28,7 @@ module Consensus : sig
     | Deposit          of {
         ticket : Ticket_id.t;
         amount : Z.t;
-        destination : Address.t;
+        destination : Key_hash.t;
       }
     | Update_root_hash of BLAKE2B.t
 

--- a/tests/contracts/helpers_contracts.ml
+++ b/tests/contracts/helpers_contracts.ml
@@ -24,16 +24,9 @@ let make_address () =
   let _secret, _key, key_hash = Key_hash.make_ed25519 () in
   key_hash
 
-let make_tezos_address () =
-  let open Crypto in
-  let open Tezos in
-  let _key, address = Ed25519.generate () in
-  let hash = Ed25519.Key_hash.of_key address in
-  Address.Implicit (Ed25519 hash)
-
 let setup ?(initial_amount = 10000) () =
   let t2 = make_ticket () in
-  let tezos_address = make_tezos_address () in
+  let tezos_address = make_address () in
   let op =
     Tezos_operation.Tezos_deposit
       {
@@ -51,10 +44,7 @@ let setup ?(initial_amount = 10000) () =
       internal_operations = [op];
     } in
   let opp = Tezos_operation.make opp in
-  let make_address =
-    tezos_address |> Tezos.Address.to_string |> Key_hash.of_string |> Option.get
-  in
-  (State.apply_tezos_operation s opp, make_address, t2)
+  (State.apply_tezos_operation s opp, tezos_address, t2)
 
 let amount =
   Alcotest.of_pp (fun ppf x -> Format.fprintf ppf "%d" (Amount.to_int x))


### PR DESCRIPTION
## Problems

As mentioned in https://github.com/marigold-dev/deku/issues/773 the types used in the current contracts (consensus + dummy_ticket) allow to deposit tickets to an originated account ("KT1 address"). Moreover, in various files, types allow all Tezos addresses as targets to a deposit, leading to the use of `failwith`.

```bash
bad_address="KT1NHBasfrhX9d2SgGVARd3Y1C5nkhfoEks3"
tezos-client transfer 0 from alice to $dummy_ticket --entrypoint mint_to_deku --arg "(Pair (Pair \"$deku_consensus\" \"$bad_address\") (Pair 100 0x))" --burn-cap 0.05
# works on main :(
```

## Solution

1. Change the two aforementioned contracts to prevent this
2. Modify `tezos_interop` to use a Key_hash.t instead of an Address.t and remove everything that's now redundant

## Tests

I tested deposit and withdrawal manually. I _did not_ test TzPortal against this; this will likely require updating TzPortal contracts as well (because of types).

## Discussion

This does not support depositing tickets to a Deku-originated contract ("DK1 address"). On the other hand, these are not supported by tezos-client either.