### PR TITLE
fix: insert or ignore block level

### DIFF
--- a/deku-p/src/core/block_storage/block_storage.ml
+++ b/deku-p/src/core/block_storage/block_storage.ml
@@ -43,6 +43,7 @@ module Query = struct
         (hash, level, timestamp, block) 
         VALUES
         (%Block_hash{block_hash}, %Level{level}, %Timestamp{timestamp}, %Block{block})    
+        ON CONFLICT DO NOTHING
         |sql}]
 
   let insert_block ~block ~timestamp pool =


### PR DESCRIPTION

## Problem

Every time we load from disk, we try to insert blocks already in the database. 


## Solution

I don't understand our startup sequence enough to know if this is a good patch or not. It might be that we want to fix the problem
upstream (maybe we should not be raising the `Chain_save_block` event at all in this this case).

But if we want to allow idempotent writes to block storage, this works. 
