### PR TITLE
fix: better exit code

### DIFF
--- a/src/bin/deku_node.ml
+++ b/src/bin/deku_node.ml
@@ -671,7 +671,7 @@ let default_info =
   Cmd.info "deku-node" ~version:"%\226\128\140%VERSION%%" ~doc ~sdocs ~exits
 
 let _ =
-  Cmd.eval
+  Cmd.eval ~catch:false
   @@ Cmd.group default_info
        [
          Cmd.v (Cmd.info "start") node;


### PR DESCRIPTION
# Problem

When the node crashes, it always returns 0 code.

# Solution
Returns a non zero code in case of an exception