### PR TITLE
fix/deku-c-toolkit: option parsing wasm 

### DIFF
--- a/deku-c/deku-c-toolkit/package.json
+++ b/deku-c/deku-c-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marigold-dev/deku-c-toolkit",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Deku typescript client to interact with deku-c",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/deku-c/deku-c-toolkit/src/contract.ts
+++ b/deku-c/deku-c-toolkit/src/contract.ts
@@ -55,6 +55,19 @@ const parseContractState = (json: JSONType): JSONType => {
         }
       }
     }
+    case "Option": {
+      const first = json[1] as Array<JSONType>;
+      const type = first[0] as string;
+      const value = first[1] as JSONType;
+      switch (type) {
+        case "None":
+          return { none: true }
+        case "Some":
+          return { none: false, some: parseContractState(value) }
+        default:
+          return null; // TODO: remove this default case which is not possible
+      }
+    }
     case "Unit": {
       return null
     }

--- a/website/package.json
+++ b/website/package.json
@@ -43,7 +43,7 @@
     "@taquito/tzip16": "^14.0.0",
     "@taquito/utils": "^14.0.0",
     "@marigold-dev/deku-toolkit": "0.1.11",
-    "@marigold-dev/deku-c-toolkit": "0.1.3",
+    "@marigold-dev/deku-c-toolkit": "0.1.4",
     "abort-controller": "^3.0.0",
     "algoliasearch": "^4.12.2",
     "axios": "^0.26.0",


### PR DESCRIPTION
# Problem:

The deku-c-toolkit can't parse the option type from the wasm contract storage

# Solution:

Improve the parser of the deku-c-toolkit