### PR TITLE
[deku-toolkit] add vmState endpoint and example

### DIFF
--- a/deku-p/deku-toolkit/examples/react/package.json
+++ b/deku-p/deku-toolkit/examples/react/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@airgap/beacon-sdk": "^3.1.3",
-    "@marigold-dev/deku-toolkit": "^0.1.6",
+    "@marigold-dev/deku-toolkit": "^0.1.9",
     "@taquito/beacon-wallet": "^13.0.1",
     "@taquito/signer": "^13.0.1",
     "@taquito/taquito": "^13.0.1",

--- a/deku-p/deku-toolkit/examples/react/src/App.tsx
+++ b/deku-p/deku-toolkit/examples/react/src/App.tsx
@@ -4,8 +4,9 @@ import logo from "./logo.png";
 import {
   DekuToolkit,
   fromMemorySigner,
-} from "@marigold-dev/deku-toolkit";
+} from "deku-toolkit";
 import { InMemorySigner } from "@taquito/signer";
+import { JSONType } from "../../../lib/utils/json";
 
 const containerStyle: CSS.Properties = {
   textAlign: "center",
@@ -21,7 +22,7 @@ const dekuSigner = fromMemorySigner(
 
 const deku = new DekuToolkit({ dekuRpc: "http://localhost:8080", dekuSigner })
   .setTezosRpc("http://localhost:20000")
-  .onBlock((block) => {
+  .onBlock((block: any) => {
     console.log("The client received a block");
     console.log(block);
   });
@@ -31,9 +32,10 @@ const App = () => {
   const [balance, setBalance] = useState(0);
   const [info, setInfo] = useState<{
     consensus: string;
-    discovery: string;
+    // discovery: string;
   } | null>(null);
 
+  const [vmState, setVmState] = useState<JSONType>(null);
   const [isActive, setIsActive] = useState(false);
   const setActive = () => setIsActive(true);
 
@@ -97,6 +99,18 @@ const App = () => {
     findBlockExample().then(console.log).catch(console.error);
   }, []);
 
+  /*
+* Example to retrieve vm state from the chain
+*/
+  const getVmStateExample = async () => {
+    const state = await deku.getVmState();
+    return state;
+  };
+
+  useEffect(() => {
+    getVmStateExample().then(setVmState).catch(console.error);
+  }, []);
+
   /**
    * How to make a transfer
    */
@@ -157,9 +171,10 @@ const App = () => {
     <div style={containerStyle}>
       <img src={logo} alt="deku logo" />
       {info && <div>Consensus : {info.consensus} </div>}
-      {info && <div>Discovery : {info.discovery} </div>}
+      {/* {info && <div>Discovery : {info.discovery} </div>} */}
       <div>Level : {level} </div>
       <div>Balance : {balance}</div>
+      <div>State : {JSON.stringify(vmState)}</div>
 
       <>
         <input
@@ -186,6 +201,10 @@ const App = () => {
         <button
           onClick={() => withdrawExample()}
           children="Withdraw (to same address as the ticketer)"
+        />
+        <button
+          onClick={() => getVmStateExample()}
+          children="VM State"
         />
       </>
     </div>

--- a/deku-p/deku-toolkit/examples/react/src/App.tsx
+++ b/deku-p/deku-toolkit/examples/react/src/App.tsx
@@ -6,7 +6,6 @@ import {
   fromMemorySigner,
 } from "deku-toolkit";
 import { InMemorySigner } from "@taquito/signer";
-import { JSONType } from "../../../lib/utils/json";
 
 const containerStyle: CSS.Properties = {
   textAlign: "center",
@@ -35,7 +34,7 @@ const App = () => {
     // discovery: string;
   } | null>(null);
 
-  const [vmState, setVmState] = useState<JSONType>(null);
+  const [vmState, setVmState] = useState<any>(null);
   const [isActive, setIsActive] = useState(false);
   const setActive = () => setIsActive(true);
 
@@ -203,7 +202,7 @@ const App = () => {
           children="Withdraw (to same address as the ticketer)"
         />
         <button
-          onClick={() => getVmStateExample()}
+          onClick={() => getVmStateExample().then(setVmState).catch(console.error)}
           children="VM State"
         />
       </>

--- a/deku-p/deku-toolkit/package.json
+++ b/deku-p/deku-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marigold-dev/deku-toolkit",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "toolkit to interact with deku",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/deku-p/deku-toolkit/src/index.ts
+++ b/deku-p/deku-toolkit/src/index.ts
@@ -12,7 +12,7 @@ import { OperationHash as OperationHashType } from "./core/operation-hash";
 import TicketID from './core/ticket-id';
 import { endpoints, get, makeEndpoints, post } from "./network";
 import { hashOperation } from './utils/hash';
-import JSONValue from './utils/json';
+import JSONValue, { JSONType } from './utils/json';
 import { DekuSigner } from './utils/signers';
 import urlJoin from "./utils/urlJoin";
 export type Proof = import('./core/proof').Proof;
@@ -228,6 +228,11 @@ export class DekuToolkit {
     async getProof(operation_hash: string): Promise<Proof> {
         const proof = await get(this.endpoints["GET_PROOF"](operation_hash));
         return proof
+    }
+
+    async getVmState(): Promise<JSONType> {
+        const state = await get(this.endpoints["GET_VM_STATE"]);
+        return state
     }
 
     /**

--- a/deku-p/deku-toolkit/src/network/index.ts
+++ b/deku-p/deku-toolkit/src/network/index.ts
@@ -27,6 +27,7 @@ export type endpoints = {
     "GET_BALANCE": (address: string, ticket_id: TicketID) => endpoint<number>,
     "GET_PROOF": (operation_hash: string) => endpoint<ProofType>
     "OPERATIONS": endpoint<string>,
+    "GET_VM_STATE": endpoint<JSONType>
 }
 
 export const makeEndpoints = (root: string): endpoints => ({
@@ -87,6 +88,14 @@ export const makeEndpoints = (root: string): endpoints => ({
         parse: (json: JSONValue) => {
             const hash = json.at("hash").as_string();
             return hash;
+        }
+    },
+    "GET_VM_STATE": {
+        uri: urlJoin(root, `${VERSION}/state/unix`),
+        expectedStatus: 200,
+        parse: (json: JSONValue) => {
+            const state = json.as_json();
+            return state;
         }
     },
 })


### PR DESCRIPTION
## Context

Get VM state was missing in Deku Toolkit.
This PR aims to add it.

## This PR contains

- new function available in deku-toolkit to fetch VM State
- example of the previous point in the `react-app`
- use local deku-toolkit in the react example
- changed version of deku-toolkit to 0.1.9 (not published)
