### PR TITLE
storage: move computing to worker

### DIFF
--- a/deku-p/src/core/bin/node/deku_node.ml
+++ b/deku-p/src/core/bin/node/deku_node.ml
@@ -95,7 +95,11 @@ let main params style_renderer log_level =
   Parallel.Pool.run ~env ~domains @@ fun () ->
   Logs.info (fun m -> m "Using %d domains" domains);
   Logs.info (fun m -> m "Default block size: %d" default_block_size);
-  let indexer = Block_storage.make ~uri:database_uri in
+  let indexer =
+    let domains = Eio.Stdenv.domain_mgr env in
+    let worker = Parallel.Worker.make ~domains ~sw in
+    Block_storage.make ~worker ~uri:database_uri
+  in
   let validator_uris =
     List.map
       (fun s ->

--- a/deku-p/src/core/block_storage/block_storage.mli
+++ b/deku-p/src/core/block_storage/block_storage.mli
@@ -1,3 +1,4 @@
+open Deku_stdlib
 open Deku_concepts
 open Deku_consensus
 open Deku_gossip
@@ -5,7 +6,7 @@ open Deku_gossip
 type storage
 type t = storage
 
-val make : uri:Uri.t -> storage
+val make : worker:Parallel.Worker.t -> uri:Uri.t -> storage
 val save_block : block:Block.t -> storage -> unit
 
 val save_block_and_votes :

--- a/deku-p/src/core/stdlib/parallel.mli
+++ b/deku-p/src/core/stdlib/parallel.mli
@@ -2,6 +2,14 @@ module Pool : sig
   val run : env:Eio.Stdenv.t -> domains:int -> (unit -> 'a) -> 'a
 end
 
+module Worker : sig
+  type worker
+  type t = worker
+
+  val make : domains:#Eio.Domain_manager.t -> sw:Eio.Switch.t -> worker
+  val schedule : worker -> (unit -> 'a) -> 'a
+end
+
 val init_p : int -> (int -> 'a) -> 'a list
 val map_p : ('a -> 'b) -> 'a list -> 'b list
 val filter_map_p : ('a -> 'b option) -> 'a list -> 'b list


### PR DESCRIPTION
## Problem

Loading and storing blocks is not fast and this currently happens on the main thread, drastically slowing the chain.

## Solution

Move all the storage work load to a specific worker.