### PR TITLE
adds interface to tezos data used in testing

### DIFF
--- a/deku-p/src/core/crypto/tests/tezos_test_data.ml
+++ b/deku-p/src/core/crypto/tests/tezos_test_data.ml
@@ -1,0 +1,23 @@
+module type Tezos_data = sig
+  val public_keys : string list
+  val compared_secret_keys : string list
+  val equality_secret_keys : bool
+  val secret_key_encoding : int list
+  val compared_public_keys : string list
+  val equality_public_keys : bool
+  val public_key_encoding : int list
+  val compared_key_hashes : string list
+  val equality_key_hash : bool
+  val public_key_hash_encoding : int list
+  val to_sign : string
+  val signatures : string
+  val verified_normal_signatures : bool list list
+  val verified_after_conversion : bool list list
+  val all_verified_normal : bool
+  val all_verified_post_conversion : bool
+  val compare_signatures : string
+  val equality_signatures : bool
+  val signature_encoding : int list
+  val zero : string
+  val size : int
+end


### PR DESCRIPTION
# Problem 
We want to prevent regressions in `Deku_crypto`
# Solution
This is the head of a PR chain which will eventually add tests using data generated on Tezos as the source of truth.
This PR adds an interface to the generated Tezos data
