### PR TITLE
support send on the network

### DIFF
--- a/src/bin/node/deku_node.ml
+++ b/src/bin/node/deku_node.ml
@@ -17,12 +17,10 @@ let main () =
 
   let pool = Parallel.Pool.make ~domains in
   let%await storage = Storage.read ~file:!storage in
-  let Storage.{ secret; initial_validators; nodes } = storage in
+  let Storage.{ secret; validators } = storage in
   let identity = Identity.make secret in
   Parallel.Pool.run pool (fun () ->
-      let node, promise =
-        Node.make ~pool ~identity ~validators:initial_validators ~nodes
-      in
+      let node, promise = Node.make ~pool ~identity ~validators in
       Node.listen node ~port:!port;
       promise)
 

--- a/src/bin/node/node.mli
+++ b/src/bin/node/node.mli
@@ -1,4 +1,5 @@
 open Deku_stdlib
+open Deku_crypto
 open Deku_concepts
 
 type node
@@ -7,8 +8,7 @@ type t = node
 val make :
   pool:Parallel.Pool.pool ->
   identity:Identity.identity ->
-  validators:Deku_crypto.Key_hash.t list ->
-  nodes:Uri.t list ->
+  validators:(Key_hash.t * Uri.t) list ->
   node * unit Lwt.t
 
 val listen : node -> port:int -> unit

--- a/src/bin/node/node.mli
+++ b/src/bin/node/node.mli
@@ -12,3 +12,4 @@ val make :
   node * unit Lwt.t
 
 val listen : node -> port:int -> unit
+val test : unit -> unit

--- a/src/chain/chain.ml
+++ b/src/chain/chain.ml
@@ -80,9 +80,8 @@ let incoming_operation ~operation node =
   let producer = Producer.incoming_operation ~operation producer in
   Chain { pool; protocol; consensus; producer }
 
-let incoming_message ~current ~message chain =
-  let open Message in
-  let (Message { hash = _; content }) = message in
+let incoming_message ~current ~content chain =
+  let open Message.Content in
   match content with
   | Content_block block -> incoming_block ~current ~block chain
   | Content_signature signature -> incoming_signature ~current ~signature chain
@@ -102,3 +101,56 @@ let incoming_timeout ~current chain =
     | None -> []
   in
   (chain, actions)
+
+let test () =
+  let get_current () = Timestamp.of_float (Unix.gettimeofday ()) in
+
+  let open Deku_crypto in
+  let secret = Ed25519.Secret.generate () in
+  let secret = Secret.Ed25519 secret in
+  let identity = Identity.make secret in
+  let validators =
+    let key = Key.of_secret secret in
+    let key_hash = Key_hash.of_key key in
+    [ key_hash ]
+  in
+  let pool = Parallel.Pool.make ~domains:8 in
+
+  let chain = make ~identity ~validators ~pool in
+  let (Chain { consensus; _ }) = chain in
+  let block =
+    let (Consensus.Consensus { state; _ }) = consensus in
+    let (State { current_level; current_block; _ }) = state in
+    let level = Level.next current_level in
+    let previous = current_block in
+    let operations = [] in
+    let block = Block.produce ~identity ~level ~previous ~operations in
+    block
+  in
+
+  let chain, actions = incoming_block ~current:(get_current ()) ~block chain in
+  assert (actions = []);
+
+  let signature = Block.sign ~identity block in
+  let chain, actions =
+    incoming_signature ~current:(get_current ()) ~signature chain
+  in
+  assert (actions <> []);
+
+  let rec loop chain actions =
+    let current = get_current () in
+    let chain, actions =
+      List.fold_left
+        (fun (chain, actions) action ->
+          let chain, additional_actions =
+            match action with
+            | Chain_trigger_timeout -> incoming_timeout ~current chain
+            | Chain_broadcast { content } ->
+                incoming_message ~current ~content chain
+          in
+          (chain, actions @ additional_actions))
+        (chain, []) actions
+    in
+    loop chain actions
+  in
+  loop chain actions

--- a/src/chain/chain.mli
+++ b/src/chain/chain.mli
@@ -26,8 +26,14 @@ val make :
   chain
 
 val incoming_message :
-  current:Timestamp.t -> message:Message.t -> chain -> chain * action list
+  current:Timestamp.t ->
+  content:Message.Content.t ->
+  chain ->
+  chain * action list
 (** [incoming ~current ~message chain] *)
 
 val incoming_timeout : current:Timestamp.t -> chain -> chain * action list
 (** [incoming_timeout ~current chain] *)
+
+(* TODO: remove this in the future *)
+val test : unit -> unit

--- a/src/consensus/block_pool.ml
+++ b/src/consensus/block_pool.ml
@@ -3,9 +3,11 @@ open Block
 
 (* TODO: old signatures and blocks are never removed *)
 type block_pool = {
-  block_by_hash : Block.t Block_hash.Map.t;
-  blocks_by_previous : Block.Set.t Block_hash.Map.t;
-  signatures_by_hash : Verified_signature.Set.t Block_hash.Map.t;
+  block_by_hash : (Block.t * Timestamp.t) Block_hash.Map.t;
+  blocks_by_previous : (Block.Set.t * Timestamp.t) Block_hash.Map.t;
+  signatures_by_hash :
+    (Verified_signature.Set.t * Timestamp.t) Block_hash.Map.t;
+  last_cleanup : Timestamp.t;
 }
 
 type t = block_pool
@@ -13,12 +15,12 @@ type t = block_pool
 (* helpers *)
 let find_blocks hash map =
   match Block_hash.Map.find_opt hash map with
-  | Some blocks -> blocks
+  | Some (blocks, _timestamp) -> blocks
   | None -> Block.Set.empty
 
 let find_signatures hash map =
   match Block_hash.Map.find_opt hash map with
-  | Some signatures -> signatures
+  | Some (signatures, _timestamp) -> signatures
   | None -> Verified_signature.Set.empty
 
 let empty =
@@ -26,44 +28,102 @@ let empty =
     block_by_hash = Block_hash.Map.empty;
     blocks_by_previous = Block_hash.Map.empty;
     signatures_by_hash = Block_hash.Map.empty;
+    last_cleanup = Timestamp.of_float 0.0;
   }
 
-let append_block block pool =
-  let { block_by_hash; blocks_by_previous; signatures_by_hash } = pool in
+let append_block ~current block pool =
+  let { block_by_hash; blocks_by_previous; signatures_by_hash; last_cleanup } =
+    pool
+  in
   let (Block { hash; previous; _ }) = block in
-  let block_by_hash = Block_hash.Map.add hash block block_by_hash in
+  let block_by_hash = Block_hash.Map.add hash (block, current) block_by_hash in
   let blocks_by_previous =
     let blocks = find_blocks previous blocks_by_previous in
     let blocks = Block.Set.add block blocks in
-    Block_hash.Map.add previous blocks blocks_by_previous
+    Block_hash.Map.add previous (blocks, current) blocks_by_previous
   in
-  { block_by_hash; blocks_by_previous; signatures_by_hash }
+  { block_by_hash; blocks_by_previous; signatures_by_hash; last_cleanup }
 
-let append_signature signature pool =
-  let { block_by_hash; blocks_by_previous; signatures_by_hash } = pool in
+let append_signature ~current signature pool =
+  let { block_by_hash; blocks_by_previous; signatures_by_hash; last_cleanup } =
+    pool
+  in
   let signature_hash = Verified_signature.signed_hash signature in
   let signature_hash = Block_hash.of_blake2b signature_hash in
   let signatures_by_hash =
     let signatures = find_signatures signature_hash signatures_by_hash in
     let signatures = Verified_signature.Set.add signature signatures in
-    Block_hash.Map.add signature_hash signatures signatures_by_hash
+    Block_hash.Map.add signature_hash (signatures, current) signatures_by_hash
   in
-  { block_by_hash; blocks_by_previous; signatures_by_hash }
+  { block_by_hash; blocks_by_previous; signatures_by_hash; last_cleanup }
 
 let find_block ~block_hash pool =
-  let { block_by_hash; blocks_by_previous = _; signatures_by_hash = _ } =
+  let {
+    block_by_hash;
+    blocks_by_previous = _;
+    signatures_by_hash = _;
+    last_cleanup = _;
+  } =
     pool
   in
-  Block_hash.Map.find_opt block_hash block_by_hash
+  match Block_hash.Map.find_opt block_hash block_by_hash with
+  | Some (block, _timestamp) -> Some block
+  | None -> None
 
 let find_next_blocks ~block_previous pool =
-  let { block_by_hash = _; blocks_by_previous; signatures_by_hash = _ } =
+  let {
+    block_by_hash = _;
+    blocks_by_previous;
+    signatures_by_hash = _;
+    last_cleanup = _;
+  } =
     pool
   in
   find_blocks block_previous blocks_by_previous
 
 let find_signatures ~block_hash pool =
-  let { block_by_hash = _; blocks_by_previous = _; signatures_by_hash } =
+  let {
+    block_by_hash = _;
+    blocks_by_previous = _;
+    signatures_by_hash;
+    last_cleanup = _;
+  } =
     pool
   in
   find_signatures block_hash signatures_by_hash
+
+let clean ~current pool =
+  let { block_by_hash; blocks_by_previous; signatures_by_hash; last_cleanup } =
+    pool
+  in
+
+  (* Format.printf "pool.clean\n%!"; *)
+  match
+    Timestamp.to_float current -. Timestamp.to_float last_cleanup
+    > Deku_constants.clean_block_pool_time
+  with
+  | true ->
+      (* Format.printf "pool.cleaning: %d %d %d\n%!"
+         (Block_hash.Map.cardinal block_by_hash)
+         (Block_hash.Map.cardinal blocks_by_previous)
+         (Block_hash.Map.cardinal signatures_by_hash); *)
+      let filter map =
+        Block_hash.Map.filter
+          (fun _hash (_block, timestamp) ->
+            let current = Timestamp.to_float current in
+            let timestamp = Timestamp.to_float timestamp in
+            let time_since = current -. timestamp in
+            time_since < Deku_constants.clean_block_pool_time)
+          map
+      in
+      let block_by_hash = filter block_by_hash in
+      let blocks_by_previous = filter blocks_by_previous in
+      let signatures_by_hash = filter signatures_by_hash in
+      let last_cleanup = current in
+      (* Format.printf "pool.cleaned: %d %d %d\n%!"
+         (Block_hash.Map.cardinal block_by_hash)
+         (Block_hash.Map.cardinal blocks_by_previous)
+         (Block_hash.Map.cardinal signatures_by_hash); *)
+      { block_by_hash; blocks_by_previous; signatures_by_hash; last_cleanup }
+  | false ->
+      { block_by_hash; blocks_by_previous; signatures_by_hash; last_cleanup }

--- a/src/consensus/block_pool.mli
+++ b/src/consensus/block_pool.mli
@@ -4,10 +4,15 @@ type block_pool
 type t = block_pool
 
 val empty : block_pool
-val append_block : Block.t -> block_pool -> block_pool
-val append_signature : Verified_signature.t -> block_pool -> block_pool
+val append_block : current:Timestamp.t -> Block.t -> block_pool -> block_pool
+
+val append_signature :
+  current:Timestamp.t -> Verified_signature.t -> block_pool -> block_pool
+
 val find_block : block_hash:Block_hash.t -> block_pool -> Block.t option
 val find_next_blocks : block_previous:Block_hash.t -> block_pool -> Block.Set.t
 
 val find_signatures :
   block_hash:Block_hash.t -> block_pool -> Verified_signature.Set.t
+
+val clean : current:Timestamp.t -> block_pool -> block_pool

--- a/src/consensus/consensus.ml
+++ b/src/consensus/consensus.ml
@@ -42,6 +42,7 @@ and with_accepted_block ~current ~block consensus =
     Format.eprintf "%a\n%!" Z.pp_print level
   in
   let state = State.apply_block ~current ~block state in
+  let block_pool = Block_pool.clean ~current block_pool in
   let consensus = Consensus { block_pool; signer; state } in
 
   let blocks = Block_pool.find_next_blocks ~block_previous:hash block_pool in
@@ -64,7 +65,7 @@ and with_accepted_block ~current ~block consensus =
 
 and incoming_block ~current ~block consensus =
   let (Consensus { block_pool; signer; state }) = consensus in
-  let block_pool = Block_pool.append_block block block_pool in
+  let block_pool = Block_pool.append_block ~current block block_pool in
   let consensus = Consensus { block_pool; signer; state } in
 
   let consensus, actions =
@@ -89,7 +90,7 @@ and incoming_block ~current ~block consensus =
 
 let incoming_signature ~current ~signature consensus =
   let (Consensus { block_pool; signer; state }) = consensus in
-  let block_pool = Block_pool.append_signature signature block_pool in
+  let block_pool = Block_pool.append_signature ~current signature block_pool in
   let consensus = Consensus { block_pool; signer; state } in
 
   let block_hash = Verified_signature.signed_hash signature in

--- a/src/consensus/judger.ml
+++ b/src/consensus/judger.ml
@@ -58,10 +58,10 @@ let is_signed ~validators ~block_pool block =
     (* TODO: O(1) cardinal *)
     let validators = Validators.cardinal validators in
     let validators = Float.of_int validators in
-    let required_signatures = Float.ceil (validators *. (2.0 /. 3.0)) in
+    let required_signatures = Float.floor (validators *. (2.0 /. 3.0)) +. 1.0 in
     Float.to_int required_signatures
   in
-  total_signatures > required_signatures
+  total_signatures >= required_signatures
 
 let is_accepted ~state ~block_pool block =
   let (State

--- a/src/consensus/timestamp.ml
+++ b/src/consensus/timestamp.ml
@@ -2,6 +2,7 @@ type timestamp = float
 type t = timestamp
 
 let of_float float = float
+let to_float timestamp = timestamp
 
 let timeouts_since ~current ~since =
   let diff = current -. since in

--- a/src/consensus/timestamp.mli
+++ b/src/consensus/timestamp.mli
@@ -4,6 +4,8 @@ type t = timestamp
 
 val of_float : float -> timestamp
 
+(* TODO: remove this function *)
+val to_float : timestamp -> float
 (* operations *)
 (* TODO: better naming, TLDR it measures how many skips since some time
    like for timeouts*)

--- a/src/constants/deku_constants.ml
+++ b/src/constants/deku_constants.ml
@@ -3,3 +3,13 @@ open Deku_stdlib
 (* TODO: this being in blocks is really weird *)
 let includable_operation_window = Option.get (N.of_z (Z.of_int 120))
 let block_timeout = 10.0
+
+let clean_block_pool_time =
+  let minutes = 60.0 in
+  (* let minutes = 0.1 in *)
+  60.0 (* seconds *) *. minutes
+
+let clean_gossip_time =
+  let minutes = 60.0 *. 2.0 (* hours *) in
+  (* let minutes = 0.2 in *)
+  60.0 (* seconds *) *. minutes

--- a/src/constants/deku_constants.mli
+++ b/src/constants/deku_constants.mli
@@ -2,3 +2,5 @@ open Deku_stdlib
 
 val includable_operation_window : N.t
 val block_timeout : float
+val clean_block_pool_time : float
+val clean_gossip_time : float

--- a/src/crypto/key_hash.ml
+++ b/src/crypto/key_hash.ml
@@ -43,6 +43,12 @@ include With_yojson_of_b58 (struct
   let to_b58 = to_b58
 end)
 
+module Map = Map.Make (struct
+  type t = key_hash
+
+  let compare = compare
+end)
+
 module Set = Set.Make (struct
   type t = key_hash
 

--- a/src/crypto/key_hash.mli
+++ b/src/crypto/key_hash.mli
@@ -13,4 +13,5 @@ val to_b58 : key_hash -> string
 (* operations *)
 val of_key : Key.t -> t
 
+module Map : Map.S with type key = key_hash
 module Set : Set.S with type elt = key_hash

--- a/src/gossip/gossip.ml
+++ b/src/gossip/gossip.ml
@@ -1,12 +1,16 @@
 open Message
 
+(* TODO: Timestamp.t *)
+type timestamp = float
+
 (* TODO: self identified map, such that id -> message[id] always holds *)
 type gossip =
   | Gossip of {
-      ready : Message.raw Message_hash.Map.t;
+      ready : (Message.raw * timestamp) Message_hash.Map.t;
       (* TODO: at max one delayed per connection,
           prevents infinite spam *)
       delayed : string list Message_hash.Map.t;
+      last_cleanup : timestamp;
     }
 
 type fragment =
@@ -27,7 +31,12 @@ type action =
 type t = gossip
 
 let empty =
-  Gossip { ready = Message_hash.Map.empty; delayed = Message_hash.Map.empty }
+  Gossip
+    {
+      ready = Message_hash.Map.empty;
+      delayed = Message_hash.Map.empty;
+      last_cleanup = 0.0;
+    }
 
 (* TODO:
       let sync ~external_messages gossip =
@@ -49,21 +58,22 @@ let empty =
 
 (* external *)
 let incoming ~expected_hash ~raw_content gossip =
-  let (Gossip { ready; delayed }) = gossip in
+  let (Gossip { ready; delayed; last_cleanup }) = gossip in
+  (* Format.printf "incoming.delayed: %d\n%!" (Message_hash.Map.cardinal delayed); *)
   match Message_hash.Map.find_opt expected_hash delayed with
   | Some raw_contents ->
       let delayed =
         let raw_contents = raw_content :: raw_contents in
         Message_hash.Map.add expected_hash raw_contents delayed
       in
-      let gossip = Gossip { delayed; ready } in
+      let gossip = Gossip { delayed; ready; last_cleanup } in
       (gossip, None)
   | None ->
       let decode = Fragment_decode { expected_hash; raw_content } in
       (gossip, Some decode)
 
 let incoming ~expected_hash ~raw_content gossip =
-  let (Gossip { ready; delayed = _ }) = gossip in
+  let (Gossip { ready; delayed = _; last_cleanup = _ }) = gossip in
   match Message_hash.Map.mem expected_hash ready with
   | true -> (gossip, None)
   | false -> incoming ~expected_hash ~raw_content gossip
@@ -75,42 +85,46 @@ let incoming ~raw_expected_hash ~raw_content gossip =
 
 let broadcast ~content = Fragment_encode { content }
 
-let on_message ~message ~raw_message gossip =
-  let (Gossip { ready; delayed }) = gossip in
+let on_message ~current ~message ~raw_message gossip =
+  let (Gossip { ready; delayed; last_cleanup }) = gossip in
   let (Message { hash; _ }) = message in
 
-  let ready = Message_hash.Map.add hash raw_message ready in
+  let ready = Message_hash.Map.add hash (raw_message, current) ready in
   let delayed = Message_hash.Map.remove hash delayed in
-  let gossip = Gossip { ready; delayed } in
+  let gossip = Gossip { ready; delayed; last_cleanup } in
 
   (* TODO: when encode, apply could be faster *)
   let action = Gossip_apply_and_broadcast { message; raw_message } in
   (gossip, Some action)
 
-let on_message ~message ~raw_message gossip =
-  let (Gossip { ready; delayed = _ }) = gossip in
+let on_message ~current ~message ~raw_message gossip =
+  let (Gossip { ready; delayed = _; last_cleanup = _ }) = gossip in
   let (Message { hash; _ }) = message in
 
   match Message_hash.Map.mem hash ready with
   | true -> (gossip, None)
-  | false -> on_message ~message ~raw_message gossip
+  | false -> on_message ~current ~message ~raw_message gossip
 
 let on_decoded_error ~expected_hash gossip =
-  let (Gossip { ready; delayed }) = gossip in
+  let (Gossip { ready; delayed; last_cleanup }) = gossip in
   match Message_hash.Map.find_opt expected_hash delayed with
-  | Some [] | None -> (gossip, None)
+  | Some [] ->
+      let delayed = Message_hash.Map.remove expected_hash delayed in
+      let gossip = Gossip { ready; delayed; last_cleanup } in
+      (gossip, None)
+  | None -> (gossip, None)
   | Some (raw_content :: raw_contents) ->
       let delayed = Message_hash.Map.add expected_hash raw_contents delayed in
-      let gossip = Gossip { ready; delayed } in
+      let gossip = Gossip { ready; delayed; last_cleanup } in
 
       let decode = Fragment_decode { expected_hash; raw_content } in
       let action = Gossip_fragment { fragment = decode } in
       (gossip, Some action)
 
-let apply ~outcome gossip =
+let apply ~current ~outcome gossip =
   match outcome with
   | Outcome_message { message; raw_message } ->
-      on_message ~message ~raw_message gossip
+      on_message ~current ~message ~raw_message gossip
   | Outcome_decoded_error { expected_hash } ->
       on_decoded_error ~expected_hash gossip
 
@@ -137,3 +151,40 @@ let compute fragment =
   | Fragment_encode { content } -> compute_encode ~content
   | Fragment_decode { expected_hash; raw_content } ->
       compute_decode ~expected_hash ~raw_content
+
+let clean ~current gossip =
+  let (Gossip { ready; delayed; last_cleanup }) = gossip in
+  (* Format.printf "gossip.clean\n%!"; *)
+  match current -. last_cleanup > Deku_constants.clean_gossip_time with
+  | true ->
+      (* Format.printf "gossip.cleaning: %d\n%!" (Message_hash.Map.cardinal ready); *)
+      let ready =
+        Message_hash.Map.filter
+          (fun _hash (_message, timestamp) ->
+            let time_since_message = current -. timestamp in
+            (* Format.printf "message: %b\n%!"
+               (time_since_message < Deku_constants.clean_gossip_time); *)
+            time_since_message < Deku_constants.clean_gossip_time)
+          ready
+      in
+      (* Format.printf "gossip.cleaned: %d\n%!" (Message_hash.Map.cardinal ready); *)
+      let last_cleanup = current in
+      Gossip { ready; delayed; last_cleanup }
+  | false -> Gossip { ready; delayed; last_cleanup }
+
+let test () =
+  let open Deku_consensus in
+  let _message, raw_message =
+    Message.encode ~content:(Content.block Genesis.block)
+  in
+  let (Raw_message { hash; _ }) = raw_message in
+  let current = 0.0 in
+  let gossip =
+    let ready = Message_hash.Map.(add hash (raw_message, current) empty) in
+    Gossip { ready; delayed = Message_hash.Map.empty; last_cleanup = current }
+  in
+  let current = current +. Deku_constants.clean_gossip_time in
+  let gossip = clean ~current gossip in
+  let current = current +. 1.0 in
+  let _ = clean ~current gossip in
+  ()

--- a/src/gossip/gossip.mli
+++ b/src/gossip/gossip.mli
@@ -10,6 +10,9 @@ type action = private
     }
   | Gossip_fragment of { fragment : fragment }
 
+(* TODO: Timestamp.t *)
+type timestamp = float
+
 val empty : gossip
 
 val incoming :
@@ -22,8 +25,15 @@ val incoming :
 val broadcast : content:Message.Content.t -> fragment
 (** [broadcast ~content gossip] *)
 
-val apply : outcome:outcome -> gossip -> gossip * action option
+val apply :
+  current:timestamp -> outcome:outcome -> gossip -> gossip * action option
 (** [apply ~compute gossip] *)
 
 val compute : fragment -> outcome
 (** [compute fragment] Can be executed in parallel *)
+
+(* TODO: this is weird *)
+val clean : current:timestamp -> gossip -> gossip
+
+(* TODO: remove this *)
+val test : unit -> unit

--- a/src/network/dune
+++ b/src/network/dune
@@ -1,7 +1,7 @@
 (library
  (name deku_network)
  (public_name deku-network)
- (libraries deku-stdlib piaf)
+ (libraries deku-stdlib deku-crypto piaf)
  (preprocess
   (pps
    ppx_let_binding

--- a/src/network/network.mli
+++ b/src/network/network.mli
@@ -1,3 +1,5 @@
+open Deku_crypto
+
 type network
 type t = network
 
@@ -6,7 +8,14 @@ val listen :
   on_message:(raw_expected_hash:string -> raw_content:string -> unit) ->
   unit
 
-val connect : nodes:Uri.t list -> network
+val connect : nodes:(Key_hash.t * Uri.t) list -> network
+
+val send :
+  to_:Key_hash.t ->
+  raw_expected_hash:string ->
+  raw_content:string ->
+  network ->
+  unit
 
 val broadcast :
   raw_expected_hash:string -> raw_content:string -> network -> unit

--- a/src/protocol/address.ml
+++ b/src/protocol/address.ml
@@ -9,8 +9,4 @@ let to_key_hash address = address
 let of_b58 = of_b58
 let to_b58 = to_b58
 
-module Map = Map.Make (struct
-  type t = address
-
-  let compare = compare
-end)
+module Map = Map

--- a/src/storage/storage.ml
+++ b/src/storage/storage.ml
@@ -4,14 +4,12 @@ open Deku_crypto
 type storage = {
   secret : Secret.t;
   (* bootstrap *)
-  initial_validators : Key_hash.t list;
-  nodes : Uri.t list;
+  validators : (Key_hash.t * Uri.t) list;
 }
 
 and t = storage [@@deriving yojson]
 
-let make ~secret ~initial_validators ~nodes =
-  { secret; initial_validators; nodes }
+let make ~secret ~validators = { secret; validators }
 
 let read ~file =
   let open Lwt.Infix in

--- a/src/storage/storage.mli
+++ b/src/storage/storage.mli
@@ -2,17 +2,11 @@ open Deku_crypto
 
 type storage = private {
   secret : Secret.t; (* bootstrap *)
-  initial_validators : Key_hash.t list;
-  nodes : Uri.t list;
+  validators : (Key_hash.t * Uri.t) list;
 }
 
 type t = storage [@@deriving yojson]
 
-val make :
-  secret:Secret.t ->
-  initial_validators:Key_hash.t list ->
-  nodes:Uri.t list ->
-  storage
-
+val make : secret:Secret.t -> validators:(Key_hash.t * Uri.t) list -> storage
 val read : file:string -> storage Lwt.t
 val write : file:string -> storage -> unit Lwt.t


### PR DESCRIPTION
## Depends

- [ ] #803

## Problem

Currently there is no way to send a message to a specific node in Deku, this is

## Solution

This makes the network handle the `validator -> uri` map, while it is not ideal especially as validators may want to change their uris, this should work nicely.