### PR TITLE
feat: endpoint to query operation receipt

### DIFF
--- a/deku-p/src/core/bin/api/api_error.ml
+++ b/deku-p/src/core/bin/api/api_error.ml
@@ -12,6 +12,7 @@ type error_kind =
   | Endpoint_not_found
   | Operation_not_found
   | Operation_is_not_a_withdraw
+  | Receipt_not_found
 
 type error = { kind : error_kind; msg : string }
 type t = error
@@ -74,6 +75,12 @@ let operation_is_not_a_withdraw operation_hash =
         (Operation_hash.to_b58 operation_hash);
   }
 
+let receipt_not_found operation_hash = 
+  {
+    kind = Receipt_not_found;
+    msg = Format.sprintf "The receipt of the operation [%s] is not found, maybe your operation is not yet included" (Operation_hash.to_b58 operation_hash)
+  }
+
 module Repr = struct
   type t = { code : string; msg : string } [@@deriving yojson_of]
 
@@ -91,6 +98,7 @@ module Repr = struct
       | Endpoint_not_found -> "ENDPOINT_NOT_FOUND"
       | Operation_not_found -> "OPERATION_NOT_FOUND"
       | Operation_is_not_a_withdraw -> "OPERATION_IS_NOT_A_WITHDRAW"
+      | Receipt_not_found -> "RECEIPT_NOT_FOUND"
     in
     { code; msg }
 end
@@ -110,3 +118,4 @@ let to_http_code { kind; _ } =
   | Endpoint_not_found -> 404
   | Operation_not_found -> 404
   | Operation_is_not_a_withdraw -> 400
+  | Receipt_not_found -> 404

--- a/deku-p/src/core/bin/api/api_error.mli
+++ b/deku-p/src/core/bin/api/api_error.mli
@@ -12,6 +12,7 @@ type error_kind = private
   | Endpoint_not_found
   | Operation_not_found
   | Operation_is_not_a_withdraw
+  | Receipt_not_found
 
 type error = private { kind : error_kind; msg : string }
 type t = error
@@ -27,6 +28,7 @@ val method_not_allowed : string -> Piaf.Method.t -> error
 val endpoint_not_found : string -> error
 val operation_not_found : Operation_hash.t -> error
 val operation_is_not_a_withdraw : Operation_hash.t -> error
+val receipt_not_found: Operation_hash.t -> error
 
 (* Utils *)
 val yojson_of_t : error -> Yojson.Safe.t

--- a/deku-p/src/core/bin/api/deku_api.ml
+++ b/deku-p/src/core/bin/api/deku_api.ml
@@ -103,6 +103,7 @@ let start_api ~env ~sw ~port ~state =
        |> Server.without_body (module Get_vm_state_key)
        |> Server.without_body (module Get_stats)
        |> Server.with_body (module Get_hexa_to_signed)
+       |> Server.without_body (module Get_receipt)
        |> Server.make_handler ~state)
   in
   let config = Piaf.Server.Config.create port in

--- a/deku-p/src/core/bin/api/handlers.ml
+++ b/deku-p/src/core/bin/api/handlers.ml
@@ -324,3 +324,19 @@ module Get_hexa_to_signed : HANDLERS = struct
     let bytes = binary |> Hex.of_string |> Hex.show in
     Ok { bytes }
 end
+
+module Get_receipt : NO_BODY_HANDLERS = struct
+  type path = Operation_hash.t
+  type response = Receipt.t [@@deriving yojson]
+
+  let meth = `GET
+  let path = Routes.(version / s "operations" / Api_path.Operation_hash.parser /? nil)
+  let route = Routes.(path @--> fun hash -> hash)
+
+  let handler ~path:operation_hash ~state = 
+    let Api_state.{receipts; _} = state in
+    let receipt = Operation_hash.Map.find_opt operation_hash receipts in
+    match receipt with
+      | Some receipt -> Ok receipt
+      | None -> Error (Api_error.receipt_not_found operation_hash)
+end


### PR DESCRIPTION
# Problem:

It's impossible to know if an operation has been included. Except by pulling each second the state

# Solution:
Add a way to get the receipt of an operation