### PR TITLE
V1 ticket table

### DIFF
--- a/src/bin/benchmark/deku_benchmark.ml
+++ b/src/bin/benchmark/deku_benchmark.ml
@@ -26,6 +26,14 @@ module Util = struct
 end
 
 module Block_application = struct
+  let default_ticket_id =
+    let address =
+      Deku_tezos.Contract_hash.of_string "KT1JQ5JQB4P1c8U8ACxfnodtZ4phDVMSDzgi"
+      |> Option.get
+    in
+    let data = Bytes.of_string "tuturu" in
+    Ticket_id.make address data
+
   let generate () =
     let secret = Ed25519.Secret.generate () in
     let secret = Secret.Ed25519 secret in
@@ -44,7 +52,9 @@ module Block_application = struct
     in
     let nonce = Nonce.of_n N.zero in
     let amount = Amount.of_n N.zero in
-    Operation.transaction ~identity ~level ~nonce ~source ~receiver ~amount
+    let ticket_id = default_ticket_id in
+    Operation.transaction ~identity ~level ~nonce ~source ~receiver ~ticket_id
+      ~amount
 
   let payload_of_operations operations =
     (* TODO: this likely should not be here *)
@@ -89,6 +99,14 @@ module Block_application = struct
 end
 
 module Block_production = struct
+  let default_ticket_id =
+    let address =
+      Deku_tezos.Contract_hash.of_string "KT1JQ5JQB4P1c8U8ACxfnodtZ4phDVMSDzgi"
+      |> Option.get
+    in
+    let data = Bytes.of_string "tuturu" in
+    Ticket_id.make address data
+
   let producer = Block_application.generate ()
   let sender = Block_application.generate ()
 
@@ -102,9 +120,10 @@ module Block_production = struct
   let operation ~nonce =
     let level = Level.zero in
     let nonce = Z.of_int nonce |> N.of_z |> Option.get |> Nonce.of_n in
+    let ticket_id = default_ticket_id in
     let amount = Amount.of_n N.zero in
     Operation.transaction ~identity:sender ~level ~nonce ~source ~receiver
-      ~amount
+      ~ticket_id ~amount
 
   let operations ~size = Parallel.init_p size (fun nonce -> operation ~nonce)
 

--- a/src/protocol/dune
+++ b/src/protocol/dune
@@ -3,4 +3,4 @@
  (public_name deku-protocol)
  (libraries deku_tezos deku_crypto deku_concepts deku_constants)
  (preprocess
-  (pps ppx_deriving.eq ppx_deriving.ord ppx_yojson_conv)))
+  (pps ppx_let_binding ppx_deriving.eq ppx_deriving.ord ppx_yojson_conv)))

--- a/src/protocol/ledger.ml
+++ b/src/protocol/ledger.ml
@@ -1,29 +1,22 @@
 open Deku_concepts
-open Amount
+open Deku_stdlib
 
-type ledger = Amount.t Address.Map.t
-type t = ledger
+type ledger = Ledger of { table : Ticket_table.t }
+and t = ledger
 
-let initial = Address.Map.empty
+let initial = Ledger { table = Ticket_table.empty }
 
-let balance address ledger =
-  match Address.Map.find_opt address ledger with
-  | Some balance -> balance
-  | None -> Amount.zero
+let balance address ticket_id (Ledger { table }) =
+  Ticket_table.balance ~sender:address ~ticket_id table
+  |> Option.value ~default:Amount.zero
 
-let deposit address amount ledger =
-  let balance = balance address ledger in
-  let balance = balance + amount in
-  Address.Map.add address balance ledger
+let deposit destination amount ticket_id (Ledger { table }) =
+  let table = Ticket_table.deposit ~destination ~ticket_id ~amount table in
+  Ledger { table }
 
-let transfer ~sender ~receiver amount ledger =
-  let sender_balance = balance sender ledger in
-  let receiver_balance = balance receiver ledger in
-
-  match sender_balance - amount with
-  | Some sender_balance ->
-      let receiver_balance = receiver_balance + amount in
-      let ledger = Address.Map.add sender sender_balance ledger in
-      let ledger = Address.Map.add receiver receiver_balance ledger in
-      Some ledger
-  | None -> None
+let transfer ~sender ~receiver ~amount ~ticket_id (Ledger { table }) =
+  let%ok table =
+    Ticket_table.transfer table ~sender ~receiver ~amount ~ticket_id
+    |> Result.map_error (fun _ -> `Insufficient_funds)
+  in
+  Ok (Ledger { table })

--- a/src/protocol/ledger.mli
+++ b/src/protocol/ledger.mli
@@ -1,11 +1,16 @@
 open Deku_concepts
 
-type ledger = private Amount.t Address.Map.t
+type ledger = private Ledger of { table : Ticket_table.t }
 type t = ledger
 
-val initial : ledger
-val balance : Address.t -> ledger -> Amount.t
-val deposit : Address.t -> Amount.t -> ledger -> ledger
+val initial : t
+val balance : Address.t -> Ticket_id.t -> t -> Amount.t
+val deposit : Address.t -> Amount.t -> Ticket_id.t -> t -> t
 
 val transfer :
-  sender:Address.t -> receiver:Address.t -> Amount.t -> ledger -> ledger option
+  sender:Address.t ->
+  receiver:Address.t ->
+  amount:Amount.t ->
+  ticket_id:Ticket_id.t ->
+  t ->
+  (t, [> `Insufficient_funds ]) result

--- a/src/protocol/operation.mli
+++ b/src/protocol/operation.mli
@@ -4,7 +4,11 @@ open Deku_concepts
 exception Invalid_signature
 
 type operation_content = private
-  | Operation_transaction of { receiver : Address.t; amount : Amount.t }
+  | Operation_transaction of {
+      receiver : Address.t;
+      ticket_id : Ticket_id.t;
+      amount : Amount.t;
+    }
 
 type operation = private
   | Operation of {
@@ -25,5 +29,6 @@ val transaction :
   nonce:Nonce.t ->
   source:Address.t ->
   receiver:Address.t ->
+  ticket_id:Ticket_id.t ->
   amount:Amount.t ->
   operation

--- a/src/protocol/tests/test_ledger.ml
+++ b/src/protocol/tests/test_ledger.ml
@@ -4,10 +4,14 @@ open Deku_concepts
 open Deku_protocol
 open Ledger
 
-let total_balance (ledger : ledger) =
-  Address.Map.fold
-    (fun _address amount total_amount -> Amount.(amount + total_amount))
-    (ledger :> Amount.t Address.Map.t)
+let total_balance ~ticket_id (Ledger { table }) =
+  let open Ticket_table in
+  Address_map.fold
+    (fun _sender ticket_map total_amount ->
+      Ticket_map.find_opt ticket_id ticket_map
+      |> Option.value ~default:Amount.zero
+      |> Amount.( + ) total_amount)
+    (table :> Amount.t Ticket_map.t Address_map.t)
     Amount.zero
 
 let new_address () =
@@ -27,35 +31,51 @@ let random_amount () =
 
 let amount = Alcotest.testable Amount.pp Amount.equal
 
-let test_total_balance ~expected ~ledger_name ~ledger () =
+let default_ticket_id () =
+  let address =
+    Deku_tezos.Contract_hash.of_string "KT1JQ5JQB4P1c8U8ACxfnodtZ4phDVMSDzgi"
+    |> Option.get
+  in
+  let data = Bytes.of_string "tuturu" in
+  Ticket_id.make address data
+
+let test_total_balance ~expected ~ledger_name ~ticket_id ~ledger () =
   let msg =
     Format.asprintf "total_balance %s = %a" ledger_name Amount.pp expected
   in
-  Alcotest.(check' amount) ~msg ~expected ~actual:(total_balance ledger)
+  Alcotest.(check' amount)
+    ~msg ~expected
+    ~actual:(total_balance ~ticket_id ledger)
 
-let test_balance ~address_name ~address ~expected ~ledger_name ~ledger () =
+let test_balance ~address_name ~address ~expected ~ledger_name ~ticket_id
+    ~ledger () =
   let msg =
     Format.asprintf "balance %s %s = %a" address_name ledger_name Amount.pp
       expected
   in
-  Alcotest.(check' amount) ~msg ~expected ~actual:(balance address ledger)
+  Alcotest.(check' amount)
+    ~msg ~expected
+    ~actual:(balance address ticket_id ledger)
 
 let test_unknown_balance ~ledger_name ~ledger () =
   let unknown = new_address () in
   test_balance ~address_name:"unknown" ~address:unknown ~expected:Amount.zero
     ~ledger_name ~ledger ()
 
-let test_balance ~address_name ~address ~expected ~ledger_name ~ledger () =
+let test_balance ~address_name ~address ~expected ~ledger_name ~ticket_id
+    ~ledger () =
   let () =
-    test_balance ~address_name ~address ~expected ~ledger_name ~ledger ()
+    test_balance ~address_name ~address ~expected ~ledger_name ~ticket_id
+      ~ledger ()
   in
-  let () = test_unknown_balance ~ledger_name ~ledger () in
+  let () = test_unknown_balance ~ledger_name ~ticket_id ~ledger () in
   ()
 
-let test_base_deposit ~address_name ~address ~amount ~ledger_name ~ledger () =
-  let ledger_balance = total_balance ledger in
-  let address_balance = balance address ledger in
-  let ledger = deposit address amount ledger in
+let test_base_deposit ~address_name ~address ~amount ~ledger_name ~ticket_id
+    ~ledger () =
+  let ledger_balance = total_balance ~ticket_id ledger in
+  let address_balance = balance address ticket_id ledger in
+  let ledger = deposit address amount ticket_id ledger in
 
   let ledger_name =
     Format.asprintf "%s[%s += %a]" ledger_name address_name Amount.pp amount
@@ -64,14 +84,14 @@ let test_base_deposit ~address_name ~address ~amount ~ledger_name ~ledger () =
   let () =
     test_balance ~address_name ~address
       ~expected:Amount.(address_balance + amount)
-      ~ledger_name ~ledger ()
+      ~ledger_name ~ticket_id ~ledger ()
   in
   let () =
     test_total_balance
       ~expected:Amount.(ledger_balance + amount)
-      ~ledger_name ~ledger ()
+      ~ledger_name ~ticket_id ~ledger ()
   in
-  let () = test_unknown_balance ~ledger_name ~ledger () in
+  let () = test_unknown_balance ~ledger_name ~ticket_id ~ledger () in
   ()
 
 let test_unknown_deposit ~ledger_name ~ledger () =
@@ -80,17 +100,19 @@ let test_unknown_deposit ~ledger_name ~ledger () =
   test_base_deposit ~address_name:"unknown" ~address:unknown ~amount
     ~ledger_name ~ledger ()
 
-let test_deposit ~address_name ~address ~amount ~ledger_name ~ledger () =
+let test_deposit ~address_name ~address ~amount ~ledger_name ~ticket_id ~ledger
+    () =
   let () =
-    test_base_deposit ~address_name ~address ~amount ~ledger_name ~ledger ()
+    test_base_deposit ~address_name ~address ~amount ~ledger_name ~ticket_id
+      ~ledger ()
   in
-  let () = test_unknown_deposit ~ledger_name ~ledger () in
+  let () = test_unknown_deposit ~ledger_name ~ticket_id ~ledger () in
   ()
 
 let test_success_transfer ~sender_name ~sender ~expected_sender_balance
-    ~receiver_name ~receiver ~amount ~ledger_name ~ledger () =
-  let ledger_balance = total_balance ledger in
-  let receiver_balance = balance receiver ledger in
+    ~receiver_name ~receiver ~amount ~ledger_name ~ticket_id ~ledger () =
+  let ledger_balance = total_balance ~ticket_id ledger in
+  let receiver_balance = balance receiver ticket_id ledger in
   let msg =
     Format.asprintf
       "Option.is_some (transfer ~sender:%s ~receiver:%s %a %s) = true"
@@ -99,10 +121,11 @@ let test_success_transfer ~sender_name ~sender ~expected_sender_balance
   let () =
     Alcotest.(check' bool)
       ~msg ~expected:true
-      ~actual:(Option.is_some (transfer ~sender ~receiver amount ledger))
+      ~actual:
+        (Result.is_ok (transfer ~sender ~receiver ~amount ~ticket_id ledger))
   in
-  let ledger = transfer ~sender ~receiver amount ledger in
-  let ledger = Option.get ledger in
+  let ledger = transfer ~sender ~receiver ~amount ~ticket_id ledger in
+  let ledger = Result.get_ok ledger in
 
   let ledger_name =
     Format.asprintf "%s[%s -[%a]> %s]" ledger_name sender_name Amount.pp amount
@@ -112,25 +135,26 @@ let test_success_transfer ~sender_name ~sender ~expected_sender_balance
   (* TODO: ensure that no other balance changed *)
   let () =
     test_balance ~address_name:sender_name ~address:sender
-      ~expected:expected_sender_balance ~ledger_name ~ledger ()
+      ~expected:expected_sender_balance ~ledger_name ~ticket_id ~ledger ()
   in
   let () =
     test_balance ~address_name:receiver_name ~address:receiver
       ~expected:Amount.(receiver_balance + amount)
-      ~ledger_name ~ledger ()
+      ~ledger_name ~ticket_id ~ledger ()
   in
   let () =
-    test_total_balance ~expected:ledger_balance ~ledger_name ~ledger ()
+    test_total_balance ~expected:ledger_balance ~ledger_name ~ticket_id ~ledger
+      ()
   in
   ()
 
 let test_base_transfer ~sender_name ~sender ~receiver_name ~receiver ~amount
-    ~ledger_name ~ledger () =
-  let sender_balance = balance sender ledger in
+    ~ledger_name ~ticket_id ~ledger () =
+  let sender_balance = balance sender ticket_id ledger in
   match Amount.(sender_balance - amount) with
   | Some expected_sender_balance ->
       test_success_transfer ~sender_name ~sender ~expected_sender_balance
-        ~receiver_name ~receiver ~amount ~ledger_name ~ledger ()
+        ~receiver_name ~receiver ~amount ~ledger_name ~ticket_id ~ledger ()
   | None ->
       let msg =
         Format.asprintf
@@ -139,75 +163,80 @@ let test_base_transfer ~sender_name ~sender ~receiver_name ~receiver ~amount
       in
       Alcotest.(check' bool)
         ~msg ~expected:true
-        ~actual:(Option.is_none (transfer ~sender ~receiver amount ledger))
+        ~actual:
+          (Result.is_ok (transfer ~sender ~receiver ~amount ~ticket_id ledger))
 
-let test_unknown_transfer ~ledger_name ~ledger () =
+let test_unknown_transfer ~ledger_name ~ticket_id ~ledger () =
   let unknown_a = new_address () in
   let unknown_b = new_address () in
 
   let amount = random_amount () in
-  let ledger = deposit unknown_a amount ledger in
+  let ledger = deposit unknown_a amount ticket_id ledger in
   let ledger_name =
     Format.asprintf "%s[unknown_a += %a]" ledger_name Amount.pp amount
   in
   test_success_transfer ~sender_name:"unknown_a" ~sender:unknown_a
     ~expected_sender_balance:Amount.zero ~receiver_name:"unknown_b"
-    ~receiver:unknown_b ~amount ~ledger_name ~ledger ()
+    ~receiver:unknown_b ~amount ~ledger_name ~ticket_id ~ledger ()
 
 let test_transfer ~sender_name ~sender ~receiver_name ~receiver ~amount
-    ~ledger_name ~ledger () =
+    ~ledger_name ~ticket_id ~ledger () =
   let () =
     test_base_transfer ~sender_name ~sender ~receiver_name ~receiver ~amount
-      ~ledger_name ~ledger ()
+      ~ledger_name ~ticket_id ~ledger ()
   in
-  let () = test_unknown_transfer ~ledger_name ~ledger () in
+  let () = test_unknown_transfer ~ledger_name ~ticket_id ~ledger () in
   ()
 
 let test_deposit_and_transfer ~address_name ~address ~address_balance
-    ~ledger_name ~ledger () =
+    ~ledger_name ~ticket_id ~ledger () =
   let third = new_address () in
   let () =
     test_deposit ~address_name:"third" ~address:third ~amount:(random_amount ())
-      ~ledger_name ~ledger ()
+      ~ledger_name ~ticket_id ~ledger ()
   in
   let () =
     test_transfer ~sender_name:address_name ~sender:address
       ~receiver_name:"third" ~receiver:third ~amount:address_balance
-      ~ledger_name ~ledger ()
+      ~ledger_name ~ticket_id ~ledger ()
   in
   ()
 
 let test_initial_total_balance () =
   test_total_balance ~expected:Amount.zero ~ledger_name:"initial"
-    ~ledger:initial ()
+    ~ticket_id:(default_ticket_id ()) ~ledger:initial ()
 
 let test_unknown_balance_on_initial () =
-  test_unknown_balance ~ledger_name:"initial" ~ledger:initial ()
+  test_unknown_balance ~ledger_name:"initial" ~ticket_id:(default_ticket_id ())
+    ~ledger:initial ()
 
 let test_unknown_deposit_on_initial () =
-  test_unknown_deposit ~ledger_name:"initial" ~ledger:initial ()
+  test_unknown_deposit ~ledger_name:"initial" ~ticket_id:(default_ticket_id ())
+    ~ledger:initial ()
 
 let test_unknown_transfer_on_initial () =
-  test_unknown_transfer ~ledger_name:"initial" ~ledger:initial ()
+  test_unknown_transfer ~ledger_name:"initial" ~ticket_id:(default_ticket_id ())
+    ~ledger:initial ()
 
 let test_simple_deposit () =
   let a = new_address () in
 
+  let ticket_id = default_ticket_id () in
   let amount = random_amount () in
-  let ledger_with_a = deposit a amount initial in
+  let ledger_with_a = deposit a amount ticket_id initial in
 
   let () =
-    test_total_balance ~expected:amount ~ledger_name:"ledger_with_a"
+    test_total_balance ~expected:amount ~ledger_name:"ledger_with_a" ~ticket_id
       ~ledger:ledger_with_a ()
   in
   let () =
     test_balance ~address_name:"a" ~address:a ~expected:amount
-      ~ledger_name:"ledger_with_a" ~ledger:ledger_with_a ()
+      ~ledger_name:"ledger_with_a" ~ticket_id ~ledger:ledger_with_a ()
   in
   let () =
     test_deposit_and_transfer ~address_name:"a" ~address:a
-      ~address_balance:amount ~ledger_name:"ledger_with_a" ~ledger:ledger_with_a
-      ()
+      ~address_balance:amount ~ledger_name:"ledger_with_a" ~ticket_id
+      ~ledger:ledger_with_a ()
   in
   ()
 
@@ -215,9 +244,11 @@ let test_simple_transfer () =
   let a = new_address () in
   let b = new_address () in
   let total_amount = amount_of_int 6 in
-  let ledger_with_a = deposit a total_amount initial in
+  let ticket_id = default_ticket_id () in
+  let ledger_with_a = deposit a total_amount ticket_id initial in
   let ledger_with_a_and_b =
-    transfer ~sender:a ~receiver:b (amount_of_int 4) ledger_with_a
+    transfer ~sender:a ~receiver:b ~amount:(amount_of_int 4) ~ticket_id
+      ledger_with_a
   in
   let () =
     Alcotest.(check' bool)
@@ -225,31 +256,34 @@ let test_simple_transfer () =
         "Option.is_some (transfer ~sender:a ~receiver:b 6 ledger_with_a) = true"
       ~expected:true
       ~actual:
-        (Option.is_some
-           (transfer ~sender:a ~receiver:b (amount_of_int 4) ledger_with_a))
+        (Result.is_ok
+           (transfer ~sender:a ~receiver:b ~amount:(amount_of_int 4) ~ticket_id
+              ledger_with_a))
   in
-  let ledger_with_a_and_b = Option.get ledger_with_a_and_b in
+  let ledger_with_a_and_b = Result.get_ok ledger_with_a_and_b in
 
   let () =
     test_total_balance ~expected:total_amount ~ledger_name:"ledger_with_a"
-      ~ledger:ledger_with_a ()
+      ~ticket_id ~ledger:ledger_with_a ()
   in
   let () =
     test_balance ~address_name:"a" ~address:a ~expected:(amount_of_int 2)
-      ~ledger_name:"ledger_with_a_and_b" ~ledger:ledger_with_a_and_b ()
+      ~ticket_id ~ledger_name:"ledger_with_a_and_b" ~ledger:ledger_with_a_and_b
+      ()
   in
   let () =
     test_balance ~address_name:"b" ~address:b ~expected:(amount_of_int 4)
-      ~ledger_name:"ledger_with_a_and_b" ~ledger:ledger_with_a_and_b ()
+      ~ticket_id ~ledger_name:"ledger_with_a_and_b" ~ledger:ledger_with_a_and_b
+      ()
   in
   let () =
     test_deposit_and_transfer ~address_name:"a" ~address:a
-      ~address_balance:(amount_of_int 2) ~ledger_name:"ledger_with_a"
+      ~address_balance:(amount_of_int 2) ~ledger_name:"ledger_with_a" ~ticket_id
       ~ledger:ledger_with_a_and_b ()
   in
   let () =
     test_deposit_and_transfer ~address_name:"b" ~address:b
-      ~address_balance:(amount_of_int 4) ~ledger_name:"ledger_with_a"
+      ~address_balance:(amount_of_int 4) ~ledger_name:"ledger_with_a" ~ticket_id
       ~ledger:ledger_with_a_and_b ()
   in
   ()

--- a/src/protocol/ticket_id.ml
+++ b/src/protocol/ticket_id.ml
@@ -1,0 +1,15 @@
+type ticket_id =
+  | Ticket_id of { ticketer : Deku_tezos.Contract_hash.t; data : bytes }
+
+and t = ticket_id [@@deriving eq, ord, yojson]
+
+let make ticketer data = Ticket_id { ticketer; data }
+
+let from_tezos_ticket tezos_ticket =
+  let Deku_tezos.Ticket_id.{ ticketer; data } = tezos_ticket in
+  match ticketer with
+  | Deku_tezos.Address.Implicit _address -> Error `Ticket_from_implicit
+  | Deku_tezos.Address.Originated { contract; _ } ->
+      Ok (Ticket_id { ticketer = contract; data })
+
+(* TODO: add Deku tickets back from v0 *)

--- a/src/protocol/ticket_id.mli
+++ b/src/protocol/ticket_id.mli
@@ -1,0 +1,9 @@
+type ticket_id = private
+  | Ticket_id of { ticketer : Deku_tezos.Contract_hash.t; data : bytes }
+
+and t = ticket_id [@@deriving eq, ord, yojson]
+
+val make : Deku_tezos.Contract_hash.t -> bytes -> t
+
+val from_tezos_ticket :
+  Deku_tezos.Ticket_id.t -> (t, [> `Ticket_from_implicit ]) result

--- a/src/protocol/ticket_table.ml
+++ b/src/protocol/ticket_table.ml
@@ -1,0 +1,118 @@
+open Deku_concepts
+open Deku_stdlib
+
+module Tickets = struct
+  module Ticket_map = Map.Make (Ticket_id)
+
+  type t = Amount.t Ticket_map.t
+
+  let get_balance ~ticket_id t = Ticket_map.find_opt ticket_id t
+  let to_seq map = Ticket_map.to_seq map
+  let of_seq seq = Ticket_map.of_seq seq
+
+  let singleton ~ticket_id ~amount =
+    Ticket_map.of_seq (Seq.return (ticket_id, amount))
+
+  let join t ~ticket_id ~amount =
+    let join option ~amount =
+      let value = Option.fold ~none:amount ~some:Amount.(( + ) amount) option in
+      value
+    in
+    Ticket_map.update ticket_id
+      (fun x ->
+        let joined = join ~amount x in
+        Option.some joined)
+      t
+
+  let get_and_remove ~ticket_id ~to_take t =
+    match
+      Ticket_map.update ticket_id
+        (function
+          | Some amount ->
+              let () =
+                let compared = Amount.compare amount to_take in
+                if compared >= 0 then () else failwith "error"
+              in
+              Amount.(amount - to_take)
+          | None -> failwith "error")
+        t
+    with
+    | _ as x -> Ok x
+    | exception Failure _ -> Error `Insufficient_funds
+
+  let get_and_remove_many tickets t =
+    let fetched =
+      List.fold_left_ok
+        (fun (lst, m) (ticket_id, amount) ->
+          let%ok m = get_and_remove ~ticket_id ~to_take:amount m in
+          let lst = Seq.cons (ticket_id, amount) lst in
+          Ok (lst, m))
+        (Seq.empty, t) tickets
+    in
+    fetched
+
+  let empty = Ticket_map.empty
+  let is_empty = Ticket_map.is_empty
+end
+
+module Ticket_map = Tickets.Ticket_map
+module Address_map = Map.Make (Address)
+
+type t = Tickets.t Address_map.t
+
+let empty = Address_map.empty
+
+let balance ~sender ~ticket_id t =
+  let%some map = Address_map.find_opt sender t in
+  Tickets.get_balance ~ticket_id map
+
+let update_or_create ~amount ~ticket_id t =
+  Option.fold
+    ~some:(fun x -> Tickets.join ~amount ~ticket_id x)
+    ~none:(Tickets.singleton ~amount ~ticket_id)
+    t
+  |> Option.some
+
+let update_tickets ~sender ~ticket_ids t =
+  if Seq.is_empty ticket_ids then Address_map.remove sender t
+  else Address_map.add sender (Tickets.of_seq ticket_ids) t
+
+let deposit ~destination ~ticket_id ~amount t =
+  Address_map.update destination (update_or_create ~amount ~ticket_id) t
+
+let update ~sender ~submap t =
+  if Tickets.is_empty submap then Address_map.remove sender t
+  else Address_map.add sender submap t
+
+let transfer ~sender ~receiver ~ticket_id ~amount t =
+  let%ok map =
+    Address_map.find_opt sender t |> Option.to_result ~none:`Insufficient_funds
+  in
+  let%ok map = Tickets.get_and_remove ~ticket_id ~to_take:amount map in
+  let t = update t ~sender ~submap:map in
+  let t = Address_map.update receiver (update_or_create ~amount ~ticket_id) t in
+  Ok t
+
+let withdraw ~sender ~ticket_id ~amount t =
+  let%ok map =
+    Address_map.find_opt sender t |> Option.to_result ~none:`Insufficient_funds
+  in
+  let%ok map = Tickets.get_and_remove ~ticket_id ~to_take:amount map in
+  let t = update t ~sender ~submap:map in
+  Ok t
+
+let take_tickets ~sender ~ticket_ids
+    (t : Amount.t Tickets.Ticket_map.t Address_map.t) =
+  let%ok map =
+    Address_map.find_opt sender t |> Option.to_result ~none:`Insufficient_funds
+  in
+  let%ok ticket_ids, map = Tickets.get_and_remove_many ticket_ids map in
+  let t = update ~sender ~submap:map t in
+  Ok (ticket_ids, t)
+
+let take_all_tickets ~sender t =
+  let map =
+    Address_map.find_opt sender t |> Option.value ~default:Tickets.empty
+  in
+  let tickets = Tickets.to_seq map in
+  (tickets, Address_map.remove sender t)

--- a/src/protocol/ticket_table.mli
+++ b/src/protocol/ticket_table.mli
@@ -1,0 +1,38 @@
+open Deku_concepts
+module Ticket_map : Map.S with type key = Ticket_id.t
+module Address_map : Map.S with type key = Address.t
+
+type t = private Amount.t Ticket_map.t Address_map.t
+
+val empty : t
+val balance : sender:Address.t -> ticket_id:Ticket_id.t -> t -> Amount.t option
+
+val deposit :
+  destination:Address.t -> ticket_id:Ticket_id.t -> amount:Amount.t -> t -> t
+
+val transfer :
+  sender:Address.t ->
+  receiver:Address.t ->
+  ticket_id:Ticket_id.t ->
+  amount:Amount.t ->
+  t ->
+  (t, [> `Insufficient_funds ]) result
+
+val withdraw :
+  sender:Address.t ->
+  ticket_id:Ticket_id.t ->
+  amount:Amount.t ->
+  t ->
+  (t, [> `Insufficient_funds ]) result
+
+val take_tickets :
+  sender:Address.t ->
+  ticket_ids:(Ticket_id.t * Amount.t) list ->
+  t ->
+  ((Ticket_id.t * Amount.t) Seq.t * t, [> `Insufficient_funds ]) result
+
+val take_all_tickets :
+  sender:Address.t -> t -> (Ticket_id.t * Amount.t) Seq.t * t
+
+val update_tickets :
+  sender:Address.t -> ticket_ids:(Ticket_id.t * Amount.t) Seq.t -> t -> t

--- a/src/stdlib/deku_stdlib.ml
+++ b/src/stdlib/deku_stdlib.ml
@@ -2,6 +2,7 @@ module N = N
 module Uri = Uri_ext
 include Let_syntax
 module Parallel = Parallel
+module List = List_ext
 
 module Yojson = struct
   include Yojson

--- a/src/stdlib/deku_stdlib.mli
+++ b/src/stdlib/deku_stdlib.mli
@@ -9,6 +9,7 @@ module Uri = Uri_ext
 [%%let ("let.some" : 'a option -> ('a -> 'b option) -> 'b option)]
 
 module Parallel = Parallel
+module List = List_ext
 
 (* FIXME: not sure if this is the right thing to do.  *)
 module Yojson : sig

--- a/src/stdlib/list_ext.ml
+++ b/src/stdlib/list_ext.ml
@@ -1,0 +1,8 @@
+include List
+
+let rec fold_left_ok f state = function
+  | [] -> Ok state
+  | head :: tl -> (
+      match f state head with
+      | Ok state -> fold_left_ok f state tl
+      | Error error -> Error error)

--- a/src/stdlib/list_ext.mli
+++ b/src/stdlib/list_ext.mli
@@ -1,0 +1,4 @@
+include module type of List
+
+val fold_left_ok :
+  ('a -> 'b -> ('a, 'e) Result.t) -> 'a -> 'b list -> ('a, 'e) Result.t

--- a/src/tezos/tezos_operation_hash.ml
+++ b/src/tezos/tezos_operation_hash.ml
@@ -8,7 +8,7 @@ include BLAKE2b.With_b58 (struct
   let prefix = Prefix.operation_hash
 end)
 
-include With_yojson_of_b58(struct
+include With_yojson_of_b58 (struct
   type t = tezos_operation_hash
 
   let of_b58 = of_b58

--- a/src/tezos/tezos_operation_hash.ml
+++ b/src/tezos/tezos_operation_hash.ml
@@ -1,10 +1,18 @@
 open Deku_repr
 open Deku_crypto
 
-type t = BLAKE2b.t [@@deriving eq, ord, yojson]
+type tezos_operation_hash = BLAKE2b.t
+and t = tezos_operation_hash [@@deriving eq, ord]
 
 include BLAKE2b.With_b58 (struct
   let prefix = Prefix.operation_hash
+end)
+
+include With_yojson_of_b58(struct
+  type t = tezos_operation_hash
+
+  let of_b58 = of_b58
+  let to_b58 = to_b58
 end)
 
 module Map = Map.Make (struct

--- a/src/tezos/tezos_operation_hash.mli
+++ b/src/tezos/tezos_operation_hash.mli
@@ -1,4 +1,7 @@
-type t [@@deriving eq, ord, yojson]
+open Deku_crypto
+
+type tezos_operation_hash = BLAKE2b.t
+type t = tezos_operation_hash [@@deriving eq, ord, yojson]
 
 val of_b58 : string -> t option
 val to_b58 : t -> string

--- a/src/tezos_interop/tests/deposit_test.ml
+++ b/src/tezos_interop/tests/deposit_test.ml
@@ -1,1 +1,76 @@
-let () = ignore "FIXME:"
+open Deku_crypto
+open Deku_tezos
+open Deku_tezos_interop
+open Deku_stdlib
+
+let secret =
+  Secret.of_b58 "edsk3QoqBuvdamxouPhin7swCvkQNgq4jP5KZPbwWNnwdZpSpJiEbq"
+  |> Option.get
+
+let rpc_node = Uri.of_string "http://localhost:20000"
+
+(* We can use a random discovery contract address *)
+let discovery_contract =
+  Address.of_string "KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton" |> Option.get
+
+let main consensus_contract =
+  let t =
+    Tezos_interop.make ~rpc_node ~secret ~consensus_contract ~discovery_contract
+      ~required_confirmations:2
+  in
+
+  let () =
+    let open Tezos_interop in
+    Consensus.listen_operations
+      ~on_operation:(fun { hash = _; transactions } ->
+        let is_deposit =
+          transactions
+          |> List.exists (fun transaction ->
+                 match transaction with
+                 | Consensus.Deposit _ -> true
+                 | _ -> false)
+        in
+        if is_deposit then
+          print_endline "👍 Receive a deposit on the consensus contract";
+        exit 0)
+      t
+  in
+  Lwt_main.run (Lwt_unix.sleep 10.0);
+  print_endline "👎 Deposit wasn't seen";
+  exit 1
+
+open Cmdliner
+
+let info =
+  let doc =
+    "Tests if the tezos interop can listen to deposit transaction on the \
+     consensus contract."
+  in
+  Cmd.info "deku-deposit-test" ~version:"%\226\128\140%VERSION%%" ~doc
+
+let term =
+  let address =
+    let open Arg in
+    let parser string =
+      string |> Address.of_string
+      |> Option.to_result ~none:(`Msg "Cannot parse the given contract address")
+    in
+    let printer ppf address =
+      Format.fprintf ppf "%s" (address |> Address.to_string)
+    in
+    conv (parser, printer)
+  in
+
+  let consensus_contract =
+    let open Arg in
+    let docv = "consensus-contract" in
+    let doc = "The address of the consensus contract to listen." in
+    let env = Cmd.Env.info "DEKU_CONSENSUS_CONTRACT" in
+    required
+    & opt (some address) None
+    & info [ "consensus-contract" ] ~doc ~docv ~env
+  in
+  let open Term in
+  const main $ consensus_contract
+
+let _ = Cmd.eval ~catch:true @@ Cmd.v info term

--- a/src/tezos_interop/tests/update_state_root_hash_test.ml
+++ b/src/tezos_interop/tests/update_state_root_hash_test.ml
@@ -46,8 +46,9 @@ let main consensus_contract =
         exit 0)
       t
   in
-  let forever, _ = Lwt.wait () in
-  Lwt_main.run forever
+  Lwt_main.run (Lwt_unix.sleep 10.0);
+  print_endline "👎 State root hash not updated";
+  exit 1
 
 open Cmdliner
 


### PR DESCRIPTION
* Adds the ticket table back from V0
* Changes the style a bit to match V1
* This still duplicates `ticket_id.ml` module, I'm open to suggestions on how to change that
* Unit tests do not account for multiple tickets yet

Manual testing:
* ./start.sh
* `tezos-client transfer 0 from alice to dummy_ticket --entrypoint mint_to_deku --arg "Pair (Pair \"KT1NuDB6ehuXpwgQU8jVxuYiPZasnnMikCFH\" \"tz1RPNjHPWuM8ryS5LDttkHdM321t85dSqaf\") (Pair 100 0x)" --burn-cap 2`
(replace KT1... by the consensus contract address)
* print the ledger