### PR TITLE
feat: minimum block latency

### DIFF
--- a/deku-p/src/core/chain/chain.ml
+++ b/deku-p/src/core/chain/chain.ml
@@ -116,6 +116,12 @@ let commit ~current_level ~block ~votes ~validators =
       withdrawal_handles_hash;
     }
 
+(* TODO: move this to a transparently configurable thing in Cmdliner in Deku_node *)
+let minimum_block_latency =
+  match Sys.getenv_opt "DEKU_MINIMUM_LATENCY" with
+  | Some x -> Option.value ~default:0.0 (Float.of_string_opt x)
+  | None -> 0.0
+
 (* after gossip *)
 let apply_consensus_action chain consensus_action =
   let open Consensus in
@@ -133,6 +139,9 @@ let apply_consensus_action chain consensus_action =
       let fragment =
         Fragment_produce { producer; above; withdrawal_handles_hash }
       in
+      (match minimum_block_latency with
+      | 0. -> ()
+      | minimum_block_latency -> Unix.sleepf minimum_block_latency);
       (chain, [ Chain_fragment { fragment } ])
   | Consensus_vote { level; vote } ->
       let content = Message.Content.vote ~level ~vote in


### PR DESCRIPTION
## Problem

There are times when you want to slow the chain. The "natural" way is to have a higher workload, but sometimes the ideal spot is not on the workload-latency curve (e.g. when you're on a laptop or cheap hardware).

## Solution

Add a config for how many seconds to sleep in between blocks.

There's a problem with this patch, and that is that it's coupled to saving blocks. But what if we save blocks in batch later? Ideally we would sleep immediately before/after applying. But how do we want to inject config into the `Chain` module?
 