### PR TITLE
fix: allow HTTP CORS

### DIFF
--- a/src/bin/deku_node.ml
+++ b/src/bin/deku_node.ml
@@ -410,9 +410,16 @@ let node folder port minimum_block_delay prometheus_port =
     | Some port -> port
     | None -> Node.Server.get_port () |> Option.value ~default:4440 in
   Log.info "Listening on port %d" port;
+  let cors_middleware inner_handler req =
+    let%await response = inner_handler req in
+    Dream.add_header response "Access-Control-Allow-Origin" "*";
+    Dream.add_header response "Access-Control-Allow-Headers" "*";
+    Dream.add_header response "Allow" "*";
+    Lwt.return response in
   Lwt.all
     [
       Dream.serve ~interface:"0.0.0.0" ~port
+      @@ cors_middleware
       @@ Dream.router
            [
              handle_block_level;


### PR DESCRIPTION
## Problem

> Cross-Origin Resource Sharing ([CORS](https://developer.mozilla.org/en-US/docs/Glossary/CORS)) is an [HTTP](https://developer.mozilla.org/en-US/docs/Glossary/HTTP)-header based mechanism that allows a server to indicate any [origins](https://developer.mozilla.org/en-US/docs/Glossary/Origin) (domain, scheme, or port) other than its own from which a browser should permit loading resources. CORS also relies on a mechanism by which browsers make a "preflight" request to the server hosting the cross-origin resource, in order to check that the server will permit the actual request. In that preflight, the browser sends headers that indicate the HTTP method and headers that will be used in the actual request.
[https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)

TL;DR: when other developers call Deku endpoints from a webapp, they're stuck because the browser thinks it's a security problem.

We already took care of this in the `parametric-develop` branch to allow developers of the Cookie clicker game to proceed; this is a cherry-pick. Now @zamrokk has the same problem with Deku alphanet while trying to improve TzPortal user experience.

## Solution

Add a Dream middleware that adds the correct headers.

## Limitations

* In case of a HTTP 5** (triggered e.g. by a malformed request), I think the middleware is not applied and the users may have the impression that the error is caused by our configuration. They are likely to complain and give false reports.
* The headers may be overly permissive, please ask a real web dev.