### PR TITLE
Test v1/protocol

### DIFF
--- a/src/protocol/Included_operation_set.ml
+++ b/src/protocol/Included_operation_set.ml
@@ -1,4 +1,3 @@
-open Deku_stdlib
 open Deku_concepts
 open Operation
 
@@ -18,14 +17,7 @@ let mem operation t =
   Operation_hash.Map.mem hash t
 
 let drop ~current_level t =
-  let open Deku_constants in
   Operation_hash.Map.filter
     (fun _hash operation_level ->
-      let open Level in
-      let last_includable_block =
-        let operation_level = to_n operation_level in
-        of_n N.(operation_level + includable_operation_window)
-      in
-      (* limits for how many blocks we need to hold the operations *)
-      current_level < last_includable_block)
+      Operation.is_in_includable_window ~current_level ~operation_level)
     t

--- a/src/protocol/operation.ml
+++ b/src/protocol/operation.ml
@@ -1,5 +1,6 @@
 open Deku_crypto
 open Deku_concepts
+open Deku_stdlib
 
 exception Invalid_signature
 
@@ -111,3 +112,13 @@ let transaction ~identity ~level ~nonce ~source ~receiver ~amount =
   in
   let content = Operation_transaction { receiver; amount } in
   Operation { key; signature; hash; level; nonce; source; content }
+
+let is_in_includable_window ~current_level ~operation_level =
+  let open Level in
+  let open Deku_constants in
+  let last_includable_block =
+    let operation_level = to_n operation_level in
+    of_n N.(operation_level + includable_operation_window)
+  in
+  (* limits for how many blocks we need to hold the operations *)
+  last_includable_block > current_level

--- a/src/protocol/operation.mli
+++ b/src/protocol/operation.mli
@@ -28,4 +28,5 @@ val transaction :
   amount:Amount.t ->
   operation
 
-val is_in_includable_window : current_level:Level.t -> operation_level:Level.t -> bool
+val is_in_includable_window :
+  current_level:Level.t -> operation_level:Level.t -> bool

--- a/src/protocol/operation.mli
+++ b/src/protocol/operation.mli
@@ -27,3 +27,5 @@ val transaction :
   receiver:Address.t ->
   amount:Amount.t ->
   operation
+
+val is_in_includable_window : current_level:Level.t -> operation_level:Level.t -> bool

--- a/src/protocol/protocol.ml
+++ b/src/protocol/protocol.ml
@@ -15,11 +15,13 @@ let initial =
       ledger = Ledger.initial;
     }
 
-let apply_operation protocol operation =
+let apply_operation ~current_level protocol operation =
   let (Protocol { included_operations; ledger }) = protocol in
+  let (Operation.Operation { level; _ }) = operation in
   match
     (* TODO: check code through different lane *)
-    not (Included_operation_set.mem operation included_operations)
+    (not (Included_operation_set.mem operation included_operations))
+    && Operation.is_in_includable_window ~current_level ~operation_level:level
   with
   | true ->
       let open Operation in
@@ -59,11 +61,11 @@ let parse_operation operation =
   | operation -> Some operation
   | exception _exn -> (* TODO: print exception *) None
 
-let apply_payload ~parallel payload protocol =
+let apply_payload ~parallel ~current_level payload protocol =
   let operations = parallel parse_operation payload in
   List.fold_left
     (fun (protocol, rev_receipts) operation ->
-      match apply_operation protocol operation with
+      match apply_operation ~current_level protocol operation with
       | Some (protocol, receipt) -> (protocol, receipt :: rev_receipts)
       | None -> (protocol, rev_receipts)
       | exception _exn -> (* TODO: print exception *) (protocol, rev_receipts))
@@ -77,6 +79,8 @@ let clean ~current_level protocol =
   Protocol { included_operations; ledger }
 
 let apply ~parallel ~current_level ~payload protocol =
-  let protocol, receipts = apply_payload ~parallel payload protocol in
+  let protocol, receipts =
+    apply_payload ~parallel ~current_level payload protocol
+  in
   let protocol = clean ~current_level protocol in
   (protocol, receipts)

--- a/src/protocol/tests/deku_protocol_tests.ml
+++ b/src/protocol/tests/deku_protocol_tests.ml
@@ -1,1 +1,3 @@
-let () = Test_ledger.run ()
+let () =
+  Test_ledger.run ();
+  Test_operation.run ()

--- a/src/protocol/tests/deku_protocol_tests.ml
+++ b/src/protocol/tests/deku_protocol_tests.ml
@@ -1,3 +1,4 @@
 let () =
   Test_ledger.run ();
-  Test_operation.run ()
+  Test_operation.run ();
+  Test_protocol.run ()

--- a/src/protocol/tests/test_operation.ml
+++ b/src/protocol/tests/test_operation.ml
@@ -1,0 +1,33 @@
+open Deku_protocol
+open Deku_concepts
+open Deku_crypto
+open Deku_stdlib
+
+let alice_secret =
+  Secret.of_b58 "edsk3EYk77QNx9HM4YDh5rv5nzBL68z2YGtBUGXhkw3rMhB2eCNvHf"
+  |> Option.get
+
+let alice = Identity.make alice_secret
+
+let bob =
+  Identity.make
+    (Secret.of_b58 "edsk4Qejwxwj7JD93B45gvhYHVfMzNjkBWRQDaYkdt5JcUWLT4VDkh"
+    |> Option.get)
+
+let test_serde_transaction () =
+  let transaction =
+    Operation.transaction ~identity:alice ~level:Level.zero
+      ~nonce:(Nonce.of_n N.one)
+      ~source:(Address.of_key_hash (Identity.key_hash alice))
+      ~receiver:(Address.of_key_hash (Identity.key_hash bob))
+      ~amount:Amount.zero
+  in
+  let transaction_str () =
+    transaction |> Operation.yojson_of_t |> Operation.t_of_yojson |> fun _ -> ()
+  in
+  Alcotest.(check unit) "to and from yojson" () (transaction_str ())
+
+let run () =
+  let open Alcotest in
+  run "Operation" ~and_exit:false
+    [ ("Repr", [ test_case "inverse property" `Quick test_serde_transaction ]) ]

--- a/src/protocol/tests/test_operation.mli
+++ b/src/protocol/tests/test_operation.mli
@@ -1,0 +1,1 @@
+val run : unit -> unit

--- a/src/protocol/tests/test_protocol.ml
+++ b/src/protocol/tests/test_protocol.ml
@@ -95,6 +95,19 @@ let test_duplicated_operation_same_level () =
     "the hash correspond" true
     (Operation_hash.equal operation hash)
 
+let test_duplicated_operation_different_level () =
+  let _, op_str, _ = make_operation () in
+  let _, receipts =
+    Protocol.initial
+    |> Protocol.apply ~parallel ~current_level:Level.zero ~payload:[ op_str ]
+    |> fst
+    |> Protocol.apply ~parallel ~current_level:(Level.next Level.zero)
+         ~payload:[ op_str ]
+  in
+  Alcotest.(check bool)
+    "second operation shouldn't be applied" true
+    (List.length receipts = 0)
+
 let run () =
   let open Alcotest in
   run "Protocol" ~and_exit:false
@@ -105,5 +118,7 @@ let run () =
           test_case "apply many operations" `Quick test_many_operations;
           test_case "duplicated operation on same level" `Quick
             test_duplicated_operation_same_level;
+          test_case "duplicated operation on different level" `Quick
+            test_duplicated_operation_different_level;
         ] );
     ]

--- a/src/protocol/tests/test_protocol.ml
+++ b/src/protocol/tests/test_protocol.ml
@@ -63,22 +63,18 @@ let test_many_operations () =
     |> List.for_all (fun op ->
            Included_operation_set.mem op included_operations)
   in
-  let receipts_are_op_hashes =
-    receipts
-    |> List.for_all (fun (Receipt.Receipt { operation; _ }) ->
-           List.find_opt
-             (fun hash -> Operation_hash.equal hash operation)
-             op_hashes
-           |> Option.is_some)
+  let all_ops_have_receipts =
+    let op_hashes = List.sort Operation_hash.compare op_hashes in
+    let op_hashes_from_receipts =
+      List.map (fun (Receipt.Receipt { operation; _ }) -> operation) receipts
+      |> List.sort Operation_hash.compare
+    in
+    List.equal Operation_hash.equal op_hashes op_hashes_from_receipts
   in
-  Alcotest.(check bool)
-    "there should be 10 receipts" true
-    (List.length receipts = 10);
   Alcotest.(check bool)
     "the 10 operations should be included" true all_ops_are_included;
   Alcotest.(check bool)
-    "the receipts correspond to the given operation hashes" true
-    receipts_are_op_hashes
+    "all operations have receipts and vice versa" true all_ops_have_receipts
 
 let test_duplicated_operation_same_level () =
   let _, op_str, hash = make_operation () in

--- a/src/protocol/tests/test_protocol.ml
+++ b/src/protocol/tests/test_protocol.ml
@@ -1,0 +1,52 @@
+open Deku_concepts
+open Deku_crypto
+open Deku_stdlib
+open Deku_protocol
+
+let alice_secret =
+  Secret.of_b58 "edsk3EYk77QNx9HM4YDh5rv5nzBL68z2YGtBUGXhkw3rMhB2eCNvHf"
+  |> Option.get
+
+let alice = Identity.make alice_secret
+
+let bob_secret =
+  Secret.of_b58 "edsk4Qejwxwj7JD93B45gvhYHVfMzNjkBWRQDaYkdt5JcUWLT4VDkh"
+  |> Option.get
+
+let bob = Identity.make bob_secret
+
+(* helper to create in an easy way an operation that transfer n token from alice to bob *)
+let make_operation ?(nonce = 1) ?(level = 0) ?(amount = 0) () =
+  let level = Level.of_n (N.of_z (Z.of_int level) |> Option.get) in
+  let nonce = Nonce.of_n (N.of_z (Z.of_int nonce) |> Option.get) in
+  let amount = Amount.of_n (N.of_z (Z.of_int amount) |> Option.get) in
+  let operation =
+    Operation.transaction ~identity:alice ~level ~nonce
+      ~source:(Address.of_key_hash (Identity.key_hash alice))
+      ~receiver:(Address.of_key_hash (Identity.key_hash bob))
+      ~amount
+  in
+  let operation_str =
+    operation |> Operation.yojson_of_t |> Yojson.Safe.to_string
+  in
+  let (Operation.Operation { hash; _ }) = operation in
+  (operation, operation_str, hash)
+
+(* The parallel function given to the Protocol.apply *)
+let parallel = List.filter_map
+
+let test_apply_one_operation () =
+  let _, op_str, _ = make_operation () in
+  let _, receipts =
+    Protocol.initial
+    |> Protocol.apply ~parallel ~current_level:Level.zero ~payload:[ op_str ]
+  in
+  Alcotest.(check bool) "operation is included" true (List.length receipts = 1)
+
+let run () =
+  let open Alcotest in
+  run "Protocol" ~and_exit:false
+    [
+      ( "apply operations",
+        [ test_case "apply one operation" `Quick test_apply_one_operation ] );
+    ]

--- a/src/protocol/tests/test_protocol.ml
+++ b/src/protocol/tests/test_protocol.ml
@@ -176,6 +176,48 @@ let test_invalid_signature () =
   in
   Alcotest.(check bool) "shouldn't be included" true (List.length receipts = 0)
 
+let test_valid_signature_but_different_key () =
+  let operation =
+    `Assoc
+      [
+        ("level", Level.yojson_of_t Level.zero);
+        ("nonce", Nonce.yojson_of_t (Nonce.of_n N.one));
+        ( "source",
+          Address.yojson_of_t (Address.of_key_hash (Identity.key_hash alice)) );
+        ( "content",
+          `List
+            [
+              `String "Transaction";
+              `Assoc
+                [
+                  ( "receiver",
+                    Address.yojson_of_t
+                      (Address.of_key_hash (Identity.key_hash bob)) );
+                  ("amount", Amount.yojson_of_t Amount.zero);
+                ];
+            ] );
+      ]
+  in
+  let hash =
+    Yojson.Safe.to_string operation
+    |> Operation_hash.hash |> Operation_hash.to_blake2b
+  in
+  let signature = Identity.sign ~hash alice in
+  let json =
+    `Assoc
+      [
+        ("key", Key.yojson_of_t (Identity.key bob));
+        ("signature", Signature.yojson_of_t signature);
+        ("operation", operation);
+      ]
+  in
+  let op_str = Yojson.Safe.to_string json in
+  let _, receipts =
+    Protocol.initial
+    |> Protocol.apply ~parallel ~current_level:Level.zero ~payload:[ op_str ]
+  in
+  Alcotest.(check bool) "shouldn't be included" true (List.length receipts = 0)
+
 let run () =
   let open Alcotest in
   run "Protocol" ~and_exit:false
@@ -192,5 +234,7 @@ let run () =
             test_duplicated_operation_after_includable_window;
           test_case "invalid string" `Quick test_invalid_string;
           test_case "invalid signature" `Quick test_invalid_signature;
+          test_case "good signature, wrong key" `Quick
+            test_valid_signature_but_different_key;
         ] );
     ]

--- a/src/protocol/tests/test_protocol.ml
+++ b/src/protocol/tests/test_protocol.ml
@@ -79,6 +79,22 @@ let test_many_operations () =
     "the receipts correspond to the given operation hashes" true
     receipts_are_op_hashes
 
+let test_duplicated_operation_same_level () =
+  let _, op_str, hash = make_operation () in
+
+  let _, receipts =
+    Protocol.initial
+    |> Protocol.apply ~parallel ~current_level:Level.zero
+         ~payload:[ op_str; op_str ]
+  in
+  let (Receipt.Receipt { operation }) = List.hd receipts in
+  Alcotest.(check bool)
+    "there should only be one receipt" true
+    (List.length receipts = 1);
+  Alcotest.(check bool)
+    "the hash correspond" true
+    (Operation_hash.equal operation hash)
+
 let run () =
   let open Alcotest in
   run "Protocol" ~and_exit:false
@@ -87,5 +103,7 @@ let run () =
         [
           test_case "apply one operation" `Quick test_apply_one_operation;
           test_case "apply many operations" `Quick test_many_operations;
+          test_case "duplicated operation on same level" `Quick
+            test_duplicated_operation_same_level;
         ] );
     ]

--- a/src/protocol/tests/test_protocol.ml
+++ b/src/protocol/tests/test_protocol.ml
@@ -128,6 +128,15 @@ let test_duplicated_operation_after_includable_window () =
     "operation shouldn't be applied" true
     (List.length receipts = 0)
 
+let test_invalid_string () =
+  let wrong_op_str = "waku waku" in
+  let _, receipts =
+    Protocol.initial
+    |> Protocol.apply ~parallel ~current_level:Level.zero
+         ~payload:[ wrong_op_str ]
+  in
+  Alcotest.(check bool) "shouldn't be included" true (List.length receipts = 0)
+
 let run () =
   let open Alcotest in
   run "Protocol" ~and_exit:false
@@ -142,5 +151,6 @@ let run () =
             test_duplicated_operation_different_level;
           test_case "duplicated operation after includable window" `Quick
             test_duplicated_operation_after_includable_window;
+          test_case "invalid string" `Quick test_invalid_string;
         ] );
     ]

--- a/src/protocol/tests/test_protocol.ml
+++ b/src/protocol/tests/test_protocol.ml
@@ -218,6 +218,17 @@ let test_valid_signature_but_different_key () =
   in
   Alcotest.(check bool) "shouldn't be included" true (List.length receipts = 0)
 
+let test_receipt_implied_included_operations () =
+  let op, op_str, _ = make_operation () in
+  let protocol, receipts =
+    Protocol.initial
+    |> Protocol.apply ~parallel ~current_level:Level.zero ~payload:[ op_str ]
+  in
+  let (Protocol.Protocol { included_operations; _ }) = protocol in
+  let is_included = Included_operation_set.mem op included_operations in
+  Alcotest.(check bool) "the operation is included" true is_included;
+  Alcotest.(check bool) "there only one receipt" true (List.length receipts = 1)
+
 let run () =
   let open Alcotest in
   run "Protocol" ~and_exit:false
@@ -236,5 +247,7 @@ let run () =
           test_case "invalid signature" `Quick test_invalid_signature;
           test_case "good signature, wrong key" `Quick
             test_valid_signature_but_different_key;
+          test_case "one receipt imply one included operation" `Quick
+            test_receipt_implied_included_operations;
         ] );
     ]

--- a/src/protocol/tests/test_protocol.mli
+++ b/src/protocol/tests/test_protocol.mli
@@ -1,0 +1,1 @@
+val run : unit -> unit


### PR DESCRIPTION
Add tests of the protocol part from 
https://github.com/marigold-dev/deku/issues/770#issuecomment-1201465297

There is one test per scenario:

- [x] Many operations
- [x] Duplicated operation in same block
- [x] Duplicated operation in different blocks
- [x] Late duplicated operation(after includable window) ⚠️   Doesn't works in v1 but it's fixed in this branch 😅 
- [x] Balances are actually correct
- [x] Invalid string operation
- [x] Invalid signed operation
- [x] Valid key, signature to different source operation
- [x] Ensure receipt is only in place if operation was applied