### PR TITLE
Add hashed byte data test

### DIFF
--- a/deku-p/src/core/crypto/tests/data_for_tests/data_gen.ml
+++ b/deku-p/src/core/crypto/tests/data_for_tests/data_gen.ml
@@ -88,6 +88,21 @@ struct
       List.for_all (fun kh -> Public_key_hash.equal kh kh) key_hashes
   end
 
+  module Sig = struct
+    let secret_keys = List.map (fun id -> id.secret_key) ids
+    let public_keys = List.map (fun id -> id.public_key) ids
+
+    let byte_data =
+      List.map
+        (fun string -> String.to_bytes string)
+        [ "1"; "2"; "3"; "4"; "5" ]
+
+    let to_sign =
+      List.map
+        (fun string -> Blake2B.hash_bytes string |> Blake2B.to_bytes)
+        (List.map (fun bytes -> [ bytes ]) byte_data)
+  end
+
   module Print_secret_key = struct
     let print_public_keys () =
       Format.printf "let public_keys = [\n%!";
@@ -106,6 +121,8 @@ struct
     let print_equality_secret_keys () =
       Format.printf "let equality_secret_keys = %b\n%!"
         Skt_key.equality_secret_keys
+
+    (* TODO: encoding *)
   end
 
   module Print_key = struct
@@ -118,6 +135,8 @@ struct
 
     let print_equality_public_keys () =
       Format.printf "let equality_public_keys = %b\n%!" Ky.equality_public_keys
+
+    (* TODO: encoding *)
   end
 
   module Print_key_hash = struct
@@ -132,5 +151,26 @@ struct
 
     let print_equality_key_hash () =
       Format.printf "let equality_key_hash = %b\n%!" Ky_hash.equality_key_hash
+
+    (* TODO: encoding *)
+  end
+
+  module Print_signatures = struct
+    let helper_print_signatures signature =
+      let signature = to_b58check signature in
+      let string_list =
+        String.fold_right
+          (fun char acc -> (Char.code char |> Int.to_string) :: acc)
+          signature []
+      in
+      String.concat "" string_list
+
+    let print_to_sign () =
+      let to_sign =
+        List.map Bytes.to_string Sig.to_sign
+        |> String.concat ""
+        |> String.map (fun char -> (Char.code char |> Int.to_string).[0])
+      in
+      Format.printf "let to_sign = \"%s\"\n%!" to_sign
   end
 end

--- a/deku-p/src/core/crypto/tests/test_ed25519.ml
+++ b/deku-p/src/core/crypto/tests/test_ed25519.ml
@@ -98,4 +98,5 @@ let run () =
           test_case "compare" `Quick Test_key_hash_data.compare;
           test_case "equality" `Quick Test_key_hash_data.equality;
         ] );
+      ("Signatures", [ test_case "to_sign" `Quick Test_signature_data.to_sign ]);
     ]

--- a/deku-p/src/core/crypto/tests/tezos_test_data.ml
+++ b/deku-p/src/core/crypto/tests/tezos_test_data.ml
@@ -2,10 +2,11 @@ module type Tezos_data = sig
   val public_keys : string list
   val compared_secret_keys : string list
   val equality_secret_keys : bool
-  val compared_key_hashes : string list
   val equality_public_keys : bool
-  val equality_key_hashes : bool
   val compared_public_keys : string list
+  val compared_key_hashes : string list
+  val equality_key_hashes : bool
+  val to_sign : string
 end
 
 module Ed25519_data : Tezos_data = struct
@@ -50,4 +51,7 @@ module Ed25519_data : Tezos_data = struct
     ]
 
   let equality_key_hashes = true
+
+  let to_sign =
+    "1221111113822211222227921529112243121122121222115441211112211232817511621326112702119221122192222173718731151233283141117142231111154312111111323622251114129212"
 end


### PR DESCRIPTION
## Depends
Do _not_ merge unless target is main
- [ ] #960 

## Problem

We want to make sure we'll be signing the same hashed data that tezos-crypto.sign generates internally 

## Solution

Hash some byte data and make sure blake2b.hash generates the same bytes for both Tezos and Deku
 