### PR TITLE
Add crypto secret key comparison test

### DIFF
--- a/deku-p/src/core/crypto/tests/alg_intf_tests.ml
+++ b/deku-p/src/core/crypto/tests/alg_intf_tests.ml
@@ -16,6 +16,7 @@ struct
   module Secret_key_data = struct
     let secret_keys = List.map (fun id -> id.secret_key) ids
     let public_keys = List.map (fun sk -> Key.of_secret sk) secret_keys
+    let compared_secret_keys = List.sort Secret.compare secret_keys
   end
 
   module Test_secret_key_data = struct
@@ -26,5 +27,15 @@ struct
       Alcotest.(check' (list string))
         ~msg:"public keys are equal" ~expected:Tezos_data.public_keys
         ~actual:public_keys
+
+    let compare () =
+      let compared_secret_keys =
+        List.map
+          (fun sk -> Secret.to_b58 sk)
+          Secret_key_data.compared_secret_keys
+      in
+      Alcotest.(check' (list string))
+        ~msg:"secret key comparison works"
+        ~expected:Tezos_data.compared_secret_keys ~actual:compared_secret_keys
   end
 end

--- a/deku-p/src/core/crypto/tests/data_for_tests/data_gen.txt
+++ b/deku-p/src/core/crypto/tests/data_for_tests/data_gen.txt
@@ -71,6 +71,9 @@ struct
 
     let public_keys =
       List.map (fun sk -> Secret_key.to_public_key sk) secret_keys
+      
+    let compare_secret_keys = List.sort Secret_key.compare secret_key
+
   end
   module Print_secret_key = struct 
     let print_public_keys () =
@@ -78,6 +81,13 @@ struct
       List.iter
         (fun pk -> Format.printf "\"%s\";\n%!" (Public_key.to_b58check pk))
         Skt_key.public_keys ;
+      Format.printf "]\n%!
+
+    let print_compare_secret_keys () =
+      Format.printf "let compared_secret_keys = [\n%!" ;
+      List.iter
+        (fun sk -> Format.printf "\"%s\"\n%!;" (Secret_key.to_b58check sk))
+        Skt_key.compare_secret_keys ;
       Format.printf "]\n%!
   end
 end

--- a/deku-p/src/core/crypto/tests/test_ed25519.ml
+++ b/deku-p/src/core/crypto/tests/test_ed25519.ml
@@ -83,5 +83,8 @@ let run () =
   run "Ed25519 tezos data tests" ~and_exit:false
     [
       ( "Secret key",
-        [ test_case "public_keys" `Quick Test_secret_key_data.public_keys ] );
+        [
+          test_case "public keys" `Quick Test_secret_key_data.public_keys;
+          test_case "compare" `Quick Test_secret_key_data.compare;
+        ] );
     ]

--- a/deku-p/src/core/crypto/tests/tezos_test_data.ml
+++ b/deku-p/src/core/crypto/tests/tezos_test_data.ml
@@ -1,5 +1,6 @@
 module type Tezos_data = sig
   val public_keys : string list
+  val compared_secret_keys : string list
 end
 
 module Ed25519_data : Tezos_data = struct
@@ -10,5 +11,14 @@ module Ed25519_data : Tezos_data = struct
       "edpkvGJ8FdbDSrACkSEzWD1veGeoBQgCTKyX4SVvBc1TBRwcWrbRDQ";
       "edpkvK2woY7vgguhuTZQDVM1hCjbVrEB2dhGVejvgQxHEoGgYqJNuD";
       "edpkutzyeRZkzmcGxQZr7gXTH7Cf7ygDsrn5LSZ2bffHpCeTACB4su";
+    ]
+
+  let compared_secret_keys =
+    [
+      "edsk2kvYWbhbdg6CsgwkZ3svMR76zSJyWUGmpWrRgDRJGJDxZ7aiK3";
+      "edsk41Sr6vNDRPenQMNBs11huD26wYMeuJqjFsnC7mNaidVEWuJyh8";
+      "edsk44dngys12G6hnRf1VJVTVRcxJWF3nxpPLgKtVJpLzS56eRnYrJ";
+      "edsk48oQs2NkiDDNmGfiNnt3NQzL34Cy3tvy9YRCB3RBFXVkkoWnha";
+      "edsk4MXvxxHjZKJuW6Rgr1C6tkt6Mwx39o9Tpowco7JjncmSfNb2GF";
     ]
 end


### PR DESCRIPTION
## Depends

- [x] #937 

## Problem

We want to make sure our secret key comparison matches Tezos'
## Solution

This PR uses the secret key comparison to sort a list of secret keys and compare the result with Tezos' output for a similar function
 