### PR TITLE
feat/deku-api: send blocks through websockets

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -1,0 +1,5 @@
+for N in 0 1 2 3; do
+    chain_level=`cat chain/data/$N/chain.json| jq -r '.[1].consensus[1].current_block.block.level'`
+    db_level=`sqlite3 chain/data/0/database.db "$sql select max(level) from blocks"`
+    echo node-$N: $chain_level \($db_level\)
+done

--- a/reset.sh
+++ b/reset.sh
@@ -1,0 +1,8 @@
+for N in 0 1 2 3; do
+    rm -rf "./chain/data/$N/chain.json"
+    rm -rf "./chain/data/$N/chain.tmp.json"
+    rm -rf "./chain/data/$N/database.db"
+
+    rm -rf "./chain/data/$N/pipe_read"
+    rm -rf "./chain/data/$N/pipe_write"
+done

--- a/src/bin/node/deku_api.ml
+++ b/src/bin/node/deku_api.ml
@@ -8,6 +8,9 @@ let error_to_response error =
   let body = Api_error.yojson_of_t error |> Yojson.Safe.to_string in
   Dream.json ~status body
 
+let method_not_allowed_handler path meth _ =
+  Api_error.method_not_allowed path meth |> error_to_response
+
 let make_handler (node : t) (indexer : Indexer.t) (constants : Api_constants.t)
     (module Handler : HANDLER) =
   let handler request =
@@ -24,8 +27,8 @@ let make_handler (node : t) (indexer : Indexer.t) (constants : Api_constants.t)
             Dream.json ~status:`OK body
         | Error error -> error_to_response error)
   in
-  let method_not_allowed_handler _ =
-    Api_error.method_not_allowed Handler.path Handler.meth |> error_to_response
+  let method_not_allowed_handler req =
+    method_not_allowed_handler Handler.path Handler.meth req
   in
   let route =
     match Handler.meth with
@@ -46,6 +49,84 @@ let no_cache_middleware handler req =
   Dream.add_header response "Cache-Control" "max-age=0, no-cache, no-store";
   Lwt.return response
 
+(* Websockets *)
+let counter = ref 0
+
+module Websockets = Stdlib.Map.Make (Int)
+
+let websockets = ref Websockets.empty
+
+let ws_block_monitor =
+  let handler _ =
+    Dream.websocket ~close:false (fun websocket ->
+        let id = !counter + 1 in
+        counter := id;
+        websockets := Websockets.add id websocket !websockets;
+        let rec loop () =
+          let%await msg = Dream.receive websocket in
+          match msg with
+          | Some _msg -> loop ()
+          | None ->
+              let%await () = Dream.close_websocket websocket in
+              websockets := Websockets.remove id !websockets;
+              Lwt.return_unit
+        in
+        loop ())
+  in
+  let path = "/chain/blocks/monitor" in
+  let meth = `GET in
+  let route = Dream.get "/chain/blocks/monitor" handler in
+  let method_not_allowed_handler req =
+    method_not_allowed_handler path meth req
+  in
+  [ route; Dream.any path method_not_allowed_handler ]
+
+(* Client just needs to know the hash, level and the list of operations
+   If the client wants to know further informations on a block, he can always query chain/blocks/{hash/level}
+*)
+module BlockDTO = struct
+  open Deku_consensus
+  open Deku_concepts
+  open Deku_protocol
+
+  type block = {
+    hash : Block_hash.t;
+    level : Level.t;
+    operations : Operation_hash.t list;
+  }
+  [@@deriving yojson_of]
+
+  type t = block
+
+  let of_block (block : Block.t) =
+    let (Block.Block { hash; level; payload; _ }) = block in
+    (* TODO: deserialize in a parallel pool ?? *)
+    let parse_operation operation =
+      match
+        let json = Yojson.Safe.from_string operation in
+        let operation = Operation.t_of_yojson json in
+        let (Operation.Operation { hash; _ }) = operation in
+        hash
+      with
+      | hash -> Some hash
+      | exception _ -> None
+    in
+    let operations = payload |> List.filter_map parse_operation in
+    { hash; level; operations }
+end
+
+let on_block block =
+  let block =
+    BlockDTO.of_block block |> BlockDTO.yojson_of_block |> Yojson.Safe.to_string
+  in
+  Lwt_list.iter_p
+    (fun (_id, websocket) ->
+      let%await () = Dream.send websocket block in
+      Lwt.return_unit)
+    (!websockets |> Websockets.to_seq |> List.of_seq)
+
+let on_block block = Lwt.async (fun () -> on_block block)
+
 let make_routes node indexer constants =
   cors_middleware @@ no_cache_middleware
   @@ Dream.router
@@ -53,6 +134,7 @@ let make_routes node indexer constants =
          Dream.scope "/api/v1/" []
            (List.flatten
               [
+                ws_block_monitor;
                 make_handler node indexer constants (module Get_genesis);
                 make_handler node indexer constants (module Get_head);
                 make_handler node indexer constants (module Get_level);

--- a/src/bin/node/deku_node.ml
+++ b/src/bin/node/deku_node.ml
@@ -156,9 +156,13 @@ let main params =
         |> Lwt.return
   in
   let dump = make_dump_loop ~pool ~folder:data_folder ~chain in
+  let notify_api =
+    match api_enabled with true -> Deku_api.on_block | false -> fun _ -> ()
+  in
+
   let node, promise =
     Node.make ~pool ~dump ~chain ~nodes:validator_uris ~indexer:(Some indexer)
-      ~tezos_interop:(Some tezos_interop) ()
+      ~tezos_interop:(Some tezos_interop) ~notify_api ()
   in
   let node_uri = Uri.of_string "http://localhost" in
   let node_uri = Uri.with_port node_uri (Some port) in

--- a/src/bin/node/node.mli
+++ b/src/bin/node/node.mli
@@ -3,6 +3,7 @@ open Deku_chain
 open Deku_network
 open Deku_indexer
 open Deku_tezos_interop
+open Deku_consensus
 
 type node = private {
   pool : Parallel.Pool.t;
@@ -12,6 +13,7 @@ type node = private {
   tezos_interop : Tezos_interop.t option;
   mutable chain : Chain.t;
   mutable trigger_timeout : unit -> unit;
+  notify_api : Block.t -> unit;
 }
 
 type t = node
@@ -23,6 +25,7 @@ val make :
   nodes:Uri.t list ->
   ?indexer:Indexer.t option ->
   ?tezos_interop:Tezos_interop.t option ->
+  notify_api:(Block.t -> unit) ->
   unit ->
   node * unit Lwt.t
 

--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,7 @@
 
 trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 
-dune build
+dune build || exit 1
 
 dir=$(dirname $0)
 source $dir/scripts/common.sh


### PR DESCRIPTION
Sends blocks through websocket so that clients will be able to observe the chain and check if their operations are included in the chain without pulling the api