### PR TITLE
Add key hash comparison test

### DIFF
--- a/deku-p/src/core/crypto/tests/alg_intf_tests.ml
+++ b/deku-p/src/core/crypto/tests/alg_intf_tests.ml
@@ -22,6 +22,11 @@ struct
       List.for_all (fun sk -> Secret.equal sk sk) secret_keys
   end
 
+  module Key_hash_data = struct
+    let key_hashes = List.map (fun id -> id.public_key_hash) ids
+    let compared_key_hashes = List.sort Key_hash.compare key_hashes
+  end
+
   module Test_secret_key_data = struct
     let public_keys () =
       let public_keys =
@@ -46,5 +51,17 @@ struct
         ~msg:"secret key equality works"
         ~expected:Tezos_data.equality_secret_keys
         ~actual:Secret_key_data.equality_secret_keys
+  end
+
+  module Test_key_hash_data = struct
+    let compare () =
+      let compared_key_hashes =
+        List.map
+          (fun kh -> Key_hash.to_b58 kh)
+          Key_hash_data.compared_key_hashes
+      in
+      Alcotest.(check' (list string))
+        ~msg:"key hash comparison works"
+        ~expected:Tezos_data.compared_key_hashes ~actual:compared_key_hashes
   end
 end

--- a/deku-p/src/core/crypto/tests/data_for_tests/data_gen.ml
+++ b/deku-p/src/core/crypto/tests/data_for_tests/data_gen.ml
@@ -67,6 +67,14 @@ struct
       List.for_all (fun sk -> Secret_key.equal sk sk) secret_keys
   end
 
+  module Ky_hash = struct
+    let key_hashes = List.map (fun id -> id.public_key_hash) ids
+
+    let compare_key_hashes =
+      List.sort Public_key_hash.compare
+        (List.map (fun id -> id.public_key_hash) ids)
+  end
+
   module Print_secret_key = struct
     let print_public_keys () =
       Format.printf "let public_keys = [\n%!";
@@ -85,5 +93,16 @@ struct
     let print_equality_secret_keys () =
       Format.printf "let equality_secret_keys = %b\n%!"
         Skt_key.equality_secret_keys
+  end
+
+  module Print_key_hash = struct
+    (* TODO: print_key_hashes *)
+
+    let print_compare_key_hash () =
+      Format.printf "let compared_key_hashes = [\n%!";
+      List.iter
+        (fun sk -> Format.printf "\"%s\"\n%!;" (Public_key_hash.to_b58check sk))
+        Ky_hash.compare_key_hashes;
+      Format.printf "]\n%!"
   end
 end

--- a/deku-p/src/core/crypto/tests/test_ed25519.ml
+++ b/deku-p/src/core/crypto/tests/test_ed25519.ml
@@ -88,4 +88,5 @@ let run () =
           test_case "compare" `Quick Test_secret_key_data.compare;
           test_case "equality" `Quick Test_secret_key_data.equality;
         ] );
+      ("Key hash", [ test_case "compare" `Quick Test_key_hash_data.compare ]);
     ]

--- a/deku-p/src/core/crypto/tests/tezos_test_data.ml
+++ b/deku-p/src/core/crypto/tests/tezos_test_data.ml
@@ -2,6 +2,7 @@ module type Tezos_data = sig
   val public_keys : string list
   val compared_secret_keys : string list
   val equality_secret_keys : bool
+  val compared_key_hashes : string list
 end
 
 module Ed25519_data : Tezos_data = struct
@@ -24,4 +25,13 @@ module Ed25519_data : Tezos_data = struct
     ]
 
   let equality_secret_keys = true
+
+  let compared_key_hashes =
+    [
+      "tz1LMf9NoTATvLJ7EQjYDzy7XZZ9KHjei5jH";
+      "tz1NS9mkwQxD2jgH8kiGVPD33VmLXVVe3wug";
+      "tz1UDkGwdCYTyZMG1wwMWMfmbiRtagvP3kXg";
+      "tz1aBiQ188pozN9JuSvwUPpkZoajCG6AT7XX";
+      "tz1iijagWhWfmG3Cmx7oJ62EkQByPG2foNBU";
+    ]
 end


### PR DESCRIPTION
## Depends
Do _not_ merge unless target is main
- [ ] #947 

## Problem
We want to ensure the derived comparison function for key_hashes matches that of Tezos'

## Solution
Adds generated comparison data and test for key hash comparison. 