### PR TITLE
V1 withdraw draft

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -24,6 +24,8 @@ with ocamlPackages; buildDunePackage rec {
     mirage-crypto-ec
     mirage-crypto-rng
     secp256k1-internal
+    cohttp
+    cohttp-lwt-unix
     piaf
     domainslib
     cmdliner

--- a/src/bin/benchmark/deku_benchmark.ml
+++ b/src/bin/benchmark/deku_benchmark.ml
@@ -26,6 +26,14 @@ module Util = struct
 end
 
 module Block_application = struct
+  let default_ticket_id =
+    let address =
+      Deku_tezos.Contract_hash.of_string "KT1JQ5JQB4P1c8U8ACxfnodtZ4phDVMSDzgi"
+      |> Option.get
+    in
+    let data = Bytes.of_string "tuturu" in
+    Ticket_id.make address data
+
   let generate () =
     let secret = Ed25519.Secret.generate () in
     let secret = Secret.Ed25519 secret in
@@ -44,7 +52,9 @@ module Block_application = struct
     in
     let nonce = Nonce.of_n N.zero in
     let amount = Amount.of_n N.zero in
-    Operation.transaction ~identity ~level ~nonce ~source ~receiver ~amount
+    let ticket_id = default_ticket_id in
+    Operation.transaction ~identity ~level ~nonce ~source ~receiver ~ticket_id
+      ~amount
 
   let payload_of_operations operations =
     (* TODO: this likely should not be here *)
@@ -89,6 +99,14 @@ module Block_application = struct
 end
 
 module Block_production = struct
+  let default_ticket_id =
+    let address =
+      Deku_tezos.Contract_hash.of_string "KT1JQ5JQB4P1c8U8ACxfnodtZ4phDVMSDzgi"
+      |> Option.get
+    in
+    let data = Bytes.of_string "tuturu" in
+    Ticket_id.make address data
+
   let producer = Block_application.generate ()
   let sender = Block_application.generate ()
 
@@ -102,9 +120,10 @@ module Block_production = struct
   let operation ~nonce =
     let level = Level.zero in
     let nonce = Z.of_int nonce |> N.of_z |> Option.get |> Nonce.of_n in
+    let ticket_id = default_ticket_id in
     let amount = Amount.of_n N.zero in
     Operation.transaction ~identity:sender ~level ~nonce ~source ~receiver
-      ~amount
+      ~ticket_id ~amount
 
   let operations ~size = Parallel.init_p size (fun nonce -> operation ~nonce)
 

--- a/src/bin/node/deku_node.ml
+++ b/src/bin/node/deku_node.ml
@@ -77,7 +77,10 @@ module Node = struct
               (chain, [])
           | Bootstrap ->
               Chain.incoming_bootstrap_signal ~bootstrap_signal:packet ~current
-                chain)
+                chain
+          | Withdraw_proof ->
+              (* TODO make this case impossible*)
+              (chain, []))
       | None -> (chain, [])
     in
     let node = Node { chain; network; applied_block; tezos_interop; indexer } in
@@ -158,8 +161,13 @@ module Server = struct
   let with_endpoint Server.{ ctx = _; request } next =
     let path = request.target in
     let meth = request.meth in
+    let body = request.body in
 
     match Endpoint.of_string path with
+    | Some (Ex Withdraw_proof) ->
+        let%await body = Body.to_string body in
+        (* TODO find the receipt, get the proof, send the proof back *)
+        error ~message:"Not implemented yet" `Method_not_allowed
     | Some endpoint -> (
         match meth with
         | `POST -> next Server.{ ctx = endpoint; request }
@@ -281,4 +289,11 @@ let main () =
   Tezos_bridge.listen ();
   Server.start !port
 
-let () = Lwt_main.run (main ())
+let () =
+  (*  Tentative code to produce JSON to test the CLI for PL and I
+  let key = Deku_crypto.Key.of_b58 "edpktuhQHH83GN1Rbkte9kp6URtsw9yqrGuBo7vfmpmgGEBttKeCpN" in
+  let signature = Deku_crypto.Signature.of_b58
+  let operation = Operation.Operation {
+    key;
+  *)
+  Lwt_main.run (main ())

--- a/src/bin/node/dune
+++ b/src/bin/node/dune
@@ -11,4 +11,4 @@
   deku-indexer
   cmdliner)
  (preprocess
-  (pps ppx_let_binding)))
+  (pps ppx_let_binding ppx_yojson_conv)))

--- a/src/bin/transaction/dune
+++ b/src/bin/transaction/dune
@@ -1,0 +1,22 @@
+(executables
+ (names transaction withdraw proof)
+ (libraries
+  deku_tezos
+  deku_tezos_interop
+  deku-chain
+  deku-network
+  deku-storage
+  deku-indexer
+  cohttp
+  cohttp-lwt
+  cohttp-lwt-unix
+  yojson
+  piaf
+  cmdliner)
+ (preprocess
+  (pps
+   ppx_let_binding
+   ppx_deriving.show
+   ppx_deriving.eq
+   ppx_deriving.ord
+   ppx_yojson_conv)))

--- a/src/bin/transaction/proof.ml
+++ b/src/bin/transaction/proof.ml
@@ -1,0 +1,61 @@
+open Deku_protocol
+open Deku_crypto
+open Cohttp_lwt_unix
+
+let post body uri =
+  let body = Cohttp_lwt.Body.of_string body in
+  Client.post ~body uri
+
+module Proof_response = struct
+  type t =
+    | Proof of {
+        hash : BLAKE2b.t;
+        handle : Ledger.Withdrawal_handle.t;
+        proof : Ledger.withdraw_proof;
+      }
+  [@@deriving yojson]
+end
+
+let () =
+  let arg1 = Sys.argv.(1) in
+  let arg1 = Printf.sprintf "\"%s\"" arg1 in
+  let arg1 = Yojson.Safe.from_string arg1 in
+  let operation_hash = Operation_hash.t_of_yojson arg1 in
+  let body = Operation_hash.yojson_of_t operation_hash in
+  let body = Yojson.Safe.to_string body in
+  Lwt_main.run
+    (let open Lwt.Syntax in
+    let* _reponse, body =
+      post body (Uri.of_string "http://localhost:4440/withdraw_proof")
+    in
+    let* body = Cohttp_lwt.Body.to_string body in
+    prerr_endline body;
+    let body = Yojson.Safe.from_string body in
+    match Proof_response.t_of_yojson body with
+    | Proof_response.Proof
+        {
+          handle = { id; owner; ticket_id; amount; hash = handle_hash };
+          proof;
+          hash = _;
+        } ->
+        let to_hex bytes = Hex.show (Hex.of_bytes bytes) in
+        let (Ticket_id { ticketer; data }) = ticket_id in
+        Format.printf
+          {|(Pair (Pair %S
+            (Pair (Pair %s 0x%s) %d %S)
+            %S)
+      0x%s
+      { %s })|}
+          "fixme_callback"
+          (Deku_concepts.Amount.show amount)
+          (to_hex data) id
+          (Deku_tezos.Address.to_string owner)
+          (Deku_tezos.Contract_hash.to_string ticketer)
+          (BLAKE2b.to_hex handle_hash)
+          (List.map
+             (fun (left, right) ->
+               Format.sprintf "        Pair 0x%s\n             0x%s"
+                 (BLAKE2b.to_hex left) (BLAKE2b.to_hex right))
+             proof
+          |> String.concat " ;\n" |> String.trim);
+        Lwt.return_unit)

--- a/src/bin/transaction/transaction.ml
+++ b/src/bin/transaction/transaction.ml
@@ -1,0 +1,85 @@
+open Deku_protocol
+open Deku_crypto
+open Deku_concepts
+open Lwt_result.Syntax
+open Cohttp_lwt_unix
+open Lwt
+
+(*
+(* FIXME this does not work, don't know why *)
+let post body uri =
+  let headers =
+    let open Piaf.Headers in
+    (* TODO: maybe add json to Well_known in Piaf*)
+    let json = Mime_types.map_extension "json" in
+    [ (Well_known.content_type, json) ]
+  in
+  let body = Piaf.Body.of_string body in
+  prerr_endline "oui";
+  let* post_result = Piaf.Client.Oneshot.post ~headers ~body uri in
+  prerr_endline "test";  (* never shown *)
+  Lwt.return (Ok post_result)
+  *)
+
+let post body uri =
+  let body = Cohttp_lwt.Body.of_string body in
+  Client.post ~body uri
+
+let () =
+  let ticket = "KT18h9RX4oh7YBHxdjZr8kWEW14JeZ6bybah" in
+  let url = "http://localhost:4441/level" in
+  let level =
+    Lwt_main.run
+      (let* response = Piaf.Client.Oneshot.get (Uri.of_string url) in
+       let* level = Piaf.Body.to_string response.body in
+       prerr_endline level;
+       let level = Yojson.Safe.from_string level in
+       let level = Level.next (Level.next (Level.t_of_yojson level)) in
+       Lwt.return (Ok level))
+    |> Result.get_ok
+  in
+  let secret =
+    Secret.of_b58 "edsk2qXLn3PdFyb5QYGCqbK5kKZFpfTmTtiUDKSA8RuKN34U3BUKHo"
+    |> Option.get
+  in
+  let identity = Identity.make secret in
+  let source =
+    let key_hash = Identity.key_hash identity in
+    Address.of_key_hash key_hash
+  in
+  let receiver =
+    Address.of_b58 "tz1bPFuX14fYT43fnmXbxzZuyT7ABJic7Rz7" |> Option.get
+  in
+  let ticketer = Deku_tezos.Contract_hash.of_string ticket |> Option.get in
+  let data = Bytes.of_string "" in
+  let ticket_id = Ticket_id.make ticketer data in
+  let nonce = Nonce.of_n (Obj.magic level) in
+  let operation =
+    Operation.transaction ~identity ~level ~nonce ~source ~receiver ~ticket_id
+      ~amount:(Deku_concepts.Amount.of_int 10 |> Option.get)
+  in
+  let uris =
+    [
+      "http://localhost:4440/operations";
+      (* "http://localhost:4441/";
+         "http://localhost:4442/";
+         "http://localhost:4443/" *)
+    ]
+    |> List.map Uri.of_string
+  in
+  let body = Operation.yojson_of_t operation in
+  let packet = Deku_network.Packet.make ~content:body in
+  let packet = Deku_network.Packet.yojson_of_t packet in
+  Lwt_main.run
+    (Lwt_list.iter_p
+       (fun uri ->
+         let body = Yojson.Safe.to_string packet in
+         post body uri >>= fun _ -> Lwt.return_unit)
+       uris);
+  let (Operation.Operation { hash; _ }) = operation in
+  let hash = Operation_hash.to_blake2b hash in
+  Printf.printf "operation.hash: %s\n%!" (BLAKE2b.to_hex hash);
+  Printf.printf "operation code: %s\n%!"
+    (Operation.yojson_of_t operation |> Yojson.Safe.to_string);
+  prerr_endline "operation broadcasted";
+  ()

--- a/src/bin/transaction/withdraw.ml
+++ b/src/bin/transaction/withdraw.ml
@@ -1,0 +1,71 @@
+open Deku_protocol
+open Deku_crypto
+open Deku_concepts
+open Lwt_result.Syntax
+open Cohttp_lwt_unix
+open Lwt
+
+(* TODO arthur : réessayer Piaf avec les packets *)
+let post body uri =
+  let body = Cohttp_lwt.Body.of_string body in
+  Client.post ~body uri
+
+let () =
+  let ticket = "KT18h9RX4oh7YBHxdjZr8kWEW14JeZ6bybah" in
+  let url = "http://localhost:4441/level" in
+  let level =
+    Lwt_main.run
+      (let* response = Piaf.Client.Oneshot.get (Uri.of_string url) in
+       let* level = Piaf.Body.to_string response.body in
+       prerr_endline level;
+       let level = Yojson.Safe.from_string level in
+       let level = Level.next (Level.next (Level.t_of_yojson level)) in
+       Lwt.return (Ok level))
+    |> Result.get_ok
+  in
+  let secret =
+    Secret.of_b58 "edsk2qXLn3PdFyb5QYGCqbK5kKZFpfTmTtiUDKSA8RuKN34U3BUKHo"
+    |> Option.get
+  in
+  let identity = Identity.make secret in
+  let source =
+    let key_hash = Identity.key_hash identity in
+    Address.of_key_hash key_hash
+  in
+  let tezos_owner =
+    Deku_tezos.Address.of_string "tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"
+    |> Option.get
+  in
+  let ticketer = Deku_tezos.Contract_hash.of_string ticket |> Option.get in
+  let data = Bytes.of_string "" in
+  let ticket_id = Ticket_id.make ticketer data in
+  let nonce = Nonce.of_n (Obj.magic level) in
+  let operation =
+    Operation.withdraw ~identity ~level ~nonce ~source ~tezos_owner ~ticket_id
+      ~amount:(Deku_concepts.Amount.of_int 10 |> Option.get)
+  in
+  let uris =
+    [
+      "http://localhost:4440/operations";
+      (* "http://localhost:4441/";
+         "http://localhost:4442/";
+         "http://localhost:4443/" *)
+    ]
+    |> List.map Uri.of_string
+  in
+  let body = Operation.yojson_of_t operation in
+  let packet = Deku_network.Packet.make ~content:body in
+  let packet = Deku_network.Packet.yojson_of_t packet in
+  Lwt_main.run
+    (Lwt_list.iter_p
+       (fun uri ->
+         let body = Yojson.Safe.to_string packet in
+         post body uri >>= fun _ -> Lwt.return_unit)
+       uris);
+  let (Operation.Operation { hash; _ }) = operation in
+  let hash = Operation_hash.yojson_of_t hash |> Yojson.Safe.to_string in
+  Printf.printf "operation.hash: %s\n%!" hash;
+  Printf.printf "operation code: %s\n%!"
+    (Operation.yojson_of_t operation |> Yojson.Safe.to_string);
+  prerr_endline "operation broadcasted";
+  ()

--- a/src/chain/chain.ml
+++ b/src/chain/chain.ml
@@ -46,6 +46,8 @@ let apply_block ~pool ~current ~block chain =
     | None -> []
   in
   let effects = Save_block block :: Reset_timeout :: effects in
+  let (Protocol { ledger; _ }) = protocol in
+  Ledger.show_ledger ledger;
   (Chain { protocol; consensus; verifier; signer; producer }, effects)
 
 let incoming_block ~pool ~current ~block chain =

--- a/src/concepts/amount.ml
+++ b/src/concepts/amount.ml
@@ -10,3 +10,4 @@ let of_n x = x
 let to_n x = x
 let ( + ) a b = a + b
 let ( - ) a b = a - b
+let of_int x = N.of_z (Z.of_int x)

--- a/src/concepts/amount.mli
+++ b/src/concepts/amount.mli
@@ -9,3 +9,4 @@ val of_n : N.t -> amount
 val to_n : amount -> N.t
 val ( + ) : amount -> amount -> amount
 val ( - ) : amount -> amount -> amount option
+val of_int : int -> amount option

--- a/src/consensus/producer.ml
+++ b/src/consensus/producer.ml
@@ -44,10 +44,9 @@ let clean ~receipts ~tezos_operations producer =
     List.fold_left
       (fun operations receipt ->
         match receipt with
-          | Receipt.Receipt_operation { operation = hash } ->
+        | Receipt.Receipt_operation { operation = hash } ->
             Operation_hash.Map.remove hash operations
-          | _ ->   (* TODO: I think we do nothing here *)
-            operations)
+        | _ -> operations)
       operations receipts
   in
   let tezos_operations =

--- a/src/consensus/producer.ml
+++ b/src/consensus/producer.ml
@@ -43,8 +43,11 @@ let clean ~receipts ~tezos_operations producer =
   let operations =
     List.fold_left
       (fun operations receipt ->
-        let (Receipt.Receipt { operation = hash }) = receipt in
-        Operation_hash.Map.remove hash operations)
+        match receipt with
+          | Receipt.Receipt_operation { operation = hash } ->
+            Operation_hash.Map.remove hash operations
+          | _ ->   (* TODO: I think we do nothing here *)
+            operations)
       operations receipts
   in
   let tezos_operations =

--- a/src/crypto/incremental_patricia.ml
+++ b/src/crypto/incremental_patricia.ml
@@ -1,0 +1,72 @@
+module Make (V : sig
+  type t [@@deriving yojson]
+
+  val hash : t -> BLAKE2b.t
+end) =
+struct
+  type value = V.t [@@deriving yojson]
+  type key = int [@@deriving yojson]
+
+  type tree =
+    | Empty
+    | Leaf of { value : value; hash : BLAKE2b.t }
+    | Node of { left : tree; hash : BLAKE2b.t; right : tree }
+  [@@deriving yojson]
+
+  type t = { tree : tree; top_bit : key; last_key : key } [@@deriving yojson]
+
+  let is_set bit number = (1 lsl bit) land number <> 0
+  let empty_hash = BLAKE2b.hash ""
+
+  let hash_of_t = function
+    | Empty -> empty_hash
+    | Leaf { hash; _ } | Node { hash; _ } -> hash
+
+  let rec find bit proofs key t =
+    match t with
+    | Empty -> None
+    | Leaf { value; _ } -> Some (List.rev proofs, value)
+    | Node { left; right; _ } ->
+        let t = match is_set bit key with true -> right | false -> left in
+        find (bit - 1) ((hash_of_t left, hash_of_t right) :: proofs) key t
+
+  let find key t =
+    if key >= 0 && key <= t.last_key then find (t.top_bit - 1) [] key t.tree
+    else None
+
+  let node left right =
+    let hash = BLAKE2b.both (hash_of_t left) (hash_of_t right) in
+    Node { left; hash; right }
+
+  let rec empty n =
+    if n = 0 then Empty
+    else
+      let tree = empty (n - 1) in
+      node tree tree
+
+  let add f t =
+    let rec add bit key value t =
+      match (bit, t) with
+      | -1, Empty -> Leaf { value; hash = V.hash value }
+      | _, Node { left; right; _ } -> (
+          match is_set bit key with
+          | true -> node left (add (bit - 1) key value right)
+          | false -> node (add (bit - 1) key value left) right)
+      | _ -> assert false
+    in
+    let key = t.last_key + 1 in
+    let value = f key in
+    let increase_top_bit = key lsr t.top_bit in
+    let top_bit = t.top_bit + increase_top_bit in
+    let tree =
+      if increase_top_bit = 1 then
+        let right = empty (top_bit - 1) in
+        node t.tree right
+      else t.tree
+    in
+    let tree = add (top_bit - 1) key value tree in
+    ({ tree; top_bit; last_key = key }, value)
+
+  let empty = { top_bit = 0; tree = Empty; last_key = -1 }
+  let hash t = hash_of_t t.tree
+end

--- a/src/crypto/incremental_patricia.mli
+++ b/src/crypto/incremental_patricia.mli
@@ -1,0 +1,16 @@
+module Make : functor
+  (V : sig
+     type t [@@deriving yojson]
+
+     val hash : t -> BLAKE2b.t
+   end)
+  -> sig
+  type value = V.t
+  type key = int
+  type t [@@deriving yojson]
+
+  val empty : t
+  val hash : t -> BLAKE2b.t
+  val add : (key -> value) -> t -> t * value
+  val find : key -> t -> ((BLAKE2b.t * BLAKE2b.t) list * value) option
+end

--- a/src/indexer/indexer.ml
+++ b/src/indexer/indexer.ml
@@ -99,10 +99,13 @@ let save_block ~block ~timestamp (Indexer { pool }) =
 
 let save_packet ~packet ~timestamp (Indexer { pool }) =
   Lwt.async (fun () ->
-      let packet = Yojson.Safe.from_string packet |> Packet.t_of_yojson in
-      let%await result = Query.insert_packet ~packet ~timestamp pool in
-      match result with
-      | Ok () -> Lwt.return_unit
-      | Error err ->
-          (* TODO: how do we want to handle this? *)
-          raise (Caqti_error.Exn err))
+      try
+        let packet = Yojson.Safe.from_string packet |> Packet.t_of_yojson in
+        let%await result = Query.insert_packet ~packet ~timestamp pool in
+        match result with
+        | Ok () -> Lwt.return_unit
+        | Error _err ->
+            (* TODO: how do we want to handle this? *)
+            (* raise (Caqti_error.Exn err)*)
+            Lwt.return_unit
+      with _ -> Lwt.return_unit)

--- a/src/network/endpoint.ml
+++ b/src/network/endpoint.ml
@@ -7,6 +7,7 @@ type _ endpoint =
   | Signatures : Verified_signature.t endpoint
   | Operations : Operation.t endpoint
   | Bootstrap : Bootstrap_signal.t endpoint
+  | Withdraw_proof : Ledger.withdraw_proof endpoint
 
 type 'a t = 'a endpoint
 type ex = Ex : _ endpoint -> ex
@@ -15,6 +16,7 @@ let blocks = Blocks
 let signatures = Signatures
 let operations = Operations
 let bootstrap = Bootstrap
+let withdraw_proof = Withdraw_proof
 
 let of_string path =
   match path with
@@ -22,6 +24,7 @@ let of_string path =
   | "/signatures" -> Some (Ex Signatures)
   | "/operations" -> Some (Ex Operations)
   | "/bootstrap" -> Some (Ex Bootstrap)
+  | "/withdraw_proof" -> Some (Ex Withdraw_proof)
   | _ -> None
 
 let to_string (type a) (endpoint : a endpoint) =
@@ -30,3 +33,4 @@ let to_string (type a) (endpoint : a endpoint) =
   | Signatures -> "/signatures"
   | Operations -> "/operations"
   | Bootstrap -> "/bootstrap"
+  | Withdraw_proof -> "/proof"

--- a/src/network/endpoint.ml
+++ b/src/network/endpoint.ml
@@ -7,7 +7,8 @@ type _ endpoint =
   | Signatures : Verified_signature.t endpoint
   | Operations : Operation.t endpoint
   | Bootstrap : Bootstrap_signal.t endpoint
-  | Withdraw_proof : Ledger.withdraw_proof endpoint
+  | Withdraw_proof : Operation_hash.t endpoint
+  | Level : Level.t endpoint
 
 type 'a t = 'a endpoint
 type ex = Ex : _ endpoint -> ex
@@ -17,6 +18,7 @@ let signatures = Signatures
 let operations = Operations
 let bootstrap = Bootstrap
 let withdraw_proof = Withdraw_proof
+let level = Level
 
 let of_string path =
   match path with
@@ -25,6 +27,7 @@ let of_string path =
   | "/operations" -> Some (Ex Operations)
   | "/bootstrap" -> Some (Ex Bootstrap)
   | "/withdraw_proof" -> Some (Ex Withdraw_proof)
+  | "/level" -> Some (Ex Level)
   | _ -> None
 
 let to_string (type a) (endpoint : a endpoint) =
@@ -34,3 +37,4 @@ let to_string (type a) (endpoint : a endpoint) =
   | Operations -> "/operations"
   | Bootstrap -> "/bootstrap"
   | Withdraw_proof -> "/proof"
+  | Level -> "/level"

--- a/src/network/endpoint.mli
+++ b/src/network/endpoint.mli
@@ -7,6 +7,7 @@ type _ endpoint = private
   | Signatures : Verified_signature.t endpoint
   | Operations : Operation.t endpoint
   | Bootstrap : Bootstrap_signal.t endpoint
+  | Withdraw_proof : Ledger.withdraw_proof endpoint
 
 type 'a t = 'a endpoint
 type ex = Ex : _ endpoint -> ex
@@ -15,5 +16,6 @@ val blocks : Block.t endpoint
 val signatures : Verified_signature.t endpoint
 val operations : Operation.t endpoint
 val bootstrap : Bootstrap_signal.t endpoint
+val withdraw_proof : Ledger.withdraw_proof endpoint
 val of_string : string -> ex option
 val to_string : _ endpoint -> string

--- a/src/network/endpoint.mli
+++ b/src/network/endpoint.mli
@@ -7,7 +7,8 @@ type _ endpoint = private
   | Signatures : Verified_signature.t endpoint
   | Operations : Operation.t endpoint
   | Bootstrap : Bootstrap_signal.t endpoint
-  | Withdraw_proof : Ledger.withdraw_proof endpoint
+  | Withdraw_proof : Operation_hash.t endpoint
+  | Level : Level.t endpoint
 
 type 'a t = 'a endpoint
 type ex = Ex : _ endpoint -> ex
@@ -16,6 +17,7 @@ val blocks : Block.t endpoint
 val signatures : Verified_signature.t endpoint
 val operations : Operation.t endpoint
 val bootstrap : Bootstrap_signal.t endpoint
-val withdraw_proof : Ledger.withdraw_proof endpoint
+val withdraw_proof : Operation_hash.t endpoint
+val level : Level.t endpoint
 val of_string : string -> ex option
 val to_string : _ endpoint -> string

--- a/src/network/packet.ml
+++ b/src/network/packet.ml
@@ -42,6 +42,7 @@ let content_of_yojson (type a) ~(endpoint : a endpoint) json : a =
   | Signatures -> Verified_signature.t_of_yojson json
   | Operations -> Operation.t_of_yojson json
   | Bootstrap -> Bootstrap_signal.t_of_yojson json
+  | Withdraw_proof -> prerr_endline "received here"; Ledger.withdraw_proof_of_yojson json
 
 let yojson_of_content (type a) ~(endpoint : a endpoint) (content : a) =
   match endpoint with
@@ -49,3 +50,4 @@ let yojson_of_content (type a) ~(endpoint : a endpoint) (content : a) =
   | Signatures -> Verified_signature.yojson_of_t content
   | Operations -> Operation.yojson_of_t content
   | Bootstrap -> Bootstrap_signal.yojson_of_t content
+  | Withdraw_proof -> Ledger.yojson_of_withdraw_proof content

--- a/src/network/packet.ml
+++ b/src/network/packet.ml
@@ -42,7 +42,10 @@ let content_of_yojson (type a) ~(endpoint : a endpoint) json : a =
   | Signatures -> Verified_signature.t_of_yojson json
   | Operations -> Operation.t_of_yojson json
   | Bootstrap -> Bootstrap_signal.t_of_yojson json
-  | Withdraw_proof -> prerr_endline "received here"; Ledger.withdraw_proof_of_yojson json
+  | Withdraw_proof ->
+      Operation_hash.t_of_yojson json
+  | Level ->
+      Level.t_of_yojson json
 
 let yojson_of_content (type a) ~(endpoint : a endpoint) (content : a) =
   match endpoint with
@@ -50,4 +53,5 @@ let yojson_of_content (type a) ~(endpoint : a endpoint) (content : a) =
   | Signatures -> Verified_signature.yojson_of_t content
   | Operations -> Operation.yojson_of_t content
   | Bootstrap -> Bootstrap_signal.yojson_of_t content
-  | Withdraw_proof -> Ledger.yojson_of_withdraw_proof content
+  | Withdraw_proof -> Operation_hash.yojson_of_t content
+  | Level -> Level.yojson_of_t content

--- a/src/protocol/dune
+++ b/src/protocol/dune
@@ -3,4 +3,4 @@
  (public_name deku-protocol)
  (libraries deku_tezos deku_crypto deku_concepts deku_constants)
  (preprocess
-  (pps ppx_deriving.eq ppx_deriving.ord ppx_yojson_conv)))
+  (pps ppx_let_binding ppx_deriving.eq ppx_deriving.ord ppx_yojson_conv)))

--- a/src/protocol/ledger.ml
+++ b/src/protocol/ledger.ml
@@ -12,9 +12,13 @@ module Withdrawal_handle = struct
   }
   [@@deriving yojson]
 
+  let equal handle1 handle2 = BLAKE2b.equal handle1.hash handle2.hash
+
   let hash ~id ~owner ~amount ~ticket_id =
-    let Ticket_id.Ticket_id { ticketer; data } = ticket_id in
-    let ticketer = Deku_tezos.Address.Originated { contract = ticketer; entrypoint = None } in
+    let (Ticket_id.Ticket_id { ticketer; data }) = ticket_id in
+    let ticketer =
+      Deku_tezos.Address.Originated { contract = ticketer; entrypoint = None }
+    in
     Deku_tezos.Deku.Consensus.hash_withdraw_handle ~id:(Z.of_int id) ~owner
       ~amount:(N.to_z (Amount.to_n amount))
       ~ticketer ~data
@@ -26,17 +30,29 @@ module Withdrawal_handle_tree = Incremental_patricia.Make (struct
   let hash t = t.Withdrawal_handle.hash
 end)
 
+(* TODO: remove me? *)
 type withdraw_handle_tree = Withdrawal_handle_tree.t
 
-type ledger = Ledger of { table : Ticket_table.t ; withdrawal_handles : withdraw_handle_tree }
+type ledger =
+  | Ledger of {
+      table : Ticket_table.t;
+      withdrawal_handles : withdraw_handle_tree;
+    }
+
 and t = ledger
 
 type withdraw_proof = (BLAKE2b.t * BLAKE2b.t) list [@@deriving yojson]
+type withdraw_handle = Withdrawal_handle.t [@@deriving yojson]
 
-let initial = Ledger { table = Ticket_table.empty; withdrawal_handles = Withdrawal_handle_tree.empty }
+let initial =
+  Ledger
+    {
+      table = Ticket_table.empty;
+      withdrawal_handles = Withdrawal_handle_tree.empty;
+    }
 
 let with_ticket_table t f =
-  let Ledger { table; withdrawal_handles } = t in
+  let (Ledger { table; withdrawal_handles }) = t in
   f ~get_table:(Fun.const table) ~set_table:(fun table ->
       Ledger { table; withdrawal_handles })
 
@@ -44,12 +60,13 @@ let balance address ticket_id (Ledger { table; _ }) =
   Ticket_table.balance ~sender:address ~ticket_id table
   |> Option.value ~default:Amount.zero
 
-let deposit destination amount ticket_id (Ledger { table; withdrawal_handles }) =
+let deposit destination amount ticket_id (Ledger { table; withdrawal_handles })
+    =
   let table = Ticket_table.deposit ~destination ~ticket_id ~amount table in
   Ledger { table; withdrawal_handles }
 
 let transfer ~sender ~receiver ~amount ~ticket_id
-  (Ledger { table; withdrawal_handles }) =
+    (Ledger { table; withdrawal_handles }) =
   let%ok table =
     Ticket_table.transfer table ~sender ~receiver ~amount ~ticket_id
     |> Result.map_error (fun _ -> `Insufficient_funds)
@@ -57,33 +74,59 @@ let transfer ~sender ~receiver ~amount ~ticket_id
   Ok (Ledger { table; withdrawal_handles })
 
 let withdraw ~sender ~destination ~amount ~ticket_id t =
-  let Ledger { table; withdrawal_handles } = t in
+  let (Ledger { table; withdrawal_handles }) = t in
   let%ok table =
-    Ticket_table.withdraw
-      ~sender
-      ~amount ~ticket_id
-      table
-    |> Result.map_error (function _ -> `Insufficient_funds) in
+    Ticket_table.withdraw ~sender ~amount ~ticket_id table
+    |> Result.map_error (function _ -> `Insufficient_funds)
+  in
   let withdrawal_handles, handle =
     Withdrawal_handle_tree.add
       (fun id ->
         let hash =
-          Withdrawal_handle.hash ~id ~owner:destination ~amount ~ticket_id in
+          Withdrawal_handle.hash ~id ~owner:destination ~amount ~ticket_id
+        in
         { id; hash; owner = destination; amount; ticket_id })
-      withdrawal_handles in
+      withdrawal_handles
+  in
   let t = Ledger { table; withdrawal_handles } in
   Ok (t, handle)
 
 let withdrawal_handles_find_proof handle t =
-  let Ledger { withdrawal_handles; _ } = t in
+  let (Ledger { withdrawal_handles; _ }) = t in
   match
     Withdrawal_handle_tree.find handle.Withdrawal_handle.id withdrawal_handles
   with
   | None -> assert false
   | Some (proof, _) -> proof
 
-let withdrawal_handles_find_proof_by_id key (Ledger { withdrawal_handles ; _ }) =
+let withdrawal_handles_find_proof_by_id key (Ledger { withdrawal_handles; _ }) =
   Withdrawal_handle_tree.find key withdrawal_handles
 
-let withdrawal_handles_root_hash (Ledger { withdrawal_handles ; _ }) =
+let withdrawal_handles_root_hash (Ledger { withdrawal_handles; _ }) =
   Withdrawal_handle_tree.hash withdrawal_handles
+
+(*
+let total_balance ~ticket_id (Ledger { table; withdrawal_handles = _ }) =
+  let open Ticket_table in
+  Address_map.fold
+    (fun _sender ticket_map total_amount ->
+      Ticket_map.find_opt ticket_id ticket_map
+      |> Option.value ~default:Amount.zero
+      |> Amount.( + ) total_amount)
+    (table :> Amount.t Ticket_map.t Address_map.t)
+    Amount.zero
+*)
+
+let show_ledger ledger =
+  let open Ticket_table in
+  let (Ledger { table; _ }) = ledger in
+  Address_map.iter
+    (fun address map ->
+      Printf.printf "** %s\n" (Address.to_b58 address);
+      Ticket_map.iter
+        (fun ticket_id amount ->
+          Printf.printf "    %s: %d\n%!"
+            (Ticket_id.yojson_of_ticket_id ticket_id |> Yojson.Safe.to_string)
+            (amount |> Amount.to_n |> Deku_stdlib.N.to_z |> Z.to_int))
+        map)
+    (table :> Amount.t Ticket_map.t Address_map.t)

--- a/src/protocol/ledger.ml
+++ b/src/protocol/ledger.ml
@@ -1,29 +1,22 @@
 open Deku_concepts
-open Amount
+open Deku_stdlib
 
-type ledger = Amount.t Address.Map.t
-type t = ledger
+type ledger = Ledger of { table : Ticket_table.t }
+and t = ledger
 
-let initial = Address.Map.empty
+let initial = Ledger { table = Ticket_table.empty }
 
-let balance address ledger =
-  match Address.Map.find_opt address ledger with
-  | Some balance -> balance
-  | None -> Amount.zero
+let balance address ticket_id (Ledger { table }) =
+  Ticket_table.balance ~sender:address ~ticket_id table
+  |> Option.value ~default:Amount.zero
 
-let deposit address amount ledger =
-  let balance = balance address ledger in
-  let balance = balance + amount in
-  Address.Map.add address balance ledger
+let deposit destination amount ticket_id (Ledger { table }) =
+  let table = Ticket_table.deposit ~destination ~ticket_id ~amount table in
+  Ledger { table }
 
-let transfer ~sender ~receiver amount ledger =
-  let sender_balance = balance sender ledger in
-  let receiver_balance = balance receiver ledger in
-
-  match sender_balance - amount with
-  | Some sender_balance ->
-      let receiver_balance = receiver_balance + amount in
-      let ledger = Address.Map.add sender sender_balance ledger in
-      let ledger = Address.Map.add receiver receiver_balance ledger in
-      Some ledger
-  | None -> None
+let transfer ~sender ~receiver ~amount ~ticket_id (Ledger { table }) =
+  let%ok table =
+    Ticket_table.transfer table ~sender ~receiver ~amount ~ticket_id
+    |> Result.map_error (fun _ -> `Insufficient_funds)
+  in
+  Ok (Ledger { table })

--- a/src/protocol/ledger.ml
+++ b/src/protocol/ledger.ml
@@ -31,7 +31,7 @@ type withdraw_handle_tree = Withdrawal_handle_tree.t
 type ledger = Ledger of { table : Ticket_table.t ; withdrawal_handles : withdraw_handle_tree }
 and t = ledger
 
-type withdraw_proof = (BLAKE2b.t * BLAKE2b.t) list
+type withdraw_proof = (BLAKE2b.t * BLAKE2b.t) list [@@deriving yojson]
 
 let initial = Ledger { table = Ticket_table.empty; withdrawal_handles = Withdrawal_handle_tree.empty }
 

--- a/src/protocol/ledger.ml
+++ b/src/protocol/ledger.ml
@@ -1,22 +1,89 @@
+open Deku_crypto
 open Deku_concepts
 open Deku_stdlib
 
-type ledger = Ledger of { table : Ticket_table.t }
+module Withdrawal_handle = struct
+  type t = {
+    hash : BLAKE2b.t;
+    id : int;
+    owner : Deku_tezos.Address.t;
+    amount : Amount.t;
+    ticket_id : Ticket_id.t;
+  }
+  [@@deriving yojson]
+
+  let hash ~id ~owner ~amount ~ticket_id =
+    let Ticket_id.Ticket_id { ticketer; data } = ticket_id in
+    let ticketer = Deku_tezos.Address.Originated { contract = ticketer; entrypoint = None } in
+    Deku_tezos.Deku.Consensus.hash_withdraw_handle ~id:(Z.of_int id) ~owner
+      ~amount:(N.to_z (Amount.to_n amount))
+      ~ticketer ~data
+end
+
+module Withdrawal_handle_tree = Incremental_patricia.Make (struct
+  type t = Withdrawal_handle.t [@@deriving yojson]
+
+  let hash t = t.Withdrawal_handle.hash
+end)
+
+type withdraw_handle_tree = Withdrawal_handle_tree.t
+
+type ledger = Ledger of { table : Ticket_table.t ; withdrawal_handles : withdraw_handle_tree }
 and t = ledger
 
-let initial = Ledger { table = Ticket_table.empty }
+type withdraw_proof = (BLAKE2b.t * BLAKE2b.t) list
 
-let balance address ticket_id (Ledger { table }) =
+let initial = Ledger { table = Ticket_table.empty; withdrawal_handles = Withdrawal_handle_tree.empty }
+
+let with_ticket_table t f =
+  let Ledger { table; withdrawal_handles } = t in
+  f ~get_table:(Fun.const table) ~set_table:(fun table ->
+      Ledger { table; withdrawal_handles })
+
+let balance address ticket_id (Ledger { table; _ }) =
   Ticket_table.balance ~sender:address ~ticket_id table
   |> Option.value ~default:Amount.zero
 
-let deposit destination amount ticket_id (Ledger { table }) =
+let deposit destination amount ticket_id (Ledger { table; withdrawal_handles }) =
   let table = Ticket_table.deposit ~destination ~ticket_id ~amount table in
-  Ledger { table }
+  Ledger { table; withdrawal_handles }
 
-let transfer ~sender ~receiver ~amount ~ticket_id (Ledger { table }) =
+let transfer ~sender ~receiver ~amount ~ticket_id
+  (Ledger { table; withdrawal_handles }) =
   let%ok table =
     Ticket_table.transfer table ~sender ~receiver ~amount ~ticket_id
     |> Result.map_error (fun _ -> `Insufficient_funds)
   in
-  Ok (Ledger { table })
+  Ok (Ledger { table; withdrawal_handles })
+
+let withdraw ~sender ~destination ~amount ~ticket_id t =
+  let Ledger { table; withdrawal_handles } = t in
+  let%ok table =
+    Ticket_table.withdraw
+      ~sender
+      ~amount ~ticket_id
+      table
+    |> Result.map_error (function _ -> `Insufficient_funds) in
+  let withdrawal_handles, handle =
+    Withdrawal_handle_tree.add
+      (fun id ->
+        let hash =
+          Withdrawal_handle.hash ~id ~owner:destination ~amount ~ticket_id in
+        { id; hash; owner = destination; amount; ticket_id })
+      withdrawal_handles in
+  let t = Ledger { table; withdrawal_handles } in
+  Ok (t, handle)
+
+let withdrawal_handles_find_proof handle t =
+  let Ledger { withdrawal_handles; _ } = t in
+  match
+    Withdrawal_handle_tree.find handle.Withdrawal_handle.id withdrawal_handles
+  with
+  | None -> assert false
+  | Some (proof, _) -> proof
+
+let withdrawal_handles_find_proof_by_id key (Ledger { withdrawal_handles ; _ }) =
+  Withdrawal_handle_tree.find key withdrawal_handles
+
+let withdrawal_handles_root_hash (Ledger { withdrawal_handles ; _ }) =
+  Withdrawal_handle_tree.hash withdrawal_handles

--- a/src/protocol/ledger.mli
+++ b/src/protocol/ledger.mli
@@ -9,13 +9,19 @@ module Withdrawal_handle : sig
     amount : Amount.t;
     ticket_id : Ticket_id.t;
   }
-  [@@deriving yojson]
+  [@@deriving yojson, eq]
 end
 
-type withdraw_proof [@@deriving yojson]
+type withdraw_proof = (BLAKE2b.t * BLAKE2b.t) list [@@deriving yojson]
 type withdraw_handle_tree
+type withdraw_handle = Withdrawal_handle.t [@@deriving yojson]
 
-type ledger = private Ledger of { table : Ticket_table.t ; withdrawal_handles : withdraw_handle_tree }
+type ledger = private
+  | Ledger of {
+      table : Ticket_table.t;
+      withdrawal_handles : withdraw_handle_tree;
+    }
+
 type t = ledger
 
 val with_ticket_table :
@@ -41,12 +47,12 @@ val withdraw :
   amount:Amount.t ->
   ticket_id:Ticket_id.t ->
   t ->
-  (t * Withdrawal_handle.t, [> `Insufficient_funds]) result
+  (t * Withdrawal_handle.t, [> `Insufficient_funds ]) result
 
-val withdrawal_handles_find_proof :
-  Withdrawal_handle.t -> t -> withdraw_proof
+val withdrawal_handles_find_proof : Withdrawal_handle.t -> t -> withdraw_proof
 
 val withdrawal_handles_find_proof_by_id :
   int -> t -> (withdraw_proof * Withdrawal_handle.t) option
 
 val withdrawal_handles_root_hash : t -> BLAKE2b.t
+val show_ledger : t -> unit

--- a/src/protocol/ledger.mli
+++ b/src/protocol/ledger.mli
@@ -12,7 +12,7 @@ module Withdrawal_handle : sig
   [@@deriving yojson]
 end
 
-type withdraw_proof
+type withdraw_proof [@@deriving yojson]
 type withdraw_handle_tree
 
 type ledger = private Ledger of { table : Ticket_table.t ; withdrawal_handles : withdraw_handle_tree }

--- a/src/protocol/ledger.mli
+++ b/src/protocol/ledger.mli
@@ -1,7 +1,27 @@
+open Deku_crypto
 open Deku_concepts
 
-type ledger = private Ledger of { table : Ticket_table.t }
+module Withdrawal_handle : sig
+  type t = {
+    hash : BLAKE2b.t;
+    id : int;
+    owner : Deku_tezos.Address.t;
+    amount : Amount.t;
+    ticket_id : Ticket_id.t;
+  }
+  [@@deriving yojson]
+end
+
+type withdraw_proof
+type withdraw_handle_tree
+
+type ledger = private Ledger of { table : Ticket_table.t ; withdrawal_handles : withdraw_handle_tree }
 type t = ledger
+
+val with_ticket_table :
+  t ->
+  (get_table:(unit -> Ticket_table.t) -> set_table:(Ticket_table.t -> t) -> 'a) ->
+  'a
 
 val initial : t
 val balance : Address.t -> Ticket_id.t -> t -> Amount.t
@@ -14,3 +34,19 @@ val transfer :
   ticket_id:Ticket_id.t ->
   t ->
   (t, [> `Insufficient_funds ]) result
+
+val withdraw :
+  sender:Address.t ->
+  destination:Deku_tezos.Address.t ->
+  amount:Amount.t ->
+  ticket_id:Ticket_id.t ->
+  t ->
+  (t * Withdrawal_handle.t, [> `Insufficient_funds]) result
+
+val withdrawal_handles_find_proof :
+  Withdrawal_handle.t -> t -> withdraw_proof
+
+val withdrawal_handles_find_proof_by_id :
+  int -> t -> (withdraw_proof * Withdrawal_handle.t) option
+
+val withdrawal_handles_root_hash : t -> BLAKE2b.t

--- a/src/protocol/ledger.mli
+++ b/src/protocol/ledger.mli
@@ -1,11 +1,16 @@
 open Deku_concepts
 
-type ledger = private Amount.t Address.Map.t
+type ledger = private Ledger of { table : Ticket_table.t }
 type t = ledger
 
-val initial : ledger
-val balance : Address.t -> ledger -> Amount.t
-val deposit : Address.t -> Amount.t -> ledger -> ledger
+val initial : t
+val balance : Address.t -> Ticket_id.t -> t -> Amount.t
+val deposit : Address.t -> Amount.t -> Ticket_id.t -> t -> t
 
 val transfer :
-  sender:Address.t -> receiver:Address.t -> Amount.t -> ledger -> ledger option
+  sender:Address.t ->
+  receiver:Address.t ->
+  amount:Amount.t ->
+  ticket_id:Ticket_id.t ->
+  t ->
+  (t, [> `Insufficient_funds ]) result

--- a/src/protocol/operation.ml
+++ b/src/protocol/operation.ml
@@ -9,6 +9,11 @@ type operation_content =
       ticket_id : Ticket_id.t;
       amount : Amount.t;
     }
+  | Tezos_withdraw       of {
+      owner : Deku_tezos.Address.t;
+      amount : Amount.t;
+      ticket : Ticket_id.t;
+    }
 
 and operation =
   | Operation of {

--- a/src/protocol/operation.mli
+++ b/src/protocol/operation.mli
@@ -9,10 +9,10 @@ type operation_content = private
       ticket_id : Ticket_id.t;
       amount : Amount.t;
     }
-  | Tezos_withdraw       of {
+  | Operation_withdraw of {
       owner : Deku_tezos.Address.t;
       amount : Amount.t;
-      ticket : Ticket_id.t;
+      ticket_id : Ticket_id.t;
     }
 
 type operation = private
@@ -34,6 +34,16 @@ val transaction :
   nonce:Nonce.t ->
   source:Address.t ->
   receiver:Address.t ->
+  ticket_id:Ticket_id.t ->
+  amount:Amount.t ->
+  operation
+
+val withdraw :
+  identity:Identity.t ->
+  level:Level.t ->
+  nonce:Nonce.t ->
+  source:Address.t ->
+  tezos_owner:Deku_tezos.Address.t ->
   ticket_id:Ticket_id.t ->
   amount:Amount.t ->
   operation

--- a/src/protocol/operation.mli
+++ b/src/protocol/operation.mli
@@ -9,6 +9,11 @@ type operation_content = private
       ticket_id : Ticket_id.t;
       amount : Amount.t;
     }
+  | Tezos_withdraw       of {
+      owner : Deku_tezos.Address.t;
+      amount : Amount.t;
+      ticket : Ticket_id.t;
+    }
 
 type operation = private
   | Operation of {

--- a/src/protocol/operation.mli
+++ b/src/protocol/operation.mli
@@ -4,7 +4,11 @@ open Deku_concepts
 exception Invalid_signature
 
 type operation_content = private
-  | Operation_transaction of { receiver : Address.t; amount : Amount.t }
+  | Operation_transaction of {
+      receiver : Address.t;
+      ticket_id : Ticket_id.t;
+      amount : Amount.t;
+    }
 
 type operation = private
   | Operation of {
@@ -25,5 +29,6 @@ val transaction :
   nonce:Nonce.t ->
   source:Address.t ->
   receiver:Address.t ->
+  ticket_id:Ticket_id.t ->
   amount:Amount.t ->
   operation

--- a/src/protocol/protocol.ml
+++ b/src/protocol/protocol.ml
@@ -5,6 +5,7 @@ type protocol =
       included_operations : Included_operation_set.t;
       included_tezos_operations : Deku_tezos.Tezos_operation_hash.Set.t;
       ledger : Ledger.t;
+      receipts : Receipt.t Operation_hash.Map.t;
     }
 
 type t = protocol
@@ -15,10 +16,12 @@ let initial =
       included_operations = Included_operation_set.empty;
       included_tezos_operations = Deku_tezos.Tezos_operation_hash.Set.empty;
       ledger = Ledger.initial;
+      receipts = Operation_hash.Map.empty;
     }
 
 let apply_operation protocol operation =
-  let (Protocol { included_operations; included_tezos_operations; ledger }) =
+  let (Protocol
+        { included_operations; included_tezos_operations; ledger; receipts }) =
     protocol
   in
   match
@@ -42,31 +45,48 @@ let apply_operation protocol operation =
             }) =
         operation
       in
-      let ledger, receipts =
+      let ledger, new_receipts =
         match content with
         | Operation_transaction { receiver; ticket_id; amount } -> (
+            prerr_endline "This is a transaction!";
             let sender = source in
             match
               Ledger.transfer ~sender ~receiver ~ticket_id ~amount ledger
             with
-            | Ok ledger -> ledger, []
-            | Error _ -> ledger, [])
-        | Tezos_withdraw { owner; amount; ticket } ->
-            (let sender = source in
+            | Ok ledger -> (ledger, [])
+            | Error _ ->
+                prerr_endline "Error: insufficient funds";
+                (ledger, []))
+        | Operation_withdraw { owner; amount; ticket_id } -> (
+            let sender = source in
             match
-              Ledger.withdraw ~sender ~destination:owner ~amount ~ticket_id:ticket ledger
+              Ledger.withdraw ~sender ~destination:owner ~amount ~ticket_id
+                ledger
             with
-            | Ok (ledger, handle) -> ledger, [Receipt_tezos_withdraw handle]
-            | Error _ -> ledger, [])
+            | Ok (ledger, handle) -> (ledger, [ Receipt_tezos_withdraw handle ])
+            | Error _ ->
+                prerr_endline "an error happened";
+                (ledger, []))
       in
-      let receipts = Receipt_operation { operation = hash } :: receipts in
+      let new_receipts =
+        Receipt_operation { operation = hash } :: new_receipts
+      in
+      (* FIXME add only the relevant receipts? *)
+      (* How was it working in v0?*)
+      let receipts =
+        List.fold_left
+          (fun receipts receipt -> Operation_hash.Map.add hash receipt receipts)
+          receipts new_receipts
+      in
       Some
-        ( Protocol { included_operations; included_tezos_operations; ledger },
-          receipts )
+        ( Protocol
+            { included_operations; included_tezos_operations; ledger; receipts },
+          new_receipts )
   | false -> None
 
 let apply_tezos_operation protocol tezos_operation =
-  let (Protocol { included_operations; included_tezos_operations; ledger }) =
+  let (Protocol
+        { included_operations; included_tezos_operations; ledger; receipts }) =
     protocol
   in
   let Tezos_operation.{ hash; operations } = tezos_operation in
@@ -78,15 +98,20 @@ let apply_tezos_operation protocol tezos_operation =
         Deku_tezos.Tezos_operation_hash.Set.add hash included_tezos_operations
       in
       let protocol =
-        Protocol { included_operations; included_tezos_operations; ledger }
+        Protocol
+          { included_operations; included_tezos_operations; ledger; receipts }
       in
       List.fold_left
         (fun protocol tezos_operation ->
           match tezos_operation with
           | Tezos_operation.Deposit { destination; amount; ticket } ->
               let (Protocol
-                    { ledger; included_operations; included_tezos_operations })
-                  =
+                    {
+                      ledger;
+                      included_operations;
+                      included_tezos_operations;
+                      receipts;
+                    }) =
                 protocol
               in
               let ticket_id =
@@ -95,7 +120,12 @@ let apply_tezos_operation protocol tezos_operation =
               let destination = Address.of_key_hash destination in
               let ledger = Ledger.deposit destination amount ticket_id ledger in
               Protocol
-                { ledger; included_operations; included_tezos_operations })
+                {
+                  ledger;
+                  included_operations;
+                  included_tezos_operations;
+                  receipts;
+                })
         protocol operations
   | false -> protocol
 
@@ -121,13 +151,24 @@ let apply_payload ~parallel payload protocol =
     (protocol, []) operations
 
 let clean ~current_level protocol =
-  let (Protocol { included_operations; included_tezos_operations; ledger }) =
+  let (Protocol
+        { included_operations; included_tezos_operations; ledger; receipts }) =
     protocol
   in
   let included_operations =
     Included_operation_set.drop ~current_level included_operations
   in
-  Protocol { included_operations; included_tezos_operations; ledger }
+  Protocol { included_operations; included_tezos_operations; ledger; receipts }
+
+let find_withdraw_proof ~operation_hash protocol =
+  let (Protocol { receipts; ledger; _ }) = protocol in
+  match Operation_hash.Map.find_opt operation_hash receipts with
+  | None -> Error `Unknown_operation
+  | Some (Receipt_tezos_withdraw handle) ->
+      Ok (handle, Ledger.withdrawal_handles_find_proof handle ledger)
+  | _ ->
+      prerr_endline "Found a proof that does not match";
+      Error `Unknown_operation
 
 let apply ~parallel ~current_level ~payload ~tezos_operations protocol =
   let protocol, receipts = apply_payload ~parallel payload protocol in

--- a/src/protocol/protocol.mli
+++ b/src/protocol/protocol.mli
@@ -6,11 +6,19 @@ type protocol = private
       included_operations : Included_operation_set.t;
       included_tezos_operations : Tezos_operation_hash.Set.t;
       ledger : Ledger.t;
+      receipts : Receipt.t Operation_hash.Map.t;
     }
 
 type t = protocol
 
 val initial : protocol
+
+val find_withdraw_proof :
+  operation_hash:Operation_hash.t ->
+  t ->
+  ( Ledger.withdraw_handle * Ledger.withdraw_proof,
+    [> `Unknown_operation ] )
+  Result.t
 
 val apply :
   parallel:((string -> Operation.t option) -> string list -> Operation.t list) ->

--- a/src/protocol/receipt.ml
+++ b/src/protocol/receipt.ml
@@ -1,2 +1,4 @@
-type receipt = Receipt of { operation : Operation_hash.t }
+type receipt =
+  | Receipt_operation of { operation : Operation_hash.t }
+  | Receipt_tezos_withdraw of Ledger.Withdrawal_handle.t
 type t = receipt

--- a/src/protocol/receipt.ml
+++ b/src/protocol/receipt.ml
@@ -1,4 +1,5 @@
 type receipt =
   | Receipt_operation of { operation : Operation_hash.t }
   | Receipt_tezos_withdraw of Ledger.Withdrawal_handle.t
-type t = receipt
+
+and t = receipt [@@deriving eq]

--- a/src/protocol/receipt.mli
+++ b/src/protocol/receipt.mli
@@ -1,4 +1,5 @@
 type receipt =
   | Receipt_operation of { operation : Operation_hash.t }
   | Receipt_tezos_withdraw of Ledger.Withdrawal_handle.t
-type t = receipt
+
+type t = receipt [@@deriving eq]

--- a/src/protocol/receipt.mli
+++ b/src/protocol/receipt.mli
@@ -1,2 +1,4 @@
-type receipt = Receipt of { operation : Operation_hash.t }
+type receipt =
+  | Receipt_operation of { operation : Operation_hash.t }
+  | Receipt_tezos_withdraw of Ledger.Withdrawal_handle.t
 type t = receipt

--- a/src/protocol/tests/test_ledger.ml
+++ b/src/protocol/tests/test_ledger.ml
@@ -4,10 +4,14 @@ open Deku_concepts
 open Deku_protocol
 open Ledger
 
-let total_balance (ledger : ledger) =
-  Address.Map.fold
-    (fun _address amount total_amount -> Amount.(amount + total_amount))
-    (ledger :> Amount.t Address.Map.t)
+let total_balance ~ticket_id (Ledger { table }) =
+  let open Ticket_table in
+  Address_map.fold
+    (fun _sender ticket_map total_amount ->
+      Ticket_map.find_opt ticket_id ticket_map
+      |> Option.value ~default:Amount.zero
+      |> Amount.( + ) total_amount)
+    (table :> Amount.t Ticket_map.t Address_map.t)
     Amount.zero
 
 let new_address () =
@@ -27,35 +31,51 @@ let random_amount () =
 
 let amount = Alcotest.testable Amount.pp Amount.equal
 
-let test_total_balance ~expected ~ledger_name ~ledger () =
+let default_ticket_id () =
+  let address =
+    Deku_tezos.Contract_hash.of_string "KT1JQ5JQB4P1c8U8ACxfnodtZ4phDVMSDzgi"
+    |> Option.get
+  in
+  let data = Bytes.of_string "tuturu" in
+  Ticket_id.make address data
+
+let test_total_balance ~expected ~ledger_name ~ticket_id ~ledger () =
   let msg =
     Format.asprintf "total_balance %s = %a" ledger_name Amount.pp expected
   in
-  Alcotest.(check' amount) ~msg ~expected ~actual:(total_balance ledger)
+  Alcotest.(check' amount)
+    ~msg ~expected
+    ~actual:(total_balance ~ticket_id ledger)
 
-let test_balance ~address_name ~address ~expected ~ledger_name ~ledger () =
+let test_balance ~address_name ~address ~expected ~ledger_name ~ticket_id
+    ~ledger () =
   let msg =
     Format.asprintf "balance %s %s = %a" address_name ledger_name Amount.pp
       expected
   in
-  Alcotest.(check' amount) ~msg ~expected ~actual:(balance address ledger)
+  Alcotest.(check' amount)
+    ~msg ~expected
+    ~actual:(balance address ticket_id ledger)
 
 let test_unknown_balance ~ledger_name ~ledger () =
   let unknown = new_address () in
   test_balance ~address_name:"unknown" ~address:unknown ~expected:Amount.zero
     ~ledger_name ~ledger ()
 
-let test_balance ~address_name ~address ~expected ~ledger_name ~ledger () =
+let test_balance ~address_name ~address ~expected ~ledger_name ~ticket_id
+    ~ledger () =
   let () =
-    test_balance ~address_name ~address ~expected ~ledger_name ~ledger ()
+    test_balance ~address_name ~address ~expected ~ledger_name ~ticket_id
+      ~ledger ()
   in
-  let () = test_unknown_balance ~ledger_name ~ledger () in
+  let () = test_unknown_balance ~ledger_name ~ticket_id ~ledger () in
   ()
 
-let test_base_deposit ~address_name ~address ~amount ~ledger_name ~ledger () =
-  let ledger_balance = total_balance ledger in
-  let address_balance = balance address ledger in
-  let ledger = deposit address amount ledger in
+let test_base_deposit ~address_name ~address ~amount ~ledger_name ~ticket_id
+    ~ledger () =
+  let ledger_balance = total_balance ~ticket_id ledger in
+  let address_balance = balance address ticket_id ledger in
+  let ledger = deposit address amount ticket_id ledger in
 
   let ledger_name =
     Format.asprintf "%s[%s += %a]" ledger_name address_name Amount.pp amount
@@ -64,14 +84,14 @@ let test_base_deposit ~address_name ~address ~amount ~ledger_name ~ledger () =
   let () =
     test_balance ~address_name ~address
       ~expected:Amount.(address_balance + amount)
-      ~ledger_name ~ledger ()
+      ~ledger_name ~ticket_id ~ledger ()
   in
   let () =
     test_total_balance
       ~expected:Amount.(ledger_balance + amount)
-      ~ledger_name ~ledger ()
+      ~ledger_name ~ticket_id ~ledger ()
   in
-  let () = test_unknown_balance ~ledger_name ~ledger () in
+  let () = test_unknown_balance ~ledger_name ~ticket_id ~ledger () in
   ()
 
 let test_unknown_deposit ~ledger_name ~ledger () =
@@ -80,17 +100,19 @@ let test_unknown_deposit ~ledger_name ~ledger () =
   test_base_deposit ~address_name:"unknown" ~address:unknown ~amount
     ~ledger_name ~ledger ()
 
-let test_deposit ~address_name ~address ~amount ~ledger_name ~ledger () =
+let test_deposit ~address_name ~address ~amount ~ledger_name ~ticket_id ~ledger
+    () =
   let () =
-    test_base_deposit ~address_name ~address ~amount ~ledger_name ~ledger ()
+    test_base_deposit ~address_name ~address ~amount ~ledger_name ~ticket_id
+      ~ledger ()
   in
-  let () = test_unknown_deposit ~ledger_name ~ledger () in
+  let () = test_unknown_deposit ~ledger_name ~ticket_id ~ledger () in
   ()
 
 let test_success_transfer ~sender_name ~sender ~expected_sender_balance
-    ~receiver_name ~receiver ~amount ~ledger_name ~ledger () =
-  let ledger_balance = total_balance ledger in
-  let receiver_balance = balance receiver ledger in
+    ~receiver_name ~receiver ~amount ~ledger_name ~ticket_id ~ledger () =
+  let ledger_balance = total_balance ~ticket_id ledger in
+  let receiver_balance = balance receiver ticket_id ledger in
   let msg =
     Format.asprintf
       "Option.is_some (transfer ~sender:%s ~receiver:%s %a %s) = true"
@@ -99,10 +121,11 @@ let test_success_transfer ~sender_name ~sender ~expected_sender_balance
   let () =
     Alcotest.(check' bool)
       ~msg ~expected:true
-      ~actual:(Option.is_some (transfer ~sender ~receiver amount ledger))
+      ~actual:
+        (Result.is_ok (transfer ~sender ~receiver ~amount ~ticket_id ledger))
   in
-  let ledger = transfer ~sender ~receiver amount ledger in
-  let ledger = Option.get ledger in
+  let ledger = transfer ~sender ~receiver ~amount ~ticket_id ledger in
+  let ledger = Result.get_ok ledger in
 
   let ledger_name =
     Format.asprintf "%s[%s -[%a]> %s]" ledger_name sender_name Amount.pp amount
@@ -112,25 +135,26 @@ let test_success_transfer ~sender_name ~sender ~expected_sender_balance
   (* TODO: ensure that no other balance changed *)
   let () =
     test_balance ~address_name:sender_name ~address:sender
-      ~expected:expected_sender_balance ~ledger_name ~ledger ()
+      ~expected:expected_sender_balance ~ledger_name ~ticket_id ~ledger ()
   in
   let () =
     test_balance ~address_name:receiver_name ~address:receiver
       ~expected:Amount.(receiver_balance + amount)
-      ~ledger_name ~ledger ()
+      ~ledger_name ~ticket_id ~ledger ()
   in
   let () =
-    test_total_balance ~expected:ledger_balance ~ledger_name ~ledger ()
+    test_total_balance ~expected:ledger_balance ~ledger_name ~ticket_id ~ledger
+      ()
   in
   ()
 
 let test_base_transfer ~sender_name ~sender ~receiver_name ~receiver ~amount
-    ~ledger_name ~ledger () =
-  let sender_balance = balance sender ledger in
+    ~ledger_name ~ticket_id ~ledger () =
+  let sender_balance = balance sender ticket_id ledger in
   match Amount.(sender_balance - amount) with
   | Some expected_sender_balance ->
       test_success_transfer ~sender_name ~sender ~expected_sender_balance
-        ~receiver_name ~receiver ~amount ~ledger_name ~ledger ()
+        ~receiver_name ~receiver ~amount ~ledger_name ~ticket_id ~ledger ()
   | None ->
       let msg =
         Format.asprintf
@@ -139,75 +163,80 @@ let test_base_transfer ~sender_name ~sender ~receiver_name ~receiver ~amount
       in
       Alcotest.(check' bool)
         ~msg ~expected:true
-        ~actual:(Option.is_none (transfer ~sender ~receiver amount ledger))
+        ~actual:
+          (Result.is_ok (transfer ~sender ~receiver ~amount ~ticket_id ledger))
 
-let test_unknown_transfer ~ledger_name ~ledger () =
+let test_unknown_transfer ~ledger_name ~ticket_id ~ledger () =
   let unknown_a = new_address () in
   let unknown_b = new_address () in
 
   let amount = random_amount () in
-  let ledger = deposit unknown_a amount ledger in
+  let ledger = deposit unknown_a amount ticket_id ledger in
   let ledger_name =
     Format.asprintf "%s[unknown_a += %a]" ledger_name Amount.pp amount
   in
   test_success_transfer ~sender_name:"unknown_a" ~sender:unknown_a
     ~expected_sender_balance:Amount.zero ~receiver_name:"unknown_b"
-    ~receiver:unknown_b ~amount ~ledger_name ~ledger ()
+    ~receiver:unknown_b ~amount ~ledger_name ~ticket_id ~ledger ()
 
 let test_transfer ~sender_name ~sender ~receiver_name ~receiver ~amount
-    ~ledger_name ~ledger () =
+    ~ledger_name ~ticket_id ~ledger () =
   let () =
     test_base_transfer ~sender_name ~sender ~receiver_name ~receiver ~amount
-      ~ledger_name ~ledger ()
+      ~ledger_name ~ticket_id ~ledger ()
   in
-  let () = test_unknown_transfer ~ledger_name ~ledger () in
+  let () = test_unknown_transfer ~ledger_name ~ticket_id ~ledger () in
   ()
 
 let test_deposit_and_transfer ~address_name ~address ~address_balance
-    ~ledger_name ~ledger () =
+    ~ledger_name ~ticket_id ~ledger () =
   let third = new_address () in
   let () =
     test_deposit ~address_name:"third" ~address:third ~amount:(random_amount ())
-      ~ledger_name ~ledger ()
+      ~ledger_name ~ticket_id ~ledger ()
   in
   let () =
     test_transfer ~sender_name:address_name ~sender:address
       ~receiver_name:"third" ~receiver:third ~amount:address_balance
-      ~ledger_name ~ledger ()
+      ~ledger_name ~ticket_id ~ledger ()
   in
   ()
 
 let test_initial_total_balance () =
   test_total_balance ~expected:Amount.zero ~ledger_name:"initial"
-    ~ledger:initial ()
+    ~ticket_id:(default_ticket_id ()) ~ledger:initial ()
 
 let test_unknown_balance_on_initial () =
-  test_unknown_balance ~ledger_name:"initial" ~ledger:initial ()
+  test_unknown_balance ~ledger_name:"initial" ~ticket_id:(default_ticket_id ())
+    ~ledger:initial ()
 
 let test_unknown_deposit_on_initial () =
-  test_unknown_deposit ~ledger_name:"initial" ~ledger:initial ()
+  test_unknown_deposit ~ledger_name:"initial" ~ticket_id:(default_ticket_id ())
+    ~ledger:initial ()
 
 let test_unknown_transfer_on_initial () =
-  test_unknown_transfer ~ledger_name:"initial" ~ledger:initial ()
+  test_unknown_transfer ~ledger_name:"initial" ~ticket_id:(default_ticket_id ())
+    ~ledger:initial ()
 
 let test_simple_deposit () =
   let a = new_address () in
 
+  let ticket_id = default_ticket_id () in
   let amount = random_amount () in
-  let ledger_with_a = deposit a amount initial in
+  let ledger_with_a = deposit a amount ticket_id initial in
 
   let () =
-    test_total_balance ~expected:amount ~ledger_name:"ledger_with_a"
+    test_total_balance ~expected:amount ~ledger_name:"ledger_with_a" ~ticket_id
       ~ledger:ledger_with_a ()
   in
   let () =
     test_balance ~address_name:"a" ~address:a ~expected:amount
-      ~ledger_name:"ledger_with_a" ~ledger:ledger_with_a ()
+      ~ledger_name:"ledger_with_a" ~ticket_id ~ledger:ledger_with_a ()
   in
   let () =
     test_deposit_and_transfer ~address_name:"a" ~address:a
-      ~address_balance:amount ~ledger_name:"ledger_with_a" ~ledger:ledger_with_a
-      ()
+      ~address_balance:amount ~ledger_name:"ledger_with_a" ~ticket_id
+      ~ledger:ledger_with_a ()
   in
   ()
 
@@ -215,9 +244,11 @@ let test_simple_transfer () =
   let a = new_address () in
   let b = new_address () in
   let total_amount = amount_of_int 6 in
-  let ledger_with_a = deposit a total_amount initial in
+  let ticket_id = default_ticket_id () in
+  let ledger_with_a = deposit a total_amount ticket_id initial in
   let ledger_with_a_and_b =
-    transfer ~sender:a ~receiver:b (amount_of_int 4) ledger_with_a
+    transfer ~sender:a ~receiver:b ~amount:(amount_of_int 4) ~ticket_id
+      ledger_with_a
   in
   let () =
     Alcotest.(check' bool)
@@ -225,31 +256,34 @@ let test_simple_transfer () =
         "Option.is_some (transfer ~sender:a ~receiver:b 6 ledger_with_a) = true"
       ~expected:true
       ~actual:
-        (Option.is_some
-           (transfer ~sender:a ~receiver:b (amount_of_int 4) ledger_with_a))
+        (Result.is_ok
+           (transfer ~sender:a ~receiver:b ~amount:(amount_of_int 4) ~ticket_id
+              ledger_with_a))
   in
-  let ledger_with_a_and_b = Option.get ledger_with_a_and_b in
+  let ledger_with_a_and_b = Result.get_ok ledger_with_a_and_b in
 
   let () =
     test_total_balance ~expected:total_amount ~ledger_name:"ledger_with_a"
-      ~ledger:ledger_with_a ()
+      ~ticket_id ~ledger:ledger_with_a ()
   in
   let () =
     test_balance ~address_name:"a" ~address:a ~expected:(amount_of_int 2)
-      ~ledger_name:"ledger_with_a_and_b" ~ledger:ledger_with_a_and_b ()
+      ~ticket_id ~ledger_name:"ledger_with_a_and_b" ~ledger:ledger_with_a_and_b
+      ()
   in
   let () =
     test_balance ~address_name:"b" ~address:b ~expected:(amount_of_int 4)
-      ~ledger_name:"ledger_with_a_and_b" ~ledger:ledger_with_a_and_b ()
+      ~ticket_id ~ledger_name:"ledger_with_a_and_b" ~ledger:ledger_with_a_and_b
+      ()
   in
   let () =
     test_deposit_and_transfer ~address_name:"a" ~address:a
-      ~address_balance:(amount_of_int 2) ~ledger_name:"ledger_with_a"
+      ~address_balance:(amount_of_int 2) ~ledger_name:"ledger_with_a" ~ticket_id
       ~ledger:ledger_with_a_and_b ()
   in
   let () =
     test_deposit_and_transfer ~address_name:"b" ~address:b
-      ~address_balance:(amount_of_int 4) ~ledger_name:"ledger_with_a"
+      ~address_balance:(amount_of_int 4) ~ledger_name:"ledger_with_a" ~ticket_id
       ~ledger:ledger_with_a_and_b ()
   in
   ()

--- a/src/protocol/tests/test_ledger.ml
+++ b/src/protocol/tests/test_ledger.ml
@@ -37,11 +37,8 @@ let random_ticket_id () =
   in
   (* TODO Should we expose Contract_hash.of_raw? *)
   let address : Deku_tezos.Contract_hash.t =
-    random_bytes 20
-    |> String.of_bytes
-    |> Deku_crypto.BLAKE2b.BLAKE2b_160.of_raw
-    |> Option.get
-    |> Obj.magic
+    random_bytes 20 |> String.of_bytes |> Deku_crypto.BLAKE2b.BLAKE2b_160.of_raw
+    |> Option.get |> Obj.magic
   in
   let data = random_bytes 10 in
   Ticket_id.make address data
@@ -122,8 +119,8 @@ let test_success_transfer ~sender_name ~sender ~expected_sender_balance
   let receiver_balance = balance receiver ticket_id ledger in
   let msg =
     Format.asprintf
-      "Result.is_ok (transfer ~sender:%s ~receiver:%s %a %s) = true"
-      sender_name receiver_name Amount.pp amount ledger_name
+      "Result.is_ok (transfer ~sender:%s ~receiver:%s %a %s) = true" sender_name
+      receiver_name Amount.pp amount ledger_name
   in
   let () =
     Alcotest.(check' bool)
@@ -307,14 +304,14 @@ let test_simple_withdraw () =
       ledger
   in
   let ledger = Result.get_ok ledger in
-  let ledger = withdraw ~sender:b ~destination:c ~amount:(amount_of_int 4) ~ticket_id:ticket1 ledger
+  let ledger =
+    withdraw ~sender:b ~destination:c ~amount:(amount_of_int 4)
+      ~ticket_id:ticket1 ledger
   in
-    Alcotest.(check' bool)
-      ~msg:
-        "Result.is_ok (withdraw ~sender:b ~destination:c 4 ledger_with_a) = true"
-      ~expected:true
-      ~actual:
-        (Result.is_ok ledger)
+  Alcotest.(check' bool)
+    ~msg:
+      "Result.is_ok (withdraw ~sender:b ~destination:c 4 ledger_with_a) = true"
+    ~expected:true ~actual:(Result.is_ok ledger)
 
 let test_bad_withdraw1 () =
   let msg = "Cannot withdraw a ticket that was transferred" in
@@ -329,13 +326,11 @@ let test_bad_withdraw1 () =
       ledger
   in
   let ledger = Result.get_ok ledger in
-  let ledger = withdraw ~sender:a ~destination:c ~amount:(amount_of_int 10) ~ticket_id:ticket1 ledger
+  let ledger =
+    withdraw ~sender:a ~destination:c ~amount:(amount_of_int 10)
+      ~ticket_id:ticket1 ledger
   in
-    Alcotest.(check' bool)
-      ~msg
-      ~expected:true
-      ~actual:
-        (Result.is_error ledger)
+  Alcotest.(check' bool) ~msg ~expected:true ~actual:(Result.is_error ledger)
 
 let test_bad_withdraw2 () =
   let msg = "Cannot withdraw a ticket that you do not have" in
@@ -352,13 +347,11 @@ let test_bad_withdraw2 () =
       ledger
   in
   let ledger = Result.get_ok ledger in
-  let ledger = withdraw ~sender:b ~destination:c ~amount:(amount_of_int 10) ~ticket_id:ticket2 ledger
+  let ledger =
+    withdraw ~sender:b ~destination:c ~amount:(amount_of_int 10)
+      ~ticket_id:ticket2 ledger
   in
-    Alcotest.(check' bool)
-      ~msg
-      ~expected:true
-      ~actual:
-        (Result.is_error ledger)
+  Alcotest.(check' bool) ~msg ~expected:true ~actual:(Result.is_error ledger)
 
 let test_withdraw_balance () =
   let msg = "Total balance goes down after withdraw (tickets are burned)" in
@@ -374,21 +367,20 @@ let test_withdraw_balance () =
       ledger
   in
   let ledger = Result.get_ok ledger in
-  let ledger = withdraw ~sender:a ~destination:c ~amount:(total_withdrawn) ~ticket_id:ticket1 ledger
+  let ledger =
+    withdraw ~sender:a ~destination:c ~amount:total_withdrawn ~ticket_id:ticket1
+      ledger
   in
-  let () = Alcotest.(check' bool)
-      ~msg:"You can withdraw tickets that you didn't transfer"
-      ~expected:true
-      ~actual:
-        (Result.is_ok ledger)
+  let () =
+    Alcotest.(check' bool)
+      ~msg:"You can withdraw tickets that you didn't transfer" ~expected:true
+      ~actual:(Result.is_ok ledger)
   in
   let ledger, _ = Result.get_ok ledger in
   let total_amount = total_balance ~ticket_id:ticket1 ledger in
   Alcotest.(check' bool)
-    ~msg
-    ~expected:true
-    ~actual:
-      (Some total_amount = Amount.(initial_amount - total_withdrawn))
+    ~msg ~expected:true
+    ~actual:(Some total_amount = Amount.(initial_amount - total_withdrawn))
 
 let run () =
   let open Alcotest in

--- a/src/protocol/ticket_id.ml
+++ b/src/protocol/ticket_id.ml
@@ -1,0 +1,15 @@
+type ticket_id =
+  | Ticket_id of { ticketer : Deku_tezos.Contract_hash.t; data : bytes }
+
+and t = ticket_id [@@deriving eq, ord, yojson]
+
+let make ticketer data = Ticket_id { ticketer; data }
+
+let from_tezos_ticket tezos_ticket =
+  let Deku_tezos.Ticket_id.{ ticketer; data } = tezos_ticket in
+  match ticketer with
+  | Deku_tezos.Address.Implicit _address -> Error `Ticket_from_implicit
+  | Deku_tezos.Address.Originated { contract; _ } ->
+      Ok (Ticket_id { ticketer = contract; data })
+
+(* TODO: add Deku tickets back from v0 *)

--- a/src/protocol/ticket_id.mli
+++ b/src/protocol/ticket_id.mli
@@ -1,0 +1,9 @@
+type ticket_id = private
+  | Ticket_id of { ticketer : Deku_tezos.Contract_hash.t; data : bytes }
+
+and t = ticket_id [@@deriving eq, ord, yojson]
+
+val make : Deku_tezos.Contract_hash.t -> bytes -> t
+
+val from_tezos_ticket :
+  Deku_tezos.Ticket_id.t -> (t, [> `Ticket_from_implicit ]) result

--- a/src/protocol/ticket_table.ml
+++ b/src/protocol/ticket_table.ml
@@ -1,0 +1,118 @@
+open Deku_concepts
+open Deku_stdlib
+
+module Tickets = struct
+  module Ticket_map = Map.Make (Ticket_id)
+
+  type t = Amount.t Ticket_map.t
+
+  let get_balance ~ticket_id t = Ticket_map.find_opt ticket_id t
+  let to_seq map = Ticket_map.to_seq map
+  let of_seq seq = Ticket_map.of_seq seq
+
+  let singleton ~ticket_id ~amount =
+    Ticket_map.of_seq (Seq.return (ticket_id, amount))
+
+  let join t ~ticket_id ~amount =
+    let join option ~amount =
+      let value = Option.fold ~none:amount ~some:Amount.(( + ) amount) option in
+      value
+    in
+    Ticket_map.update ticket_id
+      (fun x ->
+        let joined = join ~amount x in
+        Option.some joined)
+      t
+
+  let get_and_remove ~ticket_id ~to_take t =
+    match
+      Ticket_map.update ticket_id
+        (function
+          | Some amount ->
+              let () =
+                let compared = Amount.compare amount to_take in
+                if compared >= 0 then () else failwith "error"
+              in
+              Amount.(amount - to_take)
+          | None -> failwith "error")
+        t
+    with
+    | _ as x -> Ok x
+    | exception Failure _ -> Error `Insufficient_funds
+
+  let get_and_remove_many tickets t =
+    let fetched =
+      List.fold_left_ok
+        (fun (lst, m) (ticket_id, amount) ->
+          let%ok m = get_and_remove ~ticket_id ~to_take:amount m in
+          let lst = Seq.cons (ticket_id, amount) lst in
+          Ok (lst, m))
+        (Seq.empty, t) tickets
+    in
+    fetched
+
+  let empty = Ticket_map.empty
+  let is_empty = Ticket_map.is_empty
+end
+
+module Ticket_map = Tickets.Ticket_map
+module Address_map = Map.Make (Address)
+
+type t = Tickets.t Address_map.t
+
+let empty = Address_map.empty
+
+let balance ~sender ~ticket_id t =
+  let%some map = Address_map.find_opt sender t in
+  Tickets.get_balance ~ticket_id map
+
+let update_or_create ~amount ~ticket_id t =
+  Option.fold
+    ~some:(fun x -> Tickets.join ~amount ~ticket_id x)
+    ~none:(Tickets.singleton ~amount ~ticket_id)
+    t
+  |> Option.some
+
+let update_tickets ~sender ~ticket_ids t =
+  if Seq.is_empty ticket_ids then Address_map.remove sender t
+  else Address_map.add sender (Tickets.of_seq ticket_ids) t
+
+let deposit ~destination ~ticket_id ~amount t =
+  Address_map.update destination (update_or_create ~amount ~ticket_id) t
+
+let update ~sender ~submap t =
+  if Tickets.is_empty submap then Address_map.remove sender t
+  else Address_map.add sender submap t
+
+let transfer ~sender ~receiver ~ticket_id ~amount t =
+  let%ok map =
+    Address_map.find_opt sender t |> Option.to_result ~none:`Insufficient_funds
+  in
+  let%ok map = Tickets.get_and_remove ~ticket_id ~to_take:amount map in
+  let t = update t ~sender ~submap:map in
+  let t = Address_map.update receiver (update_or_create ~amount ~ticket_id) t in
+  Ok t
+
+let withdraw ~sender ~ticket_id ~amount t =
+  let%ok map =
+    Address_map.find_opt sender t |> Option.to_result ~none:`Insufficient_funds
+  in
+  let%ok map = Tickets.get_and_remove ~ticket_id ~to_take:amount map in
+  let t = update t ~sender ~submap:map in
+  Ok t
+
+let take_tickets ~sender ~ticket_ids
+    (t : Amount.t Tickets.Ticket_map.t Address_map.t) =
+  let%ok map =
+    Address_map.find_opt sender t |> Option.to_result ~none:`Insufficient_funds
+  in
+  let%ok ticket_ids, map = Tickets.get_and_remove_many ticket_ids map in
+  let t = update ~sender ~submap:map t in
+  Ok (ticket_ids, t)
+
+let take_all_tickets ~sender t =
+  let map =
+    Address_map.find_opt sender t |> Option.value ~default:Tickets.empty
+  in
+  let tickets = Tickets.to_seq map in
+  (tickets, Address_map.remove sender t)

--- a/src/protocol/ticket_table.mli
+++ b/src/protocol/ticket_table.mli
@@ -1,0 +1,38 @@
+open Deku_concepts
+module Ticket_map : Map.S with type key = Ticket_id.t
+module Address_map : Map.S with type key = Address.t
+
+type t = private Amount.t Ticket_map.t Address_map.t
+
+val empty : t
+val balance : sender:Address.t -> ticket_id:Ticket_id.t -> t -> Amount.t option
+
+val deposit :
+  destination:Address.t -> ticket_id:Ticket_id.t -> amount:Amount.t -> t -> t
+
+val transfer :
+  sender:Address.t ->
+  receiver:Address.t ->
+  ticket_id:Ticket_id.t ->
+  amount:Amount.t ->
+  t ->
+  (t, [> `Insufficient_funds ]) result
+
+val withdraw :
+  sender:Address.t ->
+  ticket_id:Ticket_id.t ->
+  amount:Amount.t ->
+  t ->
+  (t, [> `Insufficient_funds ]) result
+
+val take_tickets :
+  sender:Address.t ->
+  ticket_ids:(Ticket_id.t * Amount.t) list ->
+  t ->
+  ((Ticket_id.t * Amount.t) Seq.t * t, [> `Insufficient_funds ]) result
+
+val take_all_tickets :
+  sender:Address.t -> t -> (Ticket_id.t * Amount.t) Seq.t * t
+
+val update_tickets :
+  sender:Address.t -> ticket_ids:(Ticket_id.t * Amount.t) Seq.t -> t -> t

--- a/src/stdlib/deku_stdlib.ml
+++ b/src/stdlib/deku_stdlib.ml
@@ -2,6 +2,7 @@ module N = N
 module Uri = Uri_ext
 include Let_syntax
 module Parallel = Parallel
+module List = List_ext
 
 module Yojson = struct
   include Yojson

--- a/src/stdlib/deku_stdlib.mli
+++ b/src/stdlib/deku_stdlib.mli
@@ -9,6 +9,7 @@ module Uri = Uri_ext
 [%%let ("let.some" : 'a option -> ('a -> 'b option) -> 'b option)]
 
 module Parallel = Parallel
+module List = List_ext
 
 (* FIXME: not sure if this is the right thing to do.  *)
 module Yojson : sig

--- a/src/stdlib/list_ext.ml
+++ b/src/stdlib/list_ext.ml
@@ -1,0 +1,8 @@
+include List
+
+let rec fold_left_ok f state = function
+  | [] -> Ok state
+  | head :: tl -> (
+      match f state head with
+      | Ok state -> fold_left_ok f state tl
+      | Error error -> Error error)

--- a/src/stdlib/list_ext.mli
+++ b/src/stdlib/list_ext.mli
@@ -1,0 +1,4 @@
+include module type of List
+
+val fold_left_ok :
+  ('a -> 'b -> ('a, 'e) Result.t) -> 'a -> 'b list -> ('a, 'e) Result.t

--- a/src/tezos/tezos_operation_hash.ml
+++ b/src/tezos/tezos_operation_hash.ml
@@ -8,7 +8,7 @@ include BLAKE2b.With_b58 (struct
   let prefix = Prefix.operation_hash
 end)
 
-include With_yojson_of_b58(struct
+include With_yojson_of_b58 (struct
   type t = tezos_operation_hash
 
   let of_b58 = of_b58

--- a/src/tezos/tezos_operation_hash.ml
+++ b/src/tezos/tezos_operation_hash.ml
@@ -1,10 +1,18 @@
 open Deku_repr
 open Deku_crypto
 
-type t = BLAKE2b.t [@@deriving eq, ord, yojson]
+type tezos_operation_hash = BLAKE2b.t
+and t = tezos_operation_hash [@@deriving eq, ord]
 
 include BLAKE2b.With_b58 (struct
   let prefix = Prefix.operation_hash
+end)
+
+include With_yojson_of_b58(struct
+  type t = tezos_operation_hash
+
+  let of_b58 = of_b58
+  let to_b58 = to_b58
 end)
 
 module Map = Map.Make (struct

--- a/src/tezos/tezos_operation_hash.mli
+++ b/src/tezos/tezos_operation_hash.mli
@@ -1,4 +1,7 @@
-type t [@@deriving eq, ord, yojson]
+open Deku_crypto
+
+type tezos_operation_hash = BLAKE2b.t
+type t = tezos_operation_hash [@@deriving eq, ord, yojson]
 
 val of_b58 : string -> t option
 val to_b58 : t -> string

--- a/src/tezos_interop/tests/deposit_test.ml
+++ b/src/tezos_interop/tests/deposit_test.ml
@@ -1,1 +1,76 @@
-let () = ignore "FIXME:"
+open Deku_crypto
+open Deku_tezos
+open Deku_tezos_interop
+open Deku_stdlib
+
+let secret =
+  Secret.of_b58 "edsk3QoqBuvdamxouPhin7swCvkQNgq4jP5KZPbwWNnwdZpSpJiEbq"
+  |> Option.get
+
+let rpc_node = Uri.of_string "http://localhost:20000"
+
+(* We can use a random discovery contract address *)
+let discovery_contract =
+  Address.of_string "KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton" |> Option.get
+
+let main consensus_contract =
+  let t =
+    Tezos_interop.make ~rpc_node ~secret ~consensus_contract ~discovery_contract
+      ~required_confirmations:2
+  in
+
+  let () =
+    let open Tezos_interop in
+    Consensus.listen_operations
+      ~on_operation:(fun { hash = _; transactions } ->
+        let is_deposit =
+          transactions
+          |> List.exists (fun transaction ->
+                 match transaction with
+                 | Consensus.Deposit _ -> true
+                 | _ -> false)
+        in
+        if is_deposit then
+          print_endline "👍 Receive a deposit on the consensus contract";
+        exit 0)
+      t
+  in
+  Lwt_main.run (Lwt_unix.sleep 10.0);
+  print_endline "👎 Deposit wasn't seen";
+  exit 1
+
+open Cmdliner
+
+let info =
+  let doc =
+    "Tests if the tezos interop can listen to deposit transaction on the \
+     consensus contract."
+  in
+  Cmd.info "deku-deposit-test" ~version:"%\226\128\140%VERSION%%" ~doc
+
+let term =
+  let address =
+    let open Arg in
+    let parser string =
+      string |> Address.of_string
+      |> Option.to_result ~none:(`Msg "Cannot parse the given contract address")
+    in
+    let printer ppf address =
+      Format.fprintf ppf "%s" (address |> Address.to_string)
+    in
+    conv (parser, printer)
+  in
+
+  let consensus_contract =
+    let open Arg in
+    let docv = "consensus-contract" in
+    let doc = "The address of the consensus contract to listen." in
+    let env = Cmd.Env.info "DEKU_CONSENSUS_CONTRACT" in
+    required
+    & opt (some address) None
+    & info [ "consensus-contract" ] ~doc ~docv ~env
+  in
+  let open Term in
+  const main $ consensus_contract
+
+let _ = Cmd.eval ~catch:true @@ Cmd.v info term

--- a/src/tezos_interop/tests/update_state_root_hash_test.ml
+++ b/src/tezos_interop/tests/update_state_root_hash_test.ml
@@ -46,8 +46,9 @@ let main consensus_contract =
         exit 0)
       t
   in
-  let forever, _ = Lwt.wait () in
-  Lwt_main.run forever
+  Lwt_main.run (Lwt_unix.sleep 10.0);
+  print_endline "👎 State root hash not updated";
+  exit 1
 
 open Cmdliner
 


### PR DESCRIPTION
Draft with:
- ticket table, deposit, withdraw, withdraw proof generation from v0
- modification to receipts to find the handle for the proof
- modification to the ledger to store the receipts (with a bug: several receipts with the same hash, there's a FIXME in the code somewhere)
- "level" and "withdraw_proof" endpoints: mostly handled in deku_node but that's not optimal
- buggy serialization of BLAKE2b at the moment: how do I use the right functions for BLAKE2b deserialization with `@@deriving yojson`?
- 3 (three!) minimal CLI tools for testing: I used cohttp because of a weird behaviour from Piaf, I have to test again and understand if it's a bug or not

Usage:
- start deku network
- `tezos-client transfer 0 from alice to dummy_ticket   --entrypoint mint_to_deku --arg "Pair (Pair \"KT1Sw4WdzNPLMKqbZJ1VxU53bEFuDe2a4Jgb\" \"tz1Uodi1AwskSfdHiRUBh1Z856fMrSXCpc5i\") (Pair 100 0x)"    --burn-cap 2`
- `dune exec src/bin/transaction/withdraw.exe` (everything hardcoded inside)
- `dune exec src/bin/transaction/proof.exe Do2v3LgWJ9B7agjq3ebkiXH7eftFN3tVGBZL6Fk8byWDkaoSwmoC` (hash given by withdraw.exe)

Needs some refactoring obviously, will do after `proof.exe` is fixed.