### PR TITLE
test: repr of an operation

### DIFF
--- a/src/protocol/operation.ml
+++ b/src/protocol/operation.ml
@@ -71,10 +71,7 @@ module Repr = struct
       | Transaction { receiver; amount } ->
           Operation_transaction { receiver; amount }
     in
-    let hash =
-      let serialized = Yojson.Safe.to_string json in
-      Operation_hash.hash serialized
-    in
+    let hash = hash operation in
 
     (match
        let source = Address.to_key_hash source in

--- a/src/protocol/tests/deku_protocol_tests.ml
+++ b/src/protocol/tests/deku_protocol_tests.ml
@@ -1,1 +1,3 @@
-let () = Test_ledger.run ()
+let () =
+  Test_ledger.run ();
+  Test_operation.run ()

--- a/src/protocol/tests/test_operation.ml
+++ b/src/protocol/tests/test_operation.ml
@@ -1,0 +1,36 @@
+open Deku_protocol
+open Deku_concepts
+open Deku_crypto
+open Deku_stdlib
+
+let alice_secret =
+  Secret.of_b58 "edsk3EYk77QNx9HM4YDh5rv5nzBL68z2YGtBUGXhkw3rMhB2eCNvHf"
+  |> Option.get
+
+let alice = Identity.make alice_secret
+
+let bob =
+  Identity.make
+    (Secret.of_b58 "edsk4Qejwxwj7JD93B45gvhYHVfMzNjkBWRQDaYkdt5JcUWLT4VDkh"
+    |> Option.get)
+
+let test_serde_transaction () =
+  let transaction =
+    Operation.transaction ~identity:alice ~level:Level.zero
+      ~nonce:(Nonce.of_n N.one)
+      ~source:(Address.of_key_hash (Identity.key_hash alice))
+      ~receiver:(Address.of_key_hash (Identity.key_hash bob))
+      ~amount:Amount.zero
+  in
+  let transaction_str () =
+    transaction |> Operation.yojson_of_t |> Operation.t_of_yojson |> fun _ -> ()
+  in
+  Alcotest.(check unit) "to and from yojson" () (transaction_str ())
+
+let run () =
+  let open Alcotest in
+  run "Operation" ~and_exit:false
+    [
+      ( "Repr",
+        [ test_case "inverse property" `Quick test_serde_transaction ] );
+    ]

--- a/src/protocol/tests/test_operation.mli
+++ b/src/protocol/tests/test_operation.mli
@@ -1,0 +1,1 @@
+val run : unit -> unit


### PR DESCRIPTION
# Problem

A bug in the module Repr of Protocol.Operation:

```ocaml
let operation = transaction |> Operation.yojson_of_t |> Operation.t_of_yojson (*where transaction is of type Operation.t)*
```
Throws an exception because the signature is not valid