### PR TITLE
Initial crypto tests 

### DIFF
--- a/deku-p/src/core/crypto/tests/alg_intf_tests.ml
+++ b/deku-p/src/core/crypto/tests/alg_intf_tests.ml
@@ -9,9 +9,8 @@ module Test_gen (Crypto : sig
 
   val ids : id list
 end)
-(Tezos_data : Tezos_test_data.Tezos_data) : sig
-  val run : unit -> unit
-end = struct
+(Tezos_data : Tezos_test_data.Tezos_data)  
+ = struct
   open Crypto
 
   module Secret_key_data = struct
@@ -29,5 +28,4 @@ end = struct
         ~actual:public_keys
   end
 
-  let run () = Test_secret_key_data.public_keys ()
 end

--- a/deku-p/src/core/crypto/tests/alg_intf_tests.ml
+++ b/deku-p/src/core/crypto/tests/alg_intf_tests.ml
@@ -1,0 +1,33 @@
+module Test_gen (Crypto : sig
+  include Deku_crypto.Alg_intf.S
+
+  type id = {
+    public_key_hash : Key_hash.t;
+    public_key : Key.t;
+    secret_key : Secret.t;
+  }
+
+  val ids : id list
+end)
+(Tezos_data : Tezos_test_data.Tezos_data) : sig
+  val run : unit -> unit
+end = struct
+  open Crypto
+
+  module Secret_key_data = struct
+    let secret_keys = List.map (fun id -> id.secret_key) ids
+    let public_keys = List.map (fun sk -> Key.of_secret sk) secret_keys
+  end
+
+  module Test_secret_key_data = struct
+    let public_keys () =
+      let public_keys =
+        List.map (fun pk -> Key.to_b58 pk) Secret_key_data.public_keys
+      in
+      Alcotest.(check' (list string))
+        ~msg:"public keys are equal" ~expected:Tezos_data.public_keys
+        ~actual:public_keys
+  end
+
+  let run () = Test_secret_key_data.public_keys ()
+end

--- a/deku-p/src/core/crypto/tests/data_for_tests/data_gen.txt
+++ b/deku-p/src/core/crypto/tests/data_for_tests/data_gen.txt
@@ -1,0 +1,83 @@
+(* This script will generate all the data used in the Alg_intf tests 
+
+Build in a project with tezos-crypto with the following dune file:
+(executable
+ (name data_gen)
+ (libraries tezos_crypto)
+ (preprocess
+  (pps ppx_deriving_yojson)))
+
+ *)
+
+open Tezos_crypto
+
+type ed25519_id = {
+  public_key_hash : Ed25519.Public_key_hash.t;
+  public_key : Ed25519.Public_key.t;
+  secret_key : Ed25519.Secret_key.t;
+}
+
+let index = Atomic.make 0
+
+let get_incr () =
+  Atomic.incr index ;
+  Atomic.get index
+
+let get_ed25519_id () =
+  let open Ed25519 in
+  let a, b, c = generate_key () in
+  Format.printf
+    "let e%d = {public_key_hash = Public_key_hash.of_b58check_exn \"%s\";\n\
+    \    public_key = Public_key.of_b58check_exn \"%s\";\n\
+    \    secret_key = Secret_key.of_b58check_exn \"%s\";}\n\
+     %!"
+    (get_incr ())
+    (Public_key_hash.to_b58check a)
+    (Public_key.to_b58check b)
+    (Secret_key.to_b58check c)
+
+let spc () = Format.eprintf "\n%!
+
+let generate_identities () = 
+  get_ed25519_id () ;
+  spc () ;
+  get_ed25519_id () ;
+  spc () ;
+  get_ed25519_id () ;
+  spc () ;
+  get_ed25519_id () ;
+  spc () ;
+  get_ed25519_id ()
+  
+
+module Data_gen (Crypto : sig
+  include S.SIGNATURE
+
+  include S.RAW_DATA with type t := t
+
+  type id = {
+    public_key_hash : Public_key_hash.t;
+    public_key : Public_key.t;
+    secret_key : Secret_key.t;
+  }
+
+  val ids : id list
+end) =
+struct
+  open Crypto
+  
+  module Skt_key = struct
+    let secret_keys = List.map (fun id -> id.secret_key) ids
+
+    let public_keys =
+      List.map (fun sk -> Secret_key.to_public_key sk) secret_keys
+  end
+  module Print_secret_key = struct 
+    let print_public_keys () =
+      Format.printf "let public_keys = [\n%!" ;
+      List.iter
+        (fun pk -> Format.printf "\"%s\";\n%!" (Public_key.to_b58check pk))
+        Skt_key.public_keys ;
+      Format.printf "]\n%!
+  end
+end

--- a/deku-p/src/core/crypto/tests/deku_crypto_tests.ml
+++ b/deku-p/src/core/crypto/tests/deku_crypto_tests.ml
@@ -1,1 +1,2 @@
 let () = Test_blake2b.run ()
+let () = Test_ed25519.run ()

--- a/deku-p/src/core/crypto/tests/test_ed25519.ml
+++ b/deku-p/src/core/crypto/tests/test_ed25519.ml
@@ -77,4 +77,11 @@ end
 
 module Tests = Alg_intf_tests.Test_gen (Crypto) (Tezos_test_data.Ed25519_data)
 
-let run () = Tests.run ()
+let run () =
+  let open Alcotest in
+  let open Tests in
+  run "Ed25519 tezos data tests" ~and_exit:false
+    [
+      ( "Secret key",
+        [ test_case "public_keys" `Quick Test_secret_key_data.public_keys ] );
+    ]

--- a/deku-p/src/core/crypto/tests/test_ed25519.ml
+++ b/deku-p/src/core/crypto/tests/test_ed25519.ml
@@ -1,0 +1,80 @@
+module Crypto = struct
+  include Deku_crypto.Ed25519
+
+  type id = {
+    public_key_hash : Key_hash.t;
+    public_key : Key.t;
+    secret_key : Secret.t;
+  }
+
+  let e1 =
+    {
+      public_key_hash =
+        Option.get @@ Key_hash.of_b58 "tz1NS9mkwQxD2jgH8kiGVPD33VmLXVVe3wug";
+      public_key =
+        Option.get
+        @@ Key.of_b58 "edpktgopG88M5eE8M6N1ZtHbYzDCXRnGXk9vhNrLnYp9CA6aVyMRXa";
+      secret_key =
+        Option.get
+        @@ Secret.of_b58
+             "edsk2kvYWbhbdg6CsgwkZ3svMR76zSJyWUGmpWrRgDRJGJDxZ7aiK3";
+    }
+
+  let e2 =
+    {
+      public_key_hash =
+        Option.get @@ Key_hash.of_b58 "tz1iijagWhWfmG3Cmx7oJ62EkQByPG2foNBU";
+      public_key =
+        Option.get
+        @@ Key.of_b58 "edpkvLs7dfWXcdx62iEW5wpYfn8yKPuj446BCRhEbevMMbSSE9G1Yn";
+      secret_key =
+        Option.get
+        @@ Secret.of_b58
+             "edsk4MXvxxHjZKJuW6Rgr1C6tkt6Mwx39o9Tpowco7JjncmSfNb2GF";
+    }
+
+  let e3 =
+    {
+      public_key_hash =
+        Option.get @@ Key_hash.of_b58 "tz1LMf9NoTATvLJ7EQjYDzy7XZZ9KHjei5jH";
+      public_key =
+        Option.get
+        @@ Key.of_b58 "edpkvGJ8FdbDSrACkSEzWD1veGeoBQgCTKyX4SVvBc1TBRwcWrbRDQ";
+      secret_key =
+        Option.get
+        @@ Secret.of_b58
+             "edsk48oQs2NkiDDNmGfiNnt3NQzL34Cy3tvy9YRCB3RBFXVkkoWnha";
+    }
+
+  let e4 =
+    {
+      public_key_hash =
+        Option.get @@ Key_hash.of_b58 "tz1aBiQ188pozN9JuSvwUPpkZoajCG6AT7XX";
+      public_key =
+        Option.get
+        @@ Key.of_b58 "edpkvK2woY7vgguhuTZQDVM1hCjbVrEB2dhGVejvgQxHEoGgYqJNuD";
+      secret_key =
+        Option.get
+        @@ Secret.of_b58
+             "edsk44dngys12G6hnRf1VJVTVRcxJWF3nxpPLgKtVJpLzS56eRnYrJ";
+    }
+
+  let e5 =
+    {
+      public_key_hash =
+        Option.get @@ Key_hash.of_b58 "tz1UDkGwdCYTyZMG1wwMWMfmbiRtagvP3kXg";
+      public_key =
+        Option.get
+        @@ Key.of_b58 "edpkutzyeRZkzmcGxQZr7gXTH7Cf7ygDsrn5LSZ2bffHpCeTACB4su";
+      secret_key =
+        Option.get
+        @@ Secret.of_b58
+             "edsk41Sr6vNDRPenQMNBs11huD26wYMeuJqjFsnC7mNaidVEWuJyh8";
+    }
+
+  let ids = [ e1; e2; e3; e4; e5 ]
+end
+
+module Tests = Alg_intf_tests.Test_gen (Crypto) (Tezos_test_data.Ed25519_data)
+
+let run () = Tests.run ()

--- a/deku-p/src/core/crypto/tests/tezos_test_data.ml
+++ b/deku-p/src/core/crypto/tests/tezos_test_data.ml
@@ -1,0 +1,14 @@
+module type Tezos_data = sig
+  val public_keys : string list
+end
+
+module Ed25519_data : Tezos_data = struct
+  let public_keys =
+    [
+      "edpktgopG88M5eE8M6N1ZtHbYzDCXRnGXk9vhNrLnYp9CA6aVyMRXa";
+      "edpkvLs7dfWXcdx62iEW5wpYfn8yKPuj446BCRhEbevMMbSSE9G1Yn";
+      "edpkvGJ8FdbDSrACkSEzWD1veGeoBQgCTKyX4SVvBc1TBRwcWrbRDQ";
+      "edpkvK2woY7vgguhuTZQDVM1hCjbVrEB2dhGVejvgQxHEoGgYqJNuD";
+      "edpkutzyeRZkzmcGxQZr7gXTH7Cf7ygDsrn5LSZ2bffHpCeTACB4su";
+    ]
+end


### PR DESCRIPTION
## Problem

We want to prevent regressions in the Deku_crypto library

## Solution

This PR sets up all the infrastructure for running tests on `Alg_intf.S` and provides a single example test.

## Related

This is the head of a chain which will incorporate regression tests for `Alg_intf.S`.
 