### PR TITLE
Deku toolkit@0.1.8

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@marigold-dev/deku-toolkit",
-  "version": "0.1.6",
+  "version": "0.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@marigold-dev/deku-toolkit",
-      "version": "0.1.6",
+      "version": "0.1.8",
       "license": "ISC",
       "dependencies": {
         "@taquito/taquito": "^13.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marigold-dev/deku-toolkit",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "toolkit to interact with deku",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
0.1.7 does not work with nodejs because it was publish with `npm run dev` command, I publish 0.1.8 with `npm run build` now.