### PR TITLE
Fix toolkit parsing

### DIFF
--- a/deku-c/deku-c-toolkit/package.json
+++ b/deku-c/deku-c-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marigold-dev/deku-c-toolkit",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Deku typescript client to interact with deku-c",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/deku-c/deku-c-toolkit/src/contract.ts
+++ b/deku-c/deku-c-toolkit/src/contract.ts
@@ -32,8 +32,9 @@ const parseContractState = (json: JSONType): JSONType => {
       }, {});
     }
     case "Pair": {
-      const first = json[1] as JSONType;
-      const second = json[2] as JSONType;
+      const value = json[1] as Array<JSONType>;
+      const first = value[0] as JSONType;
+      const second = value[1] as JSONType;
       return [parseContractState(first), parseContractState(second)];
     }
     case "List": {

--- a/deku-c/deku-c-toolkit/src/contract.ts
+++ b/deku-c/deku-c-toolkit/src/contract.ts
@@ -41,6 +41,20 @@ const parseContractState = (json: JSONType): JSONType => {
       const first = json[1] as Array<JSONType>;
       return first.map(json => parseContractState(json))
     }
+    case "Union": {
+      const first = json[1] as Array<JSONType>;
+      const type = first[0] as string;
+      const value = first[1] as JSONType;
+      switch (type) {
+        case "Right":
+          return { right: parseContractState(value) }
+        case "Left":
+          return { left: parseContractState(value) }
+        default: {
+          return null; // TODO: remove this default case which is not possible
+        }
+      }
+    }
     default:
       console.error(`type ${type} is not yet implemented`);
       return null;

--- a/deku-c/deku-c-toolkit/src/contract.ts
+++ b/deku-c/deku-c-toolkit/src/contract.ts
@@ -55,6 +55,9 @@ const parseContractState = (json: JSONType): JSONType => {
         }
       }
     }
+    case "Unit": {
+      return null
+    }
     default:
       console.error(`type ${type} is not yet implemented`);
       return null;

--- a/deku-c/deku-c-toolkit/src/contract.ts
+++ b/deku-c/deku-c-toolkit/src/contract.ts
@@ -36,6 +36,10 @@ const parseContractState = (json: JSONType): JSONType => {
       const second = json[2] as JSONType;
       return [parseContractState(first), parseContractState(second)];
     }
+    case "List": {
+      const first = json[1] as Array<JSONType>;
+      return first.map(json => parseContractState(json))
+    }
     default:
       console.error(`type ${type} is not yet implemented`);
       return null;

--- a/website/package.json
+++ b/website/package.json
@@ -43,7 +43,7 @@
     "@taquito/tzip16": "^14.0.0",
     "@taquito/utils": "^14.0.0",
     "@marigold-dev/deku-toolkit": "0.1.11",
-    "@marigold-dev/deku-c-toolkit": "0.1.2",
+    "@marigold-dev/deku-c-toolkit": "0.1.3",
     "abort-controller": "^3.0.0",
     "algoliasearch": "^4.12.2",
     "axios": "^0.26.0",


### PR DESCRIPTION
# Problems:

 - The deku-c-toolkit can not parse several types: Union, List, Unit 
 - Bug in the Pair parsing

# Solution:

- Implements parsing for missing types
- Fix the pair parsing bug

# Publishing

A new version has been set: 0.1.3
The website was updated to this version.

