### PR TITLE
Fixes newlines in logs and cycles drops

### DIFF
--- a/deku-p/src/core/bin/node/deku_node.ml
+++ b/deku-p/src/core/bin/node/deku_node.ml
@@ -15,7 +15,7 @@ let make_dump_loop ~sw ~env ~folder =
     let chain = Eio.Promise.await promise in
     (try Storage.Chain.write ~env ~folder chain
      with exn ->
-       Logs.err (fun m -> m "storage.failure: %s\n%!" (Printexc.to_string exn)));
+       Logs.err (fun m -> m "storage.failure: %s" (Printexc.to_string exn)));
     loop ()
   in
   let dump chain =
@@ -144,7 +144,7 @@ let main params style_renderer log_level =
 
   let (Chain { consensus; _ }) = chain in
   let (Block { level; _ }) = Deku_consensus.Consensus.trusted_block consensus in
-  Logs.info (fun m -> m "Chain started at level: %a\n%!" Level.pp level);
+  Logs.info (fun m -> m "Chain started at level: %a" Level.pp level);
   let tezos =
     (tezos_rpc_node, Secret.Ed25519 tezos_secret, tezos_consensus_address)
   in
@@ -152,7 +152,7 @@ let main params style_renderer log_level =
 
 let main () =
   Sys.set_signal Sys.sigpipe
-    (Sys.Signal_handle (fun _ -> Logs.err (fun m -> m "SIGPIPE\n%!")));
+    (Sys.Signal_handle (fun _ -> Logs.err (fun m -> m "SIGPIPE")));
 
   let control = Gc.get () in
   let control = { control with minor_heap_size = 2048; space_overhead = 60 } in

--- a/deku-p/src/core/bin/node/node.ml
+++ b/deku-p/src/core/bin/node/node.ml
@@ -173,7 +173,7 @@ let start ~sw ~env ~port ~nodes ~tezos node =
       node.network
   in
   let on_message ~raw_header ~raw_content =
-    (* Logs.info (fun m -> m "incoming(%.3f): %s\n%!" (Unix.gettimeofday ()) raw_header;) *)
+    (* Logs.info (fun m -> m "incoming(%.3f): %s" (Unix.gettimeofday ()) raw_header;) *)
     on_network_message ~sw ~env ~raw_header ~raw_content node
   in
   let on_request ~connection ~raw_header ~raw_content =

--- a/deku-p/src/core/chain/chain.ml
+++ b/deku-p/src/core/chain/chain.ml
@@ -185,7 +185,7 @@ let incoming_block ~identity ~current ~block chain =
 let incoming_vote ~current ~level ~vote chain =
   (* let () =
        let key_hash = Verified_signature.key_hash vote in
-       Logs.info (fun m -> m "incoming.vote(%.3f): %s\n%!" (Unix.gettimeofday ())
+       Logs.info (fun m -> m "incoming.vote(%.3f): %s" (Unix.gettimeofday ())
          (Deku_crypto.Key_hash.to_b58 key_hash))
      in *)
   let (Chain ({ consensus; _ } as chain)) = chain in
@@ -216,7 +216,7 @@ let incoming_message ~identity ~current ~content chain =
   | Content_accepted { block; votes } ->
       let (Block { level; _ }) = block in
       let chain, actions = incoming_block ~identity ~current ~block chain in
-      Logs.info (fun m -> m "accepted: %a\n%!" Level.pp level);
+      Logs.info (fun m -> m "accepted: %a" Level.pp level);
       List.fold_left
         (fun (chain, actions) vote ->
           let chain, additional = incoming_vote ~current ~level ~vote chain in
@@ -340,10 +340,10 @@ let apply_protocol_apply ~identity ~current ~block ~votes ~protocol ~receipts
       in
       (chain, actions)
   | Error `No_pending_block ->
-      Logs.warn (fun m -> m "chain: no pending block\n%!");
+      Logs.warn (fun m -> m "chain: no pending block");
       (Chain chain, [])
   | Error `Wrong_pending_block ->
-      Logs.warn (fun m -> m "chain: wrong pending block\n%!");
+      Logs.warn (fun m -> m "chain: wrong pending block");
       (Chain chain, [])
 
 let apply_store_outcome ~level ~network chain =

--- a/deku-p/src/core/chain/chain.ml
+++ b/deku-p/src/core/chain/chain.ml
@@ -360,7 +360,14 @@ let apply_store_outcome ~level ~network chain =
     (* TODO: this is a workaround *)
     match level_int mod trusted_cycle_int = 0 && level_int <> 0 with
     | true ->
-        let trusted = drop ~until:oldest_trusted trusted in
+        (* drop previous cycle *)
+        let until =
+          ((level_int / trusted_cycle_int) - 1) * trusted_cycle_int
+          |> Z.of_int |> N.of_z
+          |> Option.value ~default:N.zero
+          |> Level.of_n
+        in
+        let trusted = drop ~until trusted in
         let oldest_trusted = N.(level_n + trusted_cycle) in
         let oldest_trusted = Level.of_n oldest_trusted in
         (oldest_trusted, trusted)

--- a/deku-p/src/core/consensus/consensus.ml
+++ b/deku-p/src/core/consensus/consensus.ml
@@ -559,7 +559,7 @@ let test () =
               incoming_vote ~current ~level ~vote consensus
           | Consensus_apply { block; votes = _ } -> (
               let (Block { level; _ }) = block in
-              Logs.info (fun m -> m "%a\n%!" Level.pp level);
+              Logs.info (fun m -> m "%a" Level.pp level);
               match finished ~identity ~current ~block consensus with
               | Ok (consensus, actions) -> (consensus, actions)
               | Error `No_pending_block -> failwith "no pending block"

--- a/deku-p/src/core/constants/deku_constants.ml
+++ b/deku-p/src/core/constants/deku_constants.ml
@@ -17,7 +17,7 @@ let clean_gossip_time =
   60.0 (* seconds *) *. minutes
 
 let async_on_error exn =
-  Logs.err (fun m -> m "async: %s\n%!" (Printexc.to_string exn))
+  Logs.err (fun m -> m "async: %s" (Printexc.to_string exn))
 
 let genesis_time = 0.0
 let trusted_cycle = Option.get (N.of_z (Z.of_int 600))

--- a/deku-p/src/core/external_vm/external_process.ml
+++ b/deku-p/src/core/external_vm/external_process.ml
@@ -30,7 +30,7 @@ let () =
 (* intentional, any exception in this file should kill the node *)
 let raise exn =
   (* TODO: https://github.com/marigold-dev/deku/issues/502 *)
-  Logs.err (fun m -> m "external_vm failure: %s\n%!" (Printexc.to_string exn));
+  Logs.err (fun m -> m "external_vm failure: %s" (Printexc.to_string exn));
   exit 1
 
 let read_all fd lengtht =

--- a/deku-p/src/core/gossip/gossip.ml
+++ b/deku-p/src/core/gossip/gossip.ml
@@ -145,11 +145,11 @@ let apply ~outcome gossip =
       (gossip, Some (Gossip_incoming_request { connection; above }))
   | Outcome_incoming_request_header_error { connection } ->
       Logs.warn (fun m ->
-          m "request.header.%a: error\n%!" Connection_id.pp connection);
+          m "request.header.%a: error" Connection_id.pp connection);
       (gossip, None)
   | Outcome_incoming_request_content_error { connection; exn } ->
       Logs.warn (fun m ->
-          m "request.content.%a: %s\n%!" Connection_id.pp connection
+          m "request.content.%a: %s" Connection_id.pp connection
             (Printexc.to_string exn));
       (gossip, None)
 

--- a/deku-p/src/core/gossip/message_pool.ml
+++ b/deku-p/src/core/gossip/message_pool.ml
@@ -90,7 +90,7 @@ let decode ~raw_header ~raw_content pool =
         (pool, Some fragment)
     | Late -> (pool, None)
   with exn ->
-    Logs.warn (fun m -> m "message.header: %s\n%!" (Printexc.to_string exn));
+    Logs.warn (fun m -> m "message.header: %s" (Printexc.to_string exn));
     (pool, None)
 
 let compute fragment =
@@ -117,7 +117,7 @@ let apply ~outcome pool =
           (pool, Some message)
       | Accepted | Late -> (pool, None))
   | Outcome_error { expected; exn } -> (
-      Logs.warn (fun m -> m "outcome.error: %s\n%!" (Printexc.to_string exn));
+      Logs.warn (fun m -> m "outcome.error: %s" (Printexc.to_string exn));
       let (Message_header { hash; level }) = expected in
       match state ~hash ~level pool with
       | Pending { queue } -> (

--- a/deku-p/src/core/network/network_manager.ml
+++ b/deku-p/src/core/network/network_manager.ml
@@ -73,7 +73,7 @@ let connect ~net ~clock ~host ~port ~on_connection ~on_request ~on_message
     with exn ->
       (* FIXME: is this properly a debug log? Or should it be warning? *)
       Logs.debug (fun m ->
-          m "reconnect(%s:%d): %s\n%!" host port (Printexc.to_string exn));
+          m "reconnect(%s:%d): %s" host port (Printexc.to_string exn));
       Eio.Time.sleep clock Deku_constants.reconnect_timeout;
       reconnect_loop ~identity ~net ~clock ~host ~port handler
   in
@@ -83,12 +83,12 @@ let connect ~net ~clock ~host ~port ~on_connection ~on_request ~on_message
 
 let listen ~net ~clock ~port ~on_connection ~on_request ~on_message network =
   let on_error exn =
-    Logs.warn (fun m -> m "listen.connection: %s\n%!" (Printexc.to_string exn))
+    Logs.warn (fun m -> m "listen.connection: %s" (Printexc.to_string exn))
   in
   let rec relisten ~identity ~net ~clock ~port ~on_error handler =
     try Network_protocol.Server.listen ~identity ~net ~port ~on_error handler
     with exn ->
-      Logs.warn (fun m -> m "relisten: %s\n%!" (Printexc.to_string exn));
+      Logs.warn (fun m -> m "relisten: %s" (Printexc.to_string exn));
       Eio.Time.sleep clock Deku_constants.listen_timeout;
       relisten ~identity ~net ~clock ~port ~on_error handler
   in
@@ -108,14 +108,14 @@ let connect ~net ~clock ~nodes ~on_connection ~on_request ~on_message network =
           network
       with exn ->
         Logs.warn (fun m ->
-            m "connect(%s:%d): %s\n%!" host port (Printexc.to_string exn)))
+            m "connect(%s:%d): %s" host port (Printexc.to_string exn)))
     nodes
 
 let send ~message ~write =
   (* write always includes a fork *)
   try write message
   with exn ->
-    Logs.warn (fun m -> m "write.error: %s\n%!" (Printexc.to_string exn))
+    Logs.warn (fun m -> m "write.error: %s" (Printexc.to_string exn))
 
 let broadcast message network =
   Key_hash.Map.iter
@@ -165,16 +165,16 @@ let test () =
   let start ~port : unit =
     let identity = identity () in
     let network = make ~identity in
-    let on_connection ~connection:_ = Logs.debug (fun m -> m "connected\n%!") in
+    let on_connection ~connection:_ = Logs.debug (fun m -> m "connected") in
     let on_request ~connection ~raw_header ~raw_content =
       Logs.debug (fun m ->
-          m "request(%s:%.3f): %d\n%!" raw_header (Unix.gettimeofday ())
+          m "request(%s:%.3f): %d" raw_header (Unix.gettimeofday ())
             (String.length raw_content));
       send ~connection ~raw_header ~raw_content network
     in
     let on_message ~raw_header ~raw_content =
       Logs.debug (fun m ->
-          m "message(%s:%.3f): %d\n%!" raw_header (Unix.gettimeofday ())
+          m "message(%s:%.3f): %d" raw_header (Unix.gettimeofday ())
             (String.length raw_content))
     in
     let raw_content = String.make 2_000_000 'a' in

--- a/deku-p/src/core/tezos_interop/js_process.ml
+++ b/deku-p/src/core/tezos_interop/js_process.ml
@@ -111,7 +111,7 @@ let make ~write = { pending = Pending.empty; write }
 let spawn ~file k =
   let prog = "node" in
   let args = [| prog; file |] in
-  Logs.info (fun m -> m "js_process.spawn: prog: %s, file: %s\n%!" prog file);
+  Logs.info (fun m -> m "js_process.spawn: prog: %s, file: %s" prog file);
   IO.spawn ~prog ~args @@ Protocol.handler
   @@ fun ~read ~write ->
   let process = make ~write in

--- a/deku-p/src/core/tezos_interop/tezos_bridge.ml
+++ b/deku-p/src/core/tezos_interop/tezos_bridge.ml
@@ -144,7 +144,7 @@ let spawn ~sw ~rpc_node ~secret ~destination ~on_transactions =
       with exn ->
         (* TODO: this should probably be a result. Currently if
            the None case is just ignored. *)
-        Logs.err (fun m -> m "inject: %s\n%!" (Printexc.to_string exn));
+        Logs.err (fun m -> m "inject: %s" (Printexc.to_string exn));
         None
     in
     Bridge
@@ -160,7 +160,7 @@ let spawn ~sw ~rpc_node ~secret ~destination ~on_transactions =
       inject_transaction_ref := inject_transaction;
       listen_transaction ~bridge process
     with exn ->
-      Logs.err (fun m -> m "spawn: %s\n%!" (Printexc.to_string exn));
+      Logs.err (fun m -> m "spawn: %s" (Printexc.to_string exn));
       respawn ()
   in
   let () = Eio.Fiber.fork ~sw @@ fun () -> respawn () in


### PR DESCRIPTION
Newlines in logs were introduced by https://github.com/marigold-dev/deku/commit/de6c7ec6acc00def73ee7ede7e7a3b816e74b6dc - sorry about that

The second commits fixes a production bug which goes like this:
- node 3 fails for some reason, say at level 205185
- the other nodes continue
- when node 3 gets back online, the other nodes reached level 205211, but every block below 205200 was dropped
- node 3 starts receiving and accumulating blocks > 205201, doesn't apply any of them, fills its RAM and dies.

Example of output (before fix) with a cycle of 30 instead of 600:
```
3: deku-node: [INFO] Chain started at level: 40
3: deku-node: [INFO] Incoming block Block [hash:
Db2n1fvMKHCUifW6ggPG4oucDjSsJFg9bEXFSmpZFVLzWTX1Vsgi, level: 61]
3: deku-node: [INFO] accepted: 61
3: deku-node: [INFO] Incoming block Block [hash:
Db2QD8ibFzbYMgb68MV6cX2ywGcG7JdroD1T7BqgqFKAc9z7nNeG, level: 63]
3: deku-node: [INFO] accepted: 63
3: deku-node: [INFO] Incoming block Block [hash:
Db2YZpyZoqMBLNsryy8hfrnGTX2TtoazpPUK6vUrmppLPeDYStcw, level: 62]
3: deku-node: [INFO] accepted: 62
3: deku-node: [INFO] Incoming block Block [hash:
Db2QD8ibFzbYMgb68MV6cX2ywGcG7JdroD1T7BqgqFKAc9z7nNeG, level: 63]
3: deku-node: [INFO] accepted: 63
```