### PR TITLE
Test protocol apply

### DIFF
--- a/deku-p/src/core/ledger/ledger.mli
+++ b/deku-p/src/core/ledger/ledger.mli
@@ -2,6 +2,7 @@ open Deku_crypto
 open Deku_concepts
 
 exception Insufficient_funds
+exception Withdraw_zero_ticket
 
 module Withdrawal_handle : sig
   module Withdrawal_handle_hash : sig

--- a/deku-p/src/core/ledger/tests/deku_ledger_tests.ml
+++ b/deku-p/src/core/ledger/tests/deku_ledger_tests.ml
@@ -1,0 +1,1 @@
+let () = Test_address.run ()

--- a/deku-p/src/core/ledger/tests/dune
+++ b/deku-p/src/core/ledger/tests/dune
@@ -1,0 +1,10 @@
+(executable
+ (name deku_ledger_tests)
+ (libraries deku_ledger alcotest))
+
+(rule
+ (alias runtest)
+ (deps
+  (:exe ./deku_ledger_tests.exe))
+ (action
+  (run %{exe})))

--- a/deku-p/src/core/ledger/tests/test_address.ml
+++ b/deku-p/src/core/ledger/tests/test_address.ml
@@ -1,0 +1,84 @@
+open Deku_ledger
+
+let addr = Alcotest.testable Address.pp Address.equal
+
+let test_address_from_string () =
+  let address = "tz1fpf9DffkGAnzT6UKMDoS4hZjNmoEKhGsK" in
+  let address = Address.of_b58 address in
+  let is_some = Option.is_some address in
+  Alcotest.(check bool) "Address has been parsed" true is_some
+
+let test_wrong_address_from_string () =
+  let address = "ksGHeh4SfkGAnzT6UKMDoS4hZjNmoEKhGsK" in
+  let address = Address.of_b58 address in
+  let is_none = Option.is_none address in
+  Alcotest.(check bool) "Address cannot be parsed" true is_none
+
+let test_b58 () =
+  let address_string = "tz1fpf9DffkGAnzT6UKMDoS4hZjNmoEKhGsK" in
+  let address_b58 =
+    address_string |> Address.of_b58 |> Option.get |> Address.to_b58
+  in
+  Alcotest.(check string)
+    "of_b58 |> to_b58 should returns the input" address_string address_b58
+
+let test_key_hash () =
+  let open Deku_crypto in
+  let raw_key_hash =
+    Key_hash.of_b58 "tz1fpf9DffkGAnzT6UKMDoS4hZjNmoEKhGsK" |> Option.get
+  in
+  let key_hash =
+    raw_key_hash |> Address.of_key_hash |> Address.to_key_hash |> Option.get
+  in
+  Alcotest.(check bool)
+    "of_key_hash |> to_key_hash shouyld returns the input" true
+    (Key_hash.equal raw_key_hash key_hash)
+
+let test_yojson () =
+  let raw_address =
+    Address.of_b58 "tz1fpf9DffkGAnzT6UKMDoS4hZjNmoEKhGsK" |> Option.get
+  in
+  let address_yojson =
+    raw_address |> Address.yojson_of_t |> Address.t_of_yojson
+  in
+  Alcotest.(check addr)
+    "yojson_of |> of_yojson should returns the input" raw_address address_yojson
+
+let test_address_equal () =
+  let address =
+    Address.of_b58 "tz1fpf9DffkGAnzT6UKMDoS4hZjNmoEKhGsK" |> Option.get
+  in
+  Alcotest.(check bool)
+    "two same addresses must be equal" true
+    (Address.equal address address)
+
+let test_address_not_equal () =
+  let address1 =
+    Address.of_b58 "tz1fpf9DffkGAnzT6UKMDoS4hZjNmoEKhGsK" |> Option.get
+  in
+  let address2 =
+    Address.of_b58 "tz1PYdVbnLwiqKo3fLFXTKxw6K7BhpddQPh8" |> Option.get
+  in
+  Alcotest.(check bool)
+    "two different addresses must not be equal" false
+    (Address.equal address1 address2)
+
+let run () =
+  let open Alcotest in
+  run "Address" ~and_exit:false
+    [
+      ( "Repr",
+        [
+          test_case "parse a correct string address " `Quick
+            test_address_from_string;
+          test_case "parsed an incorrect string address" `Quick
+            test_wrong_address_from_string;
+          test_case "of_b58 is inverse of from_b58" `Quick test_b58;
+          test_case "of_key_hash is the inverse of to_key_hash" `Quick
+            test_key_hash;
+          test_case "yojson_of is the inverse of of_yojson" `Quick test_yojson;
+          test_case "two same addresses are equal" `Quick test_address_equal;
+          test_case "two different addresses are not equal" `Quick
+            test_address_not_equal;
+        ] );
+    ]

--- a/deku-p/src/core/ledger/tests/test_address.mli
+++ b/deku-p/src/core/ledger/tests/test_address.mli
@@ -1,0 +1,1 @@
+val run : unit -> unit

--- a/deku-p/src/core/ledger/ticket_table.ml
+++ b/deku-p/src/core/ledger/ticket_table.ml
@@ -94,6 +94,10 @@ let transfer ~sender ~receiver ~ticket_id ~amount t =
   Ok t
 
 let withdraw ~sender ~ticket_id ~amount t =
+  let%ok () =
+    if Amount.equal Amount.zero amount then Error `Withdraw_zero_ticket
+    else Ok ()
+  in
   let%ok map =
     Address_map.find_opt sender t |> Option.to_result ~none:`Insufficient_funds
   in

--- a/deku-p/src/core/ledger/ticket_table.mli
+++ b/deku-p/src/core/ledger/ticket_table.mli
@@ -24,7 +24,7 @@ val withdraw :
   ticket_id:Ticket_id.t ->
   amount:Amount.t ->
   t ->
-  (t, [> `Insufficient_funds ]) result
+  (t, [> `Insufficient_funds | `Withdraw_zero_ticket ]) result
 
 val take_tickets :
   sender:Address.t ->

--- a/deku-p/src/core/protocol/tests/deku_protocol_tests.ml
+++ b/deku-p/src/core/protocol/tests/deku_protocol_tests.ml
@@ -1,4 +1,5 @@
 let () =
   Test_ledger.run ();
   Test_operation.run ();
-  Test_protocol.run ()
+  Test_protocol.run ();
+  Test_operation_hash.run ()

--- a/deku-p/src/core/protocol/tests/test_operation_hash.ml
+++ b/deku-p/src/core/protocol/tests/test_operation_hash.ml
@@ -1,0 +1,62 @@
+open Deku_protocol
+
+let correct_operation_hash =
+  "Do2YxhRwd1bK5H9A5ULe6eS2bxsMsA8hgVbCxvbpSLQcyW9bkV5S"
+
+let incorrect_operation_hash = "tz1fpf9DffkGAnzT6UKMDoS4hZjNmoEKhGsK"
+
+let test_operation_hash_from_correct_string () =
+  let operation_hash = Operation_hash.of_b58 correct_operation_hash in
+  let is_some = Option.is_some operation_hash in
+  Alcotest.(check bool) "Operation has been parsed" true is_some
+
+let test_operation_hash_from_incorrect_string () =
+  let operation_hash = Operation_hash.of_b58 incorrect_operation_hash in
+  let is_none = Option.is_none operation_hash in
+  Alcotest.(check bool) "Operation has not been parsed" true is_none
+
+let test_b58 () =
+  let result =
+    correct_operation_hash |> Operation_hash.of_b58 |> Option.get
+    |> Operation_hash.to_b58
+  in
+  Alcotest.(check string) "b58 should be the same" correct_operation_hash result
+
+let test_prefix () =
+  let operation_hash = Operation_hash.hash "hello" in
+  let operation = Operation_hash.to_b58 operation_hash in
+  Alcotest.(check bool)
+    "b58 should start by Do" true
+    (String.starts_with ~prefix:"Do" operation)
+
+let test_equal () =
+  let operation_1 = Operation_hash.hash "hello" in
+  let operation_2 = Operation_hash.hash "hello" in
+  Alcotest.(check bool)
+    "should be equal" true
+    (Operation_hash.equal operation_1 operation_2)
+
+let test_not_equal () =
+  let operation_1 = Operation_hash.hash "hello" in
+  let operation_2 = Operation_hash.hash "world" in
+  Alcotest.(check bool)
+    "should be equal" false
+    (Operation_hash.equal operation_1 operation_2)
+
+let run () =
+  let open Alcotest in
+  run "Operation hash" ~and_exit:false
+    [
+      ( "Repr",
+        [
+          test_case "parse a correct operation address" `Quick
+            test_operation_hash_from_correct_string;
+          test_case "parse an incorrect operation address" `Quick
+            test_operation_hash_from_incorrect_string;
+          test_case "of_b58 is inverse of to_b58" `Quick test_b58;
+          test_case "Do is the prefix of an operation hash" `Quick test_prefix;
+          test_case "Two same operation hash should be equal" `Quick test_equal;
+          test_case "Two different operation hash should not be equal" `Quick
+            test_not_equal;
+        ] );
+    ]

--- a/deku-p/src/core/protocol/tests/test_operation_hash.mli
+++ b/deku-p/src/core/protocol/tests/test_operation_hash.mli
@@ -1,0 +1,1 @@
+val run : unit -> unit


### PR DESCRIPTION
# Problems:

- We needs to test how operations are applied in the protocol
- A bug was discovered: user can withdraw 0 ticket, it should bot be possible because in Tezos the amount of tickets are strictly positive

# Solutions:

Add tests for:
 - noop operation
 - transfer operation
 - ticket deposit
 - ticket withdraw

Add some tests on different used types: 
 - operation hash
 - address

Fix the bug to prevent a user from generated a withdraw of 0 ticket

 
