### PR TITLE
feat: endpoint to get the contract hash

### DIFF
--- a/deku-p/src/core/bin/api/deku_api.ml
+++ b/deku-p/src/core/bin/api/deku_api.ml
@@ -104,6 +104,7 @@ let start_api ~env ~sw ~port ~state =
        |> Server.without_body (module Get_stats)
        |> Server.with_body (module Get_hexa_to_signed)
        |> Server.without_body (module Get_receipt)
+       |> Server.with_body (module Compute_contract_hash)
        |> Server.make_handler ~state)
   in
   let config = Piaf.Server.Config.create port in

--- a/deku-p/src/core/bin/api/handlers.ml
+++ b/deku-p/src/core/bin/api/handlers.ml
@@ -343,3 +343,20 @@ module Get_receipt : NO_BODY_HANDLERS = struct
     | Some receipt -> Ok receipt
     | None -> Error (Api_error.receipt_not_found operation_hash)
 end
+
+module Compute_contract_hash : HANDLERS = struct
+  type path = unit
+  type body = { hash : Operation_hash.t } [@@deriving of_yojson]
+
+  type response = { address : Deku_ledger.Contract_address.t }
+  [@@deriving yojson_of]
+
+  let meth = `POST
+  let path = Routes.(version / s "helpers" / s "compute-contract-hash" /? nil)
+  let route = Routes.(path @--> ())
+
+  let handler ~path:() ~body:{ hash } ~state:_ =
+    let blake2b = Operation_hash.to_blake2b hash in
+    let address = Deku_ledger.Contract_address.of_user_operation_hash blake2b in
+    Ok { address }
+end

--- a/deku-p/src/core/ledger/contract_address.ml
+++ b/deku-p/src/core/ledger/contract_address.ml
@@ -5,7 +5,7 @@ open BLAKE2b_160
 
 type t = BLAKE2b_160.t [@@deriving eq, ord, show]
 
-let of_user_operation_hash t = BLAKE2b_256.to_raw t |> BLAKE2b_160.hash
+let of_user_operation_hash t = BLAKE2b_256.to_hex t |> BLAKE2b_160.hash
 
 include With_b58_and_encoding_and_yojson (struct
   let name = "Deku_contract_hash"


### PR DESCRIPTION
# Problem:

Origination of a contract on deku only gives us a operation hash

# Solution:

Add an helper in the api to compute the contract address