### PR TITLE
fix: support slash at the end of urls

### DIFF
--- a/client/examples/nodejs/index.ts
+++ b/client/examples/nodejs/index.ts
@@ -10,7 +10,7 @@ const dekuSigner = fromMemorySigner(
 
 (async () => {
   const deku = new DekuToolkit({
-    dekuRpc: "https://deku-canonical-vm0.deku-v1.marigold.dev",
+    dekuRpc: "https://deku-canonical-vm0.deku-v1.marigold.dev/",
     dekuSigner,
   }).setTezosRpc("https://ghostnet.tezos.marigold.dev/");
   const data = `${Buffer.from("hello world").toString("hex")}`;

--- a/client/examples/nodejs/package-lock.json
+++ b/client/examples/nodejs/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@marigold-dev/deku-toolkit": "^0.1.6",
+                "@marigold-dev/deku-toolkit": "file:../../",
                 "@taquito/signer": "^14.0.0",
                 "@taquito/taquito": "^14.0.0",
                 "axios": "^0.27.2",
@@ -25,6 +25,27 @@
                 "ts-node": "^10.9.1",
                 "tsconfig-paths": "^4.0.0",
                 "tsconfig-paths-jest": "^0.0.1",
+                "typescript": "^4.7.4"
+            }
+        },
+        "../..": {
+            "version": "0.1.6",
+            "license": "ISC",
+            "dependencies": {
+                "@taquito/taquito": "^13.0.1",
+                "blakejs": "^1.2.1",
+                "bs58check": "^2.1.2"
+            },
+            "devDependencies": {
+                "@types/bs58check": "^2.1.0",
+                "@types/node": "^18.7.13",
+                "@typescript-eslint/eslint-plugin": "^5.35.1",
+                "@typescript-eslint/parser": "^5.35.1",
+                "eslint": "^8.23.0",
+                "rollup": "^2.79.1",
+                "rollup-plugin-json": "^4.0.0",
+                "rollup-plugin-sourcemaps": "^0.6.3",
+                "rollup-plugin-typescript2": "^0.34.0",
                 "typescript": "^4.7.4"
             }
         },
@@ -965,117 +986,8 @@
             }
         },
         "node_modules/@marigold-dev/deku-toolkit": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/@marigold-dev/deku-toolkit/-/deku-toolkit-0.1.6.tgz",
-            "integrity": "sha512-WlKyO+uc3IjM0t+T/wVsZ9ttITT4domyVqRTFG8h9e3G7wjOZAAoCeu6dwOy0TZu3e4kWCxxQeCDDZdO/O2BqA==",
-            "dependencies": {
-                "@taquito/taquito": "^13.0.1",
-                "blakejs": "^1.2.1",
-                "bs58check": "^2.1.2"
-            }
-        },
-        "node_modules/@marigold-dev/deku-toolkit/node_modules/@taquito/http-utils": {
-            "version": "13.0.1",
-            "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-13.0.1.tgz",
-            "integrity": "sha512-eHzd0HSL3qX6bOOSaQClm+0XmpbSNcJP69uzaBJwfXo7ntQR1bUfGLn6+1Hgsk/lJ0JxakD2PDA4aaeajHvyPw==",
-            "dependencies": {
-                "axios": "^0.26.0"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@marigold-dev/deku-toolkit/node_modules/@taquito/local-forging": {
-            "version": "13.0.1",
-            "resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-13.0.1.tgz",
-            "integrity": "sha512-2n1ryUzHBIOHiQYRO7ELQaurjoNhJ3KUUcX0dAnFs3xVxUBugHgDPot+T+1rNZDdLVhTS6mmK796xrWDGnO6xw==",
-            "dependencies": {
-                "@taquito/utils": "^13.0.1",
-                "bignumber.js": "^9.0.2"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@marigold-dev/deku-toolkit/node_modules/@taquito/michel-codec": {
-            "version": "13.0.1",
-            "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-13.0.1.tgz",
-            "integrity": "sha512-A9MxhDMdTTK31ty5Ke2wg4wkt7F/Y++tD8wq9YIFJzxt+MkpWX5b2i1f7yHXPsK/81YiGAi/LDamLtLCekY1LA==",
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@marigold-dev/deku-toolkit/node_modules/@taquito/michelson-encoder": {
-            "version": "13.0.1",
-            "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-13.0.1.tgz",
-            "integrity": "sha512-U80vswMHlEDQUjvARZScIKrSZkIjxdYtDLvHu4oRZ9wTqTXSlj+t64G5QmZwTEJRQkbzfhsOOr6vL40ztL0tzw==",
-            "dependencies": {
-                "@taquito/rpc": "^13.0.1",
-                "@taquito/utils": "^13.0.1",
-                "bignumber.js": "^9.0.2",
-                "fast-json-stable-stringify": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@marigold-dev/deku-toolkit/node_modules/@taquito/rpc": {
-            "version": "13.0.1",
-            "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-13.0.1.tgz",
-            "integrity": "sha512-f2Z0qzHB1ERLU5kewmXh3rAD84qIYthSjmAo04sWFbuaMgGW1HxMJKJ/EtL4s4VgoDUwahSwfATmVzmKg57BSw==",
-            "dependencies": {
-                "@taquito/http-utils": "^13.0.1",
-                "@taquito/utils": "^13.0.1",
-                "bignumber.js": "^9.0.2"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@marigold-dev/deku-toolkit/node_modules/@taquito/taquito": {
-            "version": "13.0.1",
-            "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-13.0.1.tgz",
-            "integrity": "sha512-xNtcwKsOCHSkURO9G2VhKSeI9q0qh5/OkVuYe6KM0Fo40FthXNqq205I/FTJzu5E1Q73J7cFqA7FHqUrv276gw==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "@taquito/http-utils": "^13.0.1",
-                "@taquito/local-forging": "^13.0.1",
-                "@taquito/michel-codec": "^13.0.1",
-                "@taquito/michelson-encoder": "^13.0.1",
-                "@taquito/rpc": "^13.0.1",
-                "@taquito/utils": "^13.0.1",
-                "bignumber.js": "^9.0.2",
-                "rxjs": "^6.6.3"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@marigold-dev/deku-toolkit/node_modules/@taquito/utils": {
-            "version": "13.0.1",
-            "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-13.0.1.tgz",
-            "integrity": "sha512-uRtsl4EATlVJ1UnNUiAEoibFFyexGLDLz02CBHoBrcWjqrZdj3AxA+TO63E2kWn/JmT2FM0Sqaqbm555lj4tow==",
-            "dependencies": {
-                "@stablelib/blake2b": "^1.0.1",
-                "@stablelib/ed25519": "^1.0.2",
-                "@types/bs58check": "^2.1.0",
-                "blakejs": "^1.2.1",
-                "bs58check": "^2.1.2",
-                "buffer": "^6.0.3",
-                "elliptic": "^6.5.4",
-                "typedarray-to-buffer": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@marigold-dev/deku-toolkit/node_modules/axios": {
-            "version": "0.26.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-            "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-            "dependencies": {
-                "follow-redirects": "^1.14.8"
-            }
+            "resolved": "../..",
+            "link": true
         },
         "node_modules/@sinclair/typebox": {
             "version": "0.24.44",
@@ -5329,96 +5241,21 @@
             }
         },
         "@marigold-dev/deku-toolkit": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/@marigold-dev/deku-toolkit/-/deku-toolkit-0.1.6.tgz",
-            "integrity": "sha512-WlKyO+uc3IjM0t+T/wVsZ9ttITT4domyVqRTFG8h9e3G7wjOZAAoCeu6dwOy0TZu3e4kWCxxQeCDDZdO/O2BqA==",
+            "version": "file:../..",
             "requires": {
                 "@taquito/taquito": "^13.0.1",
+                "@types/bs58check": "^2.1.0",
+                "@types/node": "^18.7.13",
+                "@typescript-eslint/eslint-plugin": "^5.35.1",
+                "@typescript-eslint/parser": "^5.35.1",
                 "blakejs": "^1.2.1",
-                "bs58check": "^2.1.2"
-            },
-            "dependencies": {
-                "@taquito/http-utils": {
-                    "version": "13.0.1",
-                    "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-13.0.1.tgz",
-                    "integrity": "sha512-eHzd0HSL3qX6bOOSaQClm+0XmpbSNcJP69uzaBJwfXo7ntQR1bUfGLn6+1Hgsk/lJ0JxakD2PDA4aaeajHvyPw==",
-                    "requires": {
-                        "axios": "^0.26.0"
-                    }
-                },
-                "@taquito/local-forging": {
-                    "version": "13.0.1",
-                    "resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-13.0.1.tgz",
-                    "integrity": "sha512-2n1ryUzHBIOHiQYRO7ELQaurjoNhJ3KUUcX0dAnFs3xVxUBugHgDPot+T+1rNZDdLVhTS6mmK796xrWDGnO6xw==",
-                    "requires": {
-                        "@taquito/utils": "^13.0.1",
-                        "bignumber.js": "^9.0.2"
-                    }
-                },
-                "@taquito/michel-codec": {
-                    "version": "13.0.1",
-                    "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-13.0.1.tgz",
-                    "integrity": "sha512-A9MxhDMdTTK31ty5Ke2wg4wkt7F/Y++tD8wq9YIFJzxt+MkpWX5b2i1f7yHXPsK/81YiGAi/LDamLtLCekY1LA=="
-                },
-                "@taquito/michelson-encoder": {
-                    "version": "13.0.1",
-                    "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-13.0.1.tgz",
-                    "integrity": "sha512-U80vswMHlEDQUjvARZScIKrSZkIjxdYtDLvHu4oRZ9wTqTXSlj+t64G5QmZwTEJRQkbzfhsOOr6vL40ztL0tzw==",
-                    "requires": {
-                        "@taquito/rpc": "^13.0.1",
-                        "@taquito/utils": "^13.0.1",
-                        "bignumber.js": "^9.0.2",
-                        "fast-json-stable-stringify": "^2.1.0"
-                    }
-                },
-                "@taquito/rpc": {
-                    "version": "13.0.1",
-                    "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-13.0.1.tgz",
-                    "integrity": "sha512-f2Z0qzHB1ERLU5kewmXh3rAD84qIYthSjmAo04sWFbuaMgGW1HxMJKJ/EtL4s4VgoDUwahSwfATmVzmKg57BSw==",
-                    "requires": {
-                        "@taquito/http-utils": "^13.0.1",
-                        "@taquito/utils": "^13.0.1",
-                        "bignumber.js": "^9.0.2"
-                    }
-                },
-                "@taquito/taquito": {
-                    "version": "13.0.1",
-                    "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-13.0.1.tgz",
-                    "integrity": "sha512-xNtcwKsOCHSkURO9G2VhKSeI9q0qh5/OkVuYe6KM0Fo40FthXNqq205I/FTJzu5E1Q73J7cFqA7FHqUrv276gw==",
-                    "requires": {
-                        "@taquito/http-utils": "^13.0.1",
-                        "@taquito/local-forging": "^13.0.1",
-                        "@taquito/michel-codec": "^13.0.1",
-                        "@taquito/michelson-encoder": "^13.0.1",
-                        "@taquito/rpc": "^13.0.1",
-                        "@taquito/utils": "^13.0.1",
-                        "bignumber.js": "^9.0.2",
-                        "rxjs": "^6.6.3"
-                    }
-                },
-                "@taquito/utils": {
-                    "version": "13.0.1",
-                    "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-13.0.1.tgz",
-                    "integrity": "sha512-uRtsl4EATlVJ1UnNUiAEoibFFyexGLDLz02CBHoBrcWjqrZdj3AxA+TO63E2kWn/JmT2FM0Sqaqbm555lj4tow==",
-                    "requires": {
-                        "@stablelib/blake2b": "^1.0.1",
-                        "@stablelib/ed25519": "^1.0.2",
-                        "@types/bs58check": "^2.1.0",
-                        "blakejs": "^1.2.1",
-                        "bs58check": "^2.1.2",
-                        "buffer": "^6.0.3",
-                        "elliptic": "^6.5.4",
-                        "typedarray-to-buffer": "^4.0.0"
-                    }
-                },
-                "axios": {
-                    "version": "0.26.1",
-                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-                    "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-                    "requires": {
-                        "follow-redirects": "^1.14.8"
-                    }
-                }
+                "bs58check": "^2.1.2",
+                "eslint": "^8.23.0",
+                "rollup": "^2.79.1",
+                "rollup-plugin-json": "^4.0.0",
+                "rollup-plugin-sourcemaps": "^0.6.3",
+                "rollup-plugin-typescript2": "^0.34.0",
+                "typescript": "^4.7.4"
             }
         },
         "@sinclair/typebox": {

--- a/client/examples/nodejs/package.json
+++ b/client/examples/nodejs/package.json
@@ -11,7 +11,7 @@
     "author": "",
     "license": "MIT",
     "dependencies": {
-        "@marigold-dev/deku-toolkit": "^0.1.6",
+        "@marigold-dev/deku-toolkit": "file:../../",
         "@taquito/signer": "^14.0.0",
         "@taquito/taquito": "^14.0.0",
         "axios": "^0.27.2",

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -1,4 +1,5 @@
 import { DekuSigner } from './utils/signers';
+import * as path from 'path';
 import { TezosToolkit } from '@taquito/taquito';
 import Consensus from './contracts/consensus';
 import Discovery from './contracts/discovery';
@@ -74,7 +75,7 @@ export class DekuToolkit {
 
 
     private async initializeStream(dekuRpc: string) {
-        const streamUri = dekuRpc + "/api/v1/chain/blocks/monitor";
+        const streamUri = path.join(dekuRpc, "/api/v1/chain/blocks/monitor");
         const response = await fetch(streamUri);
         const body = response.body;
         if (!body) return null;

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -1,5 +1,5 @@
 import { DekuSigner } from './utils/signers';
-import * as path from 'path';
+import joinPath from "../utils/paths";
 import { TezosToolkit } from '@taquito/taquito';
 import Consensus from './contracts/consensus';
 import Discovery from './contracts/discovery';
@@ -75,7 +75,7 @@ export class DekuToolkit {
 
 
     private async initializeStream(dekuRpc: string) {
-        const streamUri = path.join(dekuRpc, "/api/v1/chain/blocks/monitor");
+        const streamUri = joinPath(dekuRpc, "/api/v1/chain/blocks/monitor");
         const response = await fetch(streamUri);
         const body = response.body;
         if (!body) return null;

--- a/client/src/network/index.ts
+++ b/client/src/network/index.ts
@@ -3,7 +3,7 @@ import Level, { Level as LevelType } from "../core/level";
 import Block, { Block as BlockType } from "../core/block";
 import Proof, { Proof as ProofType } from "../core/proof";
 import { TicketID } from "../core/ticket-id";
-import * as path from 'path'
+import joinPath from "../utils/paths";
 
 const VERSION = "/api/v1"
 
@@ -27,7 +27,7 @@ export type endpoints = {
 
 export const makeEndpoints = (root: string): endpoints => ({
     "GET_CHAIN_INFO": {
-        uri: path.join(root, `${VERSION}/chain/info`),
+        uri: joinPath(root, `${VERSION}/chain/info`),
         expectedStatus: 200,
         parse: (json: JSONValue) => {
             const consensus = json.at("consensus").as_string();
@@ -38,7 +38,7 @@ export const makeEndpoints = (root: string): endpoints => ({
         }
     },
     "GET_CURRENT_LEVEL": {
-        uri: path.join(root, `${VERSION}/chain/level`),
+        uri: joinPath(root, `${VERSION}/chain/level`),
         expectedStatus: 200,
         parse: (json: JSONValue) => {
             const level_json = json.at("level");
@@ -46,39 +46,39 @@ export const makeEndpoints = (root: string): endpoints => ({
         }
     },
     "GET_BLOCK_BY_LEVEL": (level: LevelType) => ({
-        uri: path.join(root, `${VERSION}/chain/blocks/${Level.toDTO(level)}`),
+        uri: joinPath(root, `${VERSION}/chain/blocks/${Level.toDTO(level)}`),
         expectedStatus: 200,
         parse: Block.ofDTO
     }),
     "GET_BLOCK_BY_HASH": (blockHash: string) => ({
-        uri: path.join(root, `${VERSION}/chain/blocks/${blockHash}`),
+        uri: joinPath(root, `${VERSION}/chain/blocks/${blockHash}`),
         expectedStatus: 200,
         parse: Block.ofDTO
     }),
     "GET_GENESIS": {
-        uri: path.join(root, `${VERSION}/chain/blocks/genesis`),
+        uri: joinPath(root, `${VERSION}/chain/blocks/genesis`),
         expectedStatus: 200,
         parse: Block.ofDTO
     },
     "GET_CURRENT_BLOCK": {
-        uri: path.join(root, `${VERSION}/chain/blocks/genesis`),
+        uri: joinPath(root, `${VERSION}/chain/blocks/genesis`),
         expectedStatus: 200,
         parse: Block.ofDTO
     },
     "GET_BALANCE": (address: string, ticket_id: TicketID) => ({
-        uri: path.join(root, `${VERSION}/balance/${address}/${ticket_id.ticketer}/${ticket_id.data}`),
+        uri: joinPath(root, `${VERSION}/balance/${address}/${ticket_id.ticketer}/${ticket_id.data}`),
         expectedStatus: 200,
         parse: (json: JSONValue) => {
           return json.at("balance").as_int();
         }
     }),
     "GET_PROOF": (operation_hash: string) => ({
-        uri: path.join(root, `${VERSION}/proof/${operation_hash}`),
+        uri: joinPath(root, `${VERSION}/proof/${operation_hash}`),
         expectedStatus: 200,
         parse: Proof.ofDTO
     }),
     "OPERATIONS": {
-        uri: path.join(root, `${VERSION}/operations`),
+        uri: joinPath(root, `${VERSION}/operations`),
         expectedStatus: 200,
         parse: (json: JSONValue) => {
             const hash = json.at("hash").as_string();

--- a/client/src/network/index.ts
+++ b/client/src/network/index.ts
@@ -3,6 +3,7 @@ import Level, { Level as LevelType } from "../core/level";
 import Block, { Block as BlockType } from "../core/block";
 import Proof, { Proof as ProofType } from "../core/proof";
 import { TicketID } from "../core/ticket-id";
+import * as path from 'path'
 
 const VERSION = "/api/v1"
 
@@ -26,7 +27,7 @@ export type endpoints = {
 
 export const makeEndpoints = (root: string): endpoints => ({
     "GET_CHAIN_INFO": {
-        uri: `${root}${VERSION}/chain/info`,
+        uri: path.join(root, `${VERSION}/chain/info`),
         expectedStatus: 200,
         parse: (json: JSONValue) => {
             const consensus = json.at("consensus").as_string();
@@ -37,7 +38,7 @@ export const makeEndpoints = (root: string): endpoints => ({
         }
     },
     "GET_CURRENT_LEVEL": {
-        uri: `${root}${VERSION}/chain/level`,
+        uri: path.join(root, `${VERSION}/chain/level`),
         expectedStatus: 200,
         parse: (json: JSONValue) => {
             const level_json = json.at("level");
@@ -45,39 +46,39 @@ export const makeEndpoints = (root: string): endpoints => ({
         }
     },
     "GET_BLOCK_BY_LEVEL": (level: LevelType) => ({
-        uri: `${root}${VERSION}/chain/blocks/${Level.toDTO(level)}`,
+        uri: path.join(root, `${VERSION}/chain/blocks/${Level.toDTO(level)}`),
         expectedStatus: 200,
         parse: Block.ofDTO
     }),
     "GET_BLOCK_BY_HASH": (blockHash: string) => ({
-        uri: `${root}${VERSION}/chain/blocks/${blockHash}`,
+        uri: path.join(root, `${VERSION}/chain/blocks/${blockHash}`),
         expectedStatus: 200,
         parse: Block.ofDTO
     }),
     "GET_GENESIS": {
-        uri: `${root}${VERSION}/chain/blocks/genesis`,
+        uri: path.join(root, `${VERSION}/chain/blocks/genesis`),
         expectedStatus: 200,
         parse: Block.ofDTO
     },
     "GET_CURRENT_BLOCK": {
-        uri: `${root}${VERSION}/chain/blocks/genesis`,
+        uri: path.join(root, `${VERSION}/chain/blocks/genesis`),
         expectedStatus: 200,
         parse: Block.ofDTO
     },
     "GET_BALANCE": (address: string, ticket_id: TicketID) => ({
-        uri: `${root}${VERSION}/balance/${address}/${ticket_id.ticketer}/${ticket_id.data}`,
+        uri: path.join(root, `${VERSION}/balance/${address}/${ticket_id.ticketer}/${ticket_id.data}`),
         expectedStatus: 200,
         parse: (json: JSONValue) => {
           return json.at("balance").as_int();
         }
     }),
     "GET_PROOF": (operation_hash: string) => ({
-        uri: `${root}${VERSION}/proof/${operation_hash}`,
+        uri: path.join(root, `${VERSION}/proof/${operation_hash}`),
         expectedStatus: 200,
         parse: Proof.ofDTO
     }),
     "OPERATIONS": {
-        uri: `${root}${VERSION}/operations`,
+        uri: path.join(root, `${VERSION}/operations`),
         expectedStatus: 200,
         parse: (json: JSONValue) => {
             const hash = json.at("hash").as_string();


### PR DESCRIPTION
Fixes (one of) Gauthier's bugs:
```
    DekuToolkit({
        dekuRpc: "https://deku-canonical-vm0.deku-v1.marigold.dev/"
```

was making the library fail.