### PR TITLE
Add prefix to crypto

### DIFF
--- a/src/crypto/BLAKE2b.ml
+++ b/src/crypto/BLAKE2b.ml
@@ -30,10 +30,11 @@ struct
   let digest_size = P.digest_size
 
   module With_alg (Alg : Hash_intf.Alg) = struct
-    let sign secret hash = Alg.sign secret (to_raw_string hash)
+    let sign ?(prefix = "") secret hash =
+      Alg.sign secret (prefix ^ to_raw_string hash)
 
-    let verify key signature hash =
-      Alg.verify key signature (to_raw_string hash)
+    let verify ?(prefix = "") key signature hash =
+      Alg.verify key signature (prefix ^ to_raw_string hash)
   end
 
   module With_b58 (P : sig

--- a/src/crypto/alg_intf.mli
+++ b/src/crypto/alg_intf.mli
@@ -63,7 +63,7 @@ module type S = sig
     val size : int
 
     (* operations *)
-    val sign : Secret.t -> BLAKE2b.t -> signature
-    val verify : Key.t -> signature -> BLAKE2b.t -> bool
+    val sign : ?prefix:string -> Secret.t -> BLAKE2b.t -> signature
+    val verify : ?prefix:string -> Key.t -> signature -> BLAKE2b.t -> bool
   end
 end

--- a/src/crypto/ed25519.ml
+++ b/src/crypto/ed25519.ml
@@ -145,14 +145,14 @@ module Signature = struct
     type key = Key.t
     type signature = t
 
-    let sign secret hash =
-      let hash = Cstruct.of_string hash in
-      let signature = sign ~key:secret hash in
+    let sign ?(prefix = "") secret hash =
+      let prefix_and_hash = Cstruct.of_string (prefix ^ hash) in
+      let signature = sign ~key:secret prefix_and_hash in
       Cstruct.to_string signature
 
-    let verify key signature hash =
-      let hash = Cstruct.of_string hash in
+    let verify ?(prefix = "") key signature hash =
+      let prefix_and_hash = Cstruct.of_string (prefix ^ hash) in
       let signature = Cstruct.of_string signature in
-      verify ~key ~msg:hash signature
+      verify ~key ~msg:prefix_and_hash signature
   end)
 end

--- a/src/crypto/hash_intf.mli
+++ b/src/crypto/hash_intf.mli
@@ -5,8 +5,8 @@ module type Alg = sig
   type key
   type signature
 
-  val sign : secret -> string -> signature
-  val verify : key -> signature -> string -> bool
+  val sign : ?prefix:string -> secret -> string -> signature
+  val verify : ?prefix:string -> key -> signature -> string -> bool
 end
 
 module type S = sig
@@ -29,8 +29,8 @@ module type S = sig
   module With_alg (Alg : Alg) : sig
     open Alg
 
-    val sign : secret -> hash -> signature
-    val verify : key -> signature -> hash -> bool
+    val sign : ?prefix:string -> secret -> hash -> signature
+    val verify : ?prefix:string -> key -> signature -> hash -> bool
   end
 
   module With_b58 (_ : sig

--- a/src/crypto/p256.ml
+++ b/src/crypto/p256.ml
@@ -153,17 +153,17 @@ module Signature = struct
     type key = Key.t
     type signature = t
 
-    let sign secret hash =
-      let hash = Cstruct.of_string hash in
+    let sign ?(prefix = "") secret hash =
+      let prefix_and_hash = Cstruct.of_string (prefix ^ hash) in
       (* TODO: explain r and s*)
-      let r, s = sign ~key:secret hash in
+      let r, s = sign ~key:secret prefix_and_hash in
       let signature = Cstruct.append r s in
       Cstruct.to_string signature
 
-    let verify key signature hash =
+    let verify ?(prefix = "") key signature hash =
       let r, s = (String.sub signature 0 32, String.sub signature 32 32) in
       let r, s = (Cstruct.of_string r, Cstruct.of_string s) in
-      let hash = Cstruct.of_string hash in
-      verify ~key (r, s) hash
+      let prefix_and_hash = Cstruct.of_string (prefix ^ hash) in
+      verify ~key (r, s) prefix_and_hash
   end)
 end

--- a/src/crypto/secp256k1.ml
+++ b/src/crypto/secp256k1.ml
@@ -165,12 +165,12 @@ module Signature = struct
     type key = Key.t
     type signature = t
 
-    let sign secret hash =
-      let hash = Bigstring.of_string hash in
-      Sign.sign_exn context ~sk:secret hash
+    let sign ?(prefix = "") secret hash =
+      let prefix_and_hash = Bigstring.of_string (prefix ^ hash) in
+      Sign.sign_exn context ~sk:secret prefix_and_hash
 
-    let verify public signature hash =
-      let hash = Bigstring.of_string hash in
-      Sign.verify_exn context ~pk:public ~msg:hash ~signature
+    let verify ?(prefix = "") public signature hash =
+      let prefix_and_hash = Bigstring.of_string (prefix ^ hash) in
+      Sign.verify_exn context ~pk:public ~msg:prefix_and_hash ~signature
   end)
 end

--- a/src/crypto/tests/test_blake2b.ml
+++ b/src/crypto/tests/test_blake2b.ml
@@ -136,11 +136,11 @@ end = struct
     type key = secret
     type signature = { secret : secret; hash : string }
 
-    let sign secret hash = { secret; hash }
+    let sign ?(prefix = "") secret hash = { secret; hash = prefix ^ hash }
 
-    let verify key signature hash =
+    let verify ?(prefix = "") key signature hash =
       let { secret; hash = signature_hash } = signature in
-      Int.equal secret key && String.equal signature_hash hash
+      Int.equal secret key && String.equal signature_hash (prefix ^ hash)
   end
 
   open With_alg (Dummy_alg)


### PR DESCRIPTION
# Problem
To ensure wallets can sign Deku transactions, we need to identify Deku transactions in the first place.
# Solution
This PR adds an optional prefix to all crypto `sign` and `verify` functions, allowing the inclusion of information about the Deku chain in transaction hashes. This uniquely identifies a transaction hash with a chain, and prevents double spending attacks across different Deku chains.