### PR TITLE
loads data from disk

### DIFF
--- a/src/bin/node/deku_node.ml
+++ b/src/bin/node/deku_node.ml
@@ -1,29 +1,62 @@
 open Deku_stdlib
 open Deku_concepts
 open Deku_storage
+open Deku_chain
 include Node
 
 let domains = 8
 
 let main () =
   let port = ref 8080 in
-  let storage = ref "storage.json" in
+  let storage_file = ref "storage.json" in
+  let chain_file = ref "chain.bin" in
   Arg.parse
     [
       ("-p", Arg.Set_int port, " Listening port number (8080 by default)");
-      ("-s", Arg.Set_string storage, " Storage file (storage.json by default)");
+      ( "-s",
+        Arg.Set_string storage_file,
+        " Storage file (storage.json by default)" );
+      ("-c", Arg.Set_string chain_file, " Chain file (chain.bin by default)");
     ]
     ignore "Handle Deku communication. Runs forever.";
 
+  let storage_file = !storage_file in
+  let chain_file = !chain_file in
+
   let pool = Parallel.Pool.make ~domains in
-  let%await storage = Storage.read ~file:!storage in
-  let Storage.{ secret; validators } = storage in
-  (* TODO: this is a hack *)
-  let validators, nodes = List.split validators in
-  let identity = Identity.make secret in
+  let%await storage = Storage.Config.read ~file:storage_file in
+  let Storage.Config.{ secret; validators; nodes } = storage in
+
   Parallel.Pool.run pool (fun () ->
-      let node, promise = Node.make ~pool ~identity ~validators ~nodes in
+      let identity = Identity.make secret in
+      let%await chain = Storage.Chain.read ~file:chain_file in
+      let chain =
+        match chain with
+        | Some chain -> chain
+        | None -> Chain.make ~identity ~validators
+      in
+      let () =
+        let (Chain { consensus; _ }) = chain in
+        let (Consensus { current_block; _ }) = consensus in
+        let (Block { level; _ }) = current_block in
+        let level = Level.to_n level in
+        let level = N.to_z level in
+        Format.eprintf "%a\n%!" Z.pp_print level
+      in
+      let chain_ref = ref chain in
+      let dump_loop () =
+        let rec loop () =
+          let chain = !chain_ref in
+          Lwt.finalize
+            (fun () -> Storage.Chain.write ~pool ~file:chain_file chain)
+            loop
+        in
+        loop ()
+      in
+      let dump chain = chain_ref := chain in
+      let node, promise = Node.make ~pool ~dump ~chain ~nodes in
       Node.listen node ~port:!port;
+      Lwt.async (fun () -> dump_loop ());
       promise)
 
 (* let setup_log ?style_renderer level =

--- a/src/bin/node/node.mli
+++ b/src/bin/node/node.mli
@@ -1,14 +1,13 @@
 open Deku_stdlib
-open Deku_crypto
-open Deku_concepts
+open Deku_chain
 
 type node
 type t = node
 
 val make :
   pool:Parallel.Pool.pool ->
-  identity:Identity.identity ->
-  validators:Key_hash.t list ->
+  dump:(Chain.t -> unit) ->
+  chain:Chain.t ->
   nodes:Uri.t list ->
   node * unit Lwt.t
 

--- a/src/chain/chain.mli
+++ b/src/chain/chain.mli
@@ -1,4 +1,3 @@
-open Deku_stdlib
 open Deku_crypto
 open Deku_concepts
 open Deku_protocol
@@ -7,7 +6,6 @@ open Deku_gossip
 
 type chain = private
   | Chain of {
-      pool : Parallel.Pool.t;
       gossip : Gossip.t;
       protocol : Protocol.t;
       consensus : Consensus.t;
@@ -28,13 +26,10 @@ type action = private
       raw_expected_hash : string;
       raw_content : string;
     }
+  | Chain_send_not_found of { id : Request_id.t }
   | Chain_fragment of { fragment : fragment }
 
-val make :
-  identity:Identity.t ->
-  validators:Key_hash.t list ->
-  pool:Parallel.Pool.t ->
-  chain
+val make : identity:Identity.t -> validators:Key_hash.t list -> chain
 
 val incoming :
   raw_expected_hash:string ->

--- a/src/consensus/consensus.ml
+++ b/src/consensus/consensus.ml
@@ -133,6 +133,11 @@ let rec incoming_block_or_vote ~current ~block consensus =
                   (* TODO: ensure that previous.level = level - 1 *)
                   incoming_block_or_vote ~current ~block:previous consensus
               | None ->
+                  let () =
+                    let level = Level.to_n level in
+                    let level = N.to_z level in
+                    Format.eprintf "requesting: %a\n%!" Z.pp_print level
+                  in
                   let action = Consensus_request_block { hash = previous } in
                   (consensus, [ action ]))
           | false ->

--- a/src/gossip/response.ml
+++ b/src/gossip/response.ml
@@ -1,10 +1,9 @@
 module Content = struct
   open Deku_consensus
 
-  type content = Content_none | Content_block of Block.t
+  type content = Content_block of Block.t
   and t = content [@@deriving yojson]
 
-  let none = Content_none
   let block block = Content_block block
 end
 

--- a/src/gossip/response.mli
+++ b/src/gossip/response.mli
@@ -1,10 +1,9 @@
 module Content : sig
   open Deku_consensus
 
-  type content = private Content_none | Content_block of Block.t
+  type content = private Content_block of Block.t
   type t = content [@@deriving yojson]
 
-  val none : content
   val block : Block.t -> content
 end
 

--- a/src/network/network.mli
+++ b/src/network/network.mli
@@ -30,3 +30,5 @@ val respond :
   raw_content:string ->
   network ->
   unit
+
+val not_found : id:Request_id.t -> network -> unit

--- a/src/storage/dune
+++ b/src/storage/dune
@@ -1,6 +1,11 @@
 (library
  (name deku_storage)
  (public_name deku-storage)
- (libraries deku-crypto deku-stdlib uri lwt.unix)
+ (libraries deku-crypto deku-stdlib deku-chain uri lwt.unix)
  (preprocess
-  (pps ppx_deriving.show ppx_deriving.eq ppx_deriving.ord ppx_yojson_conv)))
+  (pps
+   ppx_let_binding
+   ppx_deriving.show
+   ppx_deriving.eq
+   ppx_deriving.ord
+   ppx_yojson_conv)))

--- a/src/storage/storage.ml
+++ b/src/storage/storage.ml
@@ -1,25 +1,53 @@
 open Deku_stdlib
-open Deku_crypto
 
-type storage = {
-  secret : Secret.t;
-  (* bootstrap *)
-  validators : (Key_hash.t * Uri.t) list;
-}
+module Config = struct
+  open Deku_crypto
 
-and t = storage [@@deriving yojson]
+  type config = {
+    secret : Secret.t;
+    validators : Key_hash.t list;
+    nodes : Uri.t list;
+  }
 
-let make ~secret ~validators = { secret; validators }
+  and t = config [@@deriving yojson]
 
-let read ~file =
-  let open Lwt.Infix in
-  Lwt_io.with_file ~mode:Input file (fun ic ->
-      Lwt_io.read ic >|= fun json ->
-      let json = Yojson.Safe.from_string json in
-      storage_of_yojson json)
+  let make ~secret ~validators ~nodes = { secret; validators; nodes }
 
-let write ~file storage =
-  Lwt_io.with_file ~mode:Output file (fun oc ->
-      let json = yojson_of_storage storage in
-      let string = Yojson.Safe.pretty_to_string json in
-      Lwt_io.write oc string)
+  let read ~file =
+    Lwt_io.with_file ~mode:Input file (fun ic ->
+        let%await json = Lwt_io.read ic in
+        let json = Yojson.Safe.from_string json in
+        let config = config_of_yojson json in
+        Lwt.return config)
+
+  let write ~file storage =
+    Lwt_io.with_file ~mode:Output file (fun oc ->
+        let json = yojson_of_config storage in
+        let string = Yojson.Safe.pretty_to_string json in
+        Lwt_io.write oc string)
+end
+
+module Chain = struct
+  open Deku_chain
+
+  let read ~file =
+    let%await exists = Lwt_unix.file_exists file in
+    match exists with
+    | true ->
+        Lwt_io.with_file ~mode:Input file (fun ic ->
+            let%await (chain : Chain.t) = Lwt_io.read_value ic in
+            Lwt.return (Some chain))
+    | false -> Lwt.return_none
+
+  let write ~pool ~file (chain : Chain.t) =
+    let%await temp, oc =
+      Lwt_io.open_temp_file ~prefix:"chain" ~suffix:"bin" ()
+    in
+    let%await bin =
+      Parallel.async pool (fun () -> Marshal.to_string chain [])
+    in
+    (* TODO: if those fails it will leak temp_files *)
+    let%await () = Lwt_io.write oc bin in
+    let%await () = Lwt_io.close oc in
+    Lwt_unix.rename temp file
+end

--- a/src/storage/storage.mli
+++ b/src/storage/storage.mli
@@ -1,12 +1,24 @@
+open Deku_stdlib
 open Deku_crypto
+open Deku_chain
 
-type storage = private {
-  secret : Secret.t; (* bootstrap *)
-  validators : (Key_hash.t * Uri.t) list;
-}
+module Config : sig
+  type config = private {
+    secret : Secret.t; (* bootstrap *)
+    validators : Key_hash.t list;
+    nodes : Uri.t list;
+  }
 
-type t = storage [@@deriving yojson]
+  type t = config [@@deriving yojson]
 
-val make : secret:Secret.t -> validators:(Key_hash.t * Uri.t) list -> storage
-val read : file:string -> storage Lwt.t
-val write : file:string -> storage -> unit Lwt.t
+  val make :
+    secret:Secret.t -> validators:Key_hash.t list -> nodes:Uri.t list -> config
+
+  val read : file:string -> config Lwt.t
+  val write : file:string -> config -> unit Lwt.t
+end
+
+module Chain : sig
+  val read : file:string -> Chain.t option Lwt.t
+  val write : pool:Parallel.Pool.t -> file:string -> Chain.t -> unit Lwt.t
+end


### PR DESCRIPTION
## Depends

- [ ] #812

## Problem

Deku currently is not capable of starting after being stopped.

## Solution

This writes the entire Chain.t to disk and tries to load it whenever starting a node, when coupled with the auto rejoin of the network, this allows to both stop a single node and restart it, but also stop the entire network and restart it by adding a single block, which will make all nodes slightly behind request the blocks and get in sync.

This contains some performance regressions that I will be addressing in the near future.