### PR TITLE
bug/indexer: compress blocks with gzip

### DIFF
--- a/deku-p/src/indexer/dune
+++ b/deku-p/src/indexer/dune
@@ -10,7 +10,8 @@
   deku_concepts
   deku_constants
   deku_gossip
-  ppx_rapper_eio)
+  ppx_rapper_eio
+  ezgzip)
  (preprocess
   (pps
    ppx_rapper

--- a/nix/deku-p/deku.nix
+++ b/nix/deku-p/deku.nix
@@ -50,6 +50,7 @@ with ocamlPackages; buildDunePackage rec {
     routes
     ppx_rapper
     ppx_rapper_eio
+    ezgzip
   ]
   # checkInputs are here because when cross compiling dune needs test dependencies
   # but they are not available for the build phase. The issue can be seen by adding strictDeps = true;.


### PR DESCRIPTION
# Problem:
Indexing all the blocks takes a lot of place on the disk

# Solution ?:
Compressing the blocks with gzip before saving them. 

# Warning
Using gzip algorithm slow down the block insertion in sqlite

Here is some data that show the time to insert a block in sqlite
With gzip:
 - average: 0.048s
 - 95 percentile: 0.054s
 - 99 percentile: 0.069

Without gzip:
 - average: 0.035
 - 95 percentile: 0.038
 - 99 percentile: 0.039

But the size gain is considerable:
- 1k blocks of 10 mb with gzip: 45mb
- 1k blocks of 10 mb without gzip: 9.8gb

The gain of size is significant 


