### PR TITLE
Fix e2e tests

### DIFF
--- a/deku-p/src/core/tezos_interop/tests/proof_test.ml
+++ b/deku-p/src/core/tezos_interop/tests/proof_test.ml
@@ -50,7 +50,8 @@ let main operation_hash verbose host =
                (BLAKE2b.to_hex left) (BLAKE2b.to_hex right))
            proof
         |> String.concat " ;\n" |> String.trim);
-      print_endline "")
+      print_endline "";
+      exit 0)
 
 open Cmdliner
 

--- a/deku-p/src/core/tezos_interop/tests/transaction_test.ml
+++ b/deku-p/src/core/tezos_interop/tests/transaction_test.ml
@@ -29,7 +29,8 @@ let main ticket_id receiver secret verbose host =
   Printf.eprintf "%d\n%!" code;
   let (Operation.Operation { hash; _ }) = operation in
   let hash = Operation_hash.to_blake2b hash in
-  Printf.printf "operation.hash: %s\n%!" (BLAKE2b.to_hex hash)
+  Printf.printf "operation.hash: %s\n%!" (BLAKE2b.to_hex hash);
+  exit 0
 
 open Cmdliner
 

--- a/deku-p/src/core/tezos_interop/tests/withdraw_test.ml
+++ b/deku-p/src/core/tezos_interop/tests/withdraw_test.ml
@@ -35,7 +35,8 @@ let main ticket_id tezos_owner secret verbose host =
   if verbose then (
     Printf.eprintf "operation code: %s\n%!"
       (Operation.yojson_of_t transaction |> Yojson.Safe.to_string);
-    prerr_endline "operation broadcasted")
+    prerr_endline "operation broadcasted");
+  exit 0
 (*  we can't test that the withdraws succeeded at this point *)
 
 open Cmdliner

--- a/scripts/deploy_contracts.sh
+++ b/scripts/deploy_contracts.sh
@@ -54,7 +54,7 @@ then
   storage_path=${1:-./networks/flextesa}
 
   deploy_contract "consensus" \
-      "./deku-p/src/tezos_interop/consensus.mligo" \
+      "./deku-p/src/core/tezos_interop/consensus.mligo" \
       "$(cat "$storage_path/consensus_storage.mligo")"
 
   deploy_contract "dummy_ticket" \

--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -98,7 +98,7 @@ local-setup() {
 
     # Starts the Node
     _build/install/default/bin/deku-node \
-      --default-block-size=1000 \
+      --default-block-size=10000 \
       --port "444$N" \
       --database-uri "sqlite3:./flextesa_chain/data/$N/database.db" \
       --named-pipe-path "./flextesa_chain/data/$N/pipe" \

--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -124,7 +124,7 @@ run-test() {
 
   ticket_data="Pair \"$DUMMY_TICKET_ADDRESS\" 0x"
 
-  sleep 10
+  sleep 20
 
   # We do 3 withdraws:
   # Withdraw 1 proof should not change (except for the tree)
@@ -142,35 +142,35 @@ run-test() {
   fi
 
   message Withdraw 1
-  op_hash1="$(dune exec src/tezos_interop/tests/withdraw_test.exe "$ticket_data" $DUMMY_TICKET_ADDRESS $secret1 | sed -n 's/operation.hash: "\(Do[[:alnum:]]*\)"/\1/p')"
+  op_hash1="$(dune exec deku-p/src/core/tezos_interop/tests/withdraw_test.exe "$ticket_data" $DUMMY_TICKET_ADDRESS $secret1 | sed -n 's/operation.hash: "\(Do[[:alnum:]]*\)"/\1/p')"
 
   message Transfer to $tz_addr2
 
-  dune exec src/tezos_interop/tests/transaction_test.exe "$ticket_data" $tz_addr2 $secret1
+  dune exec deku-p/src/core/tezos_interop/tests/transaction_test.exe "$ticket_data" $tz_addr2 $secret1
 
   sleep 3
 
   message Proof of withdraw 1
-  proof1_1=$(dune exec src/tezos_interop/tests/proof_test.exe $op_hash1)
+  proof1_1=$(dune exec deku-p/src/core/tezos_interop/tests/proof_test.exe $op_hash1)
 
   message Withdraw 2
-  op_hash2="$(dune exec src/tezos_interop/tests/withdraw_test.exe "$ticket_data" $DUMMY_TICKET_ADDRESS $secret2 | sed -n 's/operation.hash: "\(Do[[:alnum:]]*\)"/\1/p')" || exit 1
+  op_hash2="$(dune exec deku-p/src/core/tezos_interop/tests/withdraw_test.exe "$ticket_data" $DUMMY_TICKET_ADDRESS $secret2 | sed -n 's/operation.hash: "\(Do[[:alnum:]]*\)"/\1/p')" || exit 1
 
   sleep 2
 
   message Withdraw 3
-  op_hash3="$(dune exec src/tezos_interop/tests/withdraw_test.exe "$ticket_data" $DUMMY_TICKET_ADDRESS $secret2 | sed -n 's/operation.hash: "\(Do[[:alnum:]]*\)"/\1/p')" || exit 1
+  op_hash3="$(dune exec deku-p/src/core/tezos_interop/tests/withdraw_test.exe "$ticket_data" $DUMMY_TICKET_ADDRESS $secret2 | sed -n 's/operation.hash: "\(Do[[:alnum:]]*\)"/\1/p')" || exit 1
 
   sleep 15 # FIXME check how long we have to wait
 
   message Proof of withdraw 3
-  proof3_1=$(dune exec src/tezos_interop/tests/proof_test.exe $op_hash3)
+  proof3_1=$(dune exec deku-p/src/core/tezos_interop/tests/proof_test.exe $op_hash3)
 
   message Proof of withdraw 2
-  proof2_1=$(dune exec src/tezos_interop/tests/proof_test.exe $op_hash2)
+  proof2_1=$(dune exec deku-p/src/core/tezos_interop/tests/proof_test.exe $op_hash2)
 
   message Proof of withdraw 1, again
-  proof1_2=$(dune exec src/tezos_interop/tests/proof_test.exe $op_hash1)
+  proof1_2=$(dune exec deku-p/src/core/tezos_interop/tests/proof_test.exe $op_hash1)
 
   sleep 30
 


### PR DESCRIPTION
# Problem:
 - The e2e tests are not working anymore after the migration to the monorepo architecture

# Solution: 
 - Adapt some paths in test scripts
 - force exit in eio
