### PR TITLE
Add public key equality test

### DIFF
--- a/deku-p/src/core/crypto/tests/alg_intf_tests.ml
+++ b/deku-p/src/core/crypto/tests/alg_intf_tests.ml
@@ -25,6 +25,9 @@ struct
   module Key_data = struct
     let public_keys = List.map (fun id -> id.public_key) ids
     let compared_public_keys = List.sort Key.compare public_keys
+
+    let equality_public_keys =
+      List.for_all (fun pk -> Key.equal pk pk) public_keys
   end
 
   module Key_hash_data = struct
@@ -69,6 +72,12 @@ struct
       Alcotest.(check' (list string))
         ~msg:"public key comparison works"
         ~expected:Tezos_data.compared_public_keys ~actual:compared_public_keys
+
+    let equality () =
+      Alcotest.(check' bool)
+        ~msg:"public key equality works"
+        ~expected:Tezos_data.equality_public_keys
+        ~actual:Key_data.equality_public_keys
   end
 
   module Test_key_hash_data = struct

--- a/deku-p/src/core/crypto/tests/data_for_tests/data_gen.ml
+++ b/deku-p/src/core/crypto/tests/data_for_tests/data_gen.ml
@@ -72,6 +72,9 @@ struct
 
     let compare_public_keys =
       List.sort Public_key.compare (List.map (fun id -> id.public_key) ids)
+
+    let equality_public_keys =
+      List.for_all (fun pk -> Public_key.equal pk pk) public_keys
   end
 
   module Ky_hash = struct
@@ -112,6 +115,9 @@ struct
         (fun sk -> Format.printf "\"%s\"\n%!;" (Public_key.to_b58check sk))
         Ky.compare_public_keys;
       Format.printf "]\n%!"
+
+    let print_equality_public_keys () =
+      Format.printf "let equality_public_keys = %b\n%!" Ky.equality_public_keys
   end
 
   module Print_key_hash = struct

--- a/deku-p/src/core/crypto/tests/test_ed25519.ml
+++ b/deku-p/src/core/crypto/tests/test_ed25519.ml
@@ -88,7 +88,11 @@ let run () =
           test_case "compare" `Quick Test_secret_key_data.compare;
           test_case "equality" `Quick Test_secret_key_data.equality;
         ] );
-      ("Public key", [ test_case "compared" `Quick Test_key_data.compare ]);
+      ( "Public key",
+        [
+          test_case "compared" `Quick Test_key_data.compare;
+          test_case "equality" `Quick Test_key_data.equality;
+        ] );
       ( "Key hash",
         [
           test_case "compare" `Quick Test_key_hash_data.compare;

--- a/deku-p/src/core/crypto/tests/tezos_test_data.ml
+++ b/deku-p/src/core/crypto/tests/tezos_test_data.ml
@@ -3,6 +3,7 @@ module type Tezos_data = sig
   val compared_secret_keys : string list
   val equality_secret_keys : bool
   val compared_key_hashes : string list
+  val equality_public_keys : bool
   val equality_key_hashes : bool
   val compared_public_keys : string list
 end
@@ -36,6 +37,8 @@ module Ed25519_data : Tezos_data = struct
       "edpkvK2woY7vgguhuTZQDVM1hCjbVrEB2dhGVejvgQxHEoGgYqJNuD";
       "edpkvLs7dfWXcdx62iEW5wpYfn8yKPuj446BCRhEbevMMbSSE9G1Yn";
     ]
+
+  let equality_public_keys = true
 
   let compared_key_hashes =
     [


### PR DESCRIPTION
## Depends
Do _not_ merge unless target is main
- [ ] #959 
## Problem
We want to ensure the derived public key equality matches Tezos' 
## Solution
Adds test comparing tezos-crypto equality to deku's
