### PR TITLE
Add public key comparison test

### DIFF
--- a/deku-p/src/core/crypto/tests/alg_intf_tests.ml
+++ b/deku-p/src/core/crypto/tests/alg_intf_tests.ml
@@ -22,6 +22,11 @@ struct
       List.for_all (fun sk -> Secret.equal sk sk) secret_keys
   end
 
+  module Key_data = struct
+    let public_keys = List.map (fun id -> id.public_key) ids
+    let compared_public_keys = List.sort Key.compare public_keys
+  end
+
   module Key_hash_data = struct
     let key_hashes = List.map (fun id -> id.public_key_hash) ids
     let compared_key_hashes = List.sort Key_hash.compare key_hashes
@@ -54,6 +59,16 @@ struct
         ~msg:"secret key equality works"
         ~expected:Tezos_data.equality_secret_keys
         ~actual:Secret_key_data.equality_secret_keys
+  end
+
+  module Test_key_data = struct
+    let compare () =
+      let compared_public_keys =
+        List.map (fun pk -> Key.to_b58 pk) Key_data.compared_public_keys
+      in
+      Alcotest.(check' (list string))
+        ~msg:"public key comparison works"
+        ~expected:Tezos_data.compared_public_keys ~actual:compared_public_keys
   end
 
   module Test_key_hash_data = struct

--- a/deku-p/src/core/crypto/tests/data_for_tests/data_gen.ml
+++ b/deku-p/src/core/crypto/tests/data_for_tests/data_gen.ml
@@ -67,6 +67,13 @@ struct
       List.for_all (fun sk -> Secret_key.equal sk sk) secret_keys
   end
 
+  module Ky = struct
+    let public_keys = List.map (fun id -> id.public_key) ids
+
+    let compare_public_keys =
+      List.sort Public_key.compare (List.map (fun id -> id.public_key) ids)
+  end
+
   module Ky_hash = struct
     let key_hashes = List.map (fun id -> id.public_key_hash) ids
 
@@ -96,6 +103,15 @@ struct
     let print_equality_secret_keys () =
       Format.printf "let equality_secret_keys = %b\n%!"
         Skt_key.equality_secret_keys
+  end
+
+  module Print_key = struct
+    let print_compare_public_keys () =
+      Format.printf "let compared_public_keys = [\n%!";
+      List.iter
+        (fun sk -> Format.printf "\"%s\"\n%!;" (Public_key.to_b58check sk))
+        Ky.compare_public_keys;
+      Format.printf "]\n%!"
   end
 
   module Print_key_hash = struct

--- a/deku-p/src/core/crypto/tests/test_ed25519.ml
+++ b/deku-p/src/core/crypto/tests/test_ed25519.ml
@@ -88,6 +88,7 @@ let run () =
           test_case "compare" `Quick Test_secret_key_data.compare;
           test_case "equality" `Quick Test_secret_key_data.equality;
         ] );
+      ("Public key", [ test_case "compared" `Quick Test_key_data.compare ]);
       ( "Key hash",
         [
           test_case "compare" `Quick Test_key_hash_data.compare;

--- a/deku-p/src/core/crypto/tests/tezos_test_data.ml
+++ b/deku-p/src/core/crypto/tests/tezos_test_data.ml
@@ -4,6 +4,7 @@ module type Tezos_data = sig
   val equality_secret_keys : bool
   val compared_key_hashes : string list
   val equality_key_hashes : bool
+  val compared_public_keys : string list
 end
 
 module Ed25519_data : Tezos_data = struct
@@ -26,6 +27,15 @@ module Ed25519_data : Tezos_data = struct
     ]
 
   let equality_secret_keys = true
+
+  let compared_public_keys =
+    [
+      "edpktgopG88M5eE8M6N1ZtHbYzDCXRnGXk9vhNrLnYp9CA6aVyMRXa";
+      "edpkutzyeRZkzmcGxQZr7gXTH7Cf7ygDsrn5LSZ2bffHpCeTACB4su";
+      "edpkvGJ8FdbDSrACkSEzWD1veGeoBQgCTKyX4SVvBc1TBRwcWrbRDQ";
+      "edpkvK2woY7vgguhuTZQDVM1hCjbVrEB2dhGVejvgQxHEoGgYqJNuD";
+      "edpkvLs7dfWXcdx62iEW5wpYfn8yKPuj446BCRhEbevMMbSSE9G1Yn";
+    ]
 
   let compared_key_hashes =
     [


### PR DESCRIPTION

## Depends

- [ ] #958 
## Problem

We want to ensure that the derived public key comparison matches Tezos'

## Solution

Adds public key data generated with tezos-crypto, and tests the comparison against deku's
 