### PR TITLE
To string instead of json string

### DIFF
--- a/src/crypto/BLAKE2b.ml
+++ b/src/crypto/BLAKE2b.ml
@@ -82,6 +82,9 @@ include BLAKE2b_256
 let yojson_of_t t = `String (to_hex t)
 
 let t_of_yojson json =
+  (* TODO: Is this warning correct? *)
+  Logs.warn (fun m ->
+      m "error, an 'untyped' hash is circulating on the network");
   let json_str = Yojson.Safe.Util.to_string json in
   match json_str |> of_hex with
   | Some t -> t

--- a/src/crypto/BLAKE2b.ml
+++ b/src/crypto/BLAKE2b.ml
@@ -82,7 +82,7 @@ include BLAKE2b_256
 let yojson_of_t t = `String (to_hex t)
 
 let t_of_yojson json =
-  let json_str = Yojson.Safe.to_string json in
+  let json_str = Yojson.Safe.Util.to_string json in
   match json_str |> of_hex with
   | Some t -> t
   | None ->


### PR DESCRIPTION
## Problem

<!--- Restate the problem addressed by the PR here --->

```
Failure("cannot deserialize \"2b97aeab16c6ce67abd1fbc66782540a7a6f584800d44da84e2afa316747c7ff\" to blake2b")
```

## Solution

Create a proper string instead of json formatted string
 