### PR TITLE
JS Interop: better error management and logging

### DIFF
--- a/deku-p/src/core/tezos_interop/tezos_bridge.ml
+++ b/deku-p/src/core/tezos_interop/tezos_bridge.ml
@@ -43,6 +43,9 @@ module Inject_transaction = struct
   }
   [@@deriving yojson]
 
+  type error = Insufficient_balance of string | Unknown of string
+  [@@deriving of_yojson]
+
   type t =
     | Applied of { hash : string }
     (* TODO: in which cases the hash will not be present? *)
@@ -50,7 +53,7 @@ module Inject_transaction = struct
     | Skipped of { hash : string option }
     | Backtracked of { hash : string option }
     | Unknown of { hash : string option }
-    | Error of { error : string }
+    | Error of { error : error }
 
   let t_of_yojson json =
     let module T = struct
@@ -63,7 +66,7 @@ module Inject_transaction = struct
       type maybe_hash = { hash : string option }
       [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
-      type error = { error : string }
+      type err = { error : error }
       [@@deriving of_yojson] [@@yojson.allow_extra_fields]
     end in
     let other make =
@@ -81,7 +84,7 @@ module Inject_transaction = struct
     | "backtracked" -> other (fun hash -> Backtracked { hash })
     | "unknown" -> other (fun hash -> Unknown { hash })
     | "error" ->
-        let T.{ error } = T.error_of_yojson json in
+        let T.{ error } = T.err_of_yojson json in
         Error { error }
     | _ -> failwith "invalid status"
 end

--- a/deku-p/src/core/tezos_interop/tezos_bridge.ml
+++ b/deku-p/src/core/tezos_interop/tezos_bridge.ml
@@ -43,7 +43,10 @@ module Inject_transaction = struct
   }
   [@@deriving yojson]
 
-  type error = Insufficient_balance of string | Unknown of string
+  type error =
+    | Insufficient_balance of string
+    | Unknown of string
+    | Consensus_contract of string
   [@@deriving of_yojson]
 
   type t =

--- a/deku-p/src/core/tezos_interop/tezos_bridge.ml
+++ b/deku-p/src/core/tezos_interop/tezos_bridge.ml
@@ -47,6 +47,7 @@ module Inject_transaction = struct
     | Insufficient_balance of string
     | Unknown of string
     | Consensus_contract of string
+    | Several_operations of string
   [@@deriving of_yojson]
 
   type t =

--- a/deku-p/src/core/tezos_interop/tezos_bridge.mli
+++ b/deku-p/src/core/tezos_interop/tezos_bridge.mli
@@ -16,6 +16,7 @@ module Inject_transaction : sig
     | Insufficient_balance of string
     | Unknown of string
     | Consensus_contract of string
+    | Several_operations of string
 
   type t =
     | Applied of { hash : string }

--- a/deku-p/src/core/tezos_interop/tezos_bridge.mli
+++ b/deku-p/src/core/tezos_interop/tezos_bridge.mli
@@ -12,13 +12,15 @@ end
 
 (* response *)
 module Inject_transaction : sig
+  type error = Insufficient_balance of string | Unknown of string
+
   type t =
     | Applied of { hash : string }
     | Failed of { hash : string option }
     | Skipped of { hash : string option }
     | Backtracked of { hash : string option }
     | Unknown of { hash : string option }
-    | Error of { error : string }
+    | Error of { error : error }
 end
 
 type bridge

--- a/deku-p/src/core/tezos_interop/tezos_bridge.mli
+++ b/deku-p/src/core/tezos_interop/tezos_bridge.mli
@@ -12,7 +12,10 @@ end
 
 (* response *)
 module Inject_transaction : sig
-  type error = Insufficient_balance of string | Unknown of string
+  type error =
+    | Insufficient_balance of string
+    | Unknown of string
+    | Consensus_contract of string
 
   type t =
     | Applied of { hash : string }

--- a/deku-p/src/core/tezos_interop/tezos_interop.ml
+++ b/deku-p/src/core/tezos_interop/tezos_interop.ml
@@ -166,7 +166,10 @@ let commit_state_hash interop ~block_level ~block_payload_hash ~state_hash
       | Insufficient_balance address ->
           Logs.err (fun m -> m "Insufficient tez balance for %s" address)
       | Consensus_contract error ->
-          Logs.err (fun m -> m "Consensus smart contract error: %s" error))
+          Logs.err (fun m -> m "Consensus smart contract error: %s" error)
+      | Several_operations error ->
+          Logs.warn (fun m ->
+              m "Submitting several operations in the same block: %s" error))
   | None ->
       (* TODO: I think we can improve the types of this - maybe result would be better? *)
       Logs.warn (fun m ->

--- a/deku-p/src/core/tezos_interop/tezos_interop.ml
+++ b/deku-p/src/core/tezos_interop/tezos_interop.ml
@@ -164,7 +164,9 @@ let commit_state_hash interop ~block_level ~block_payload_hash ~state_hash
       | Unknown err ->
           Logs.err (fun m -> m "Received error from Tezos Bridge: %s" err)
       | Insufficient_balance address ->
-          Logs.err (fun m -> m "Insufficient tez balance for %s" address))
+          Logs.err (fun m -> m "Insufficient tez balance for %s" address)
+      | Consensus_contract error ->
+          Logs.err (fun m -> m "Consensus smart contract error: %s" error))
   | None ->
       (* TODO: I think we can improve the types of this - maybe result would be better? *)
       Logs.warn (fun m ->

--- a/deku-p/src/core/tezos_interop/tezos_interop.ml
+++ b/deku-p/src/core/tezos_interop/tezos_interop.ml
@@ -159,8 +159,12 @@ let commit_state_hash interop ~block_level ~block_payload_hash ~state_hash
       Logs.warn (fun m -> m "Tezos operation was backtracked")
   | Some (Unknown _) ->
       Logs.warn (fun m -> m "Unknown result of Tezos operation")
-  | Some (Error { error }) ->
-      Logs.warn (fun m -> m "Received error from Tezos Bridge: %s" error)
+  | Some (Error { error }) -> (
+      match error with
+      | Unknown err ->
+          Logs.err (fun m -> m "Received error from Tezos Bridge: %s" err)
+      | Insufficient_balance address ->
+          Logs.err (fun m -> m "Insufficient tez balance for %s" address))
   | None ->
       (* TODO: I think we can improve the types of this - maybe result would be better? *)
       Logs.warn (fun m ->

--- a/deku-p/src/core/tezos_interop/tezos_js_bridge.js
+++ b/deku-p/src/core/tezos_interop/tezos_js_bridge.js
@@ -324,7 +324,24 @@ const parseError = (err) => {
     }
     return undefined;
   };
-  return parseInsufficientBalance(err) || ["Unknown", inspect(err)];
+  const parseErrorFromSmartContract = (err) => {
+    const id = "script_rejected";
+    if (
+      err &&
+      err.errors &&
+      err.errors.find &&
+      err.errors.find((error) => error.id.includes(id))
+    ) {
+      const error = err.errors.find((error) => error.id.includes(id)).with
+        .string;
+      return ["Consensus_contract", error];
+    }
+    return undefined;
+  };
+  return (
+    parseInsufficientBalance(err) ||
+    parseErrorFromSmartContract(err) || ["Unknown", inspect(err)]
+  );
 };
 
 read((request) => {

--- a/deku-p/src/core/tezos_interop/tezos_js_bridge.js
+++ b/deku-p/src/core/tezos_interop/tezos_js_bridge.js
@@ -338,9 +338,20 @@ const parseError = (err) => {
     }
     return undefined;
   };
+  const parseFailure = (err) => {
+    const id = "failure";
+    if (err && err.body && err.body.includes && err.body.includes(id)) {
+      return [
+        "Several_operations",
+        "Only one manager operation per manager per block allowed ",
+      ];
+    }
+    return undefined;
+  };
   return (
     parseInsufficientBalance(err) ||
-    parseErrorFromSmartContract(err) || ["Unknown", inspect(err)]
+    parseErrorFromSmartContract(err) ||
+    parseFailure(err) || ["Unknown", inspect(err)]
   );
 };
 

--- a/deku-p/src/core/tezos_interop/tezos_js_bridge.js
+++ b/deku-p/src/core/tezos_interop/tezos_js_bridge.js
@@ -313,12 +313,26 @@ const onRequest = (id, content) => {
   }
 };
 
+const parseError = (err) => {
+  const parseInsufficientBalance = (err) => {
+    const id = "implicit.empty_implicit_contract";
+    if (err && err.body && err.body.includes && err.body.includes(id)) {
+      const address = JSON.parse(err?.body).find((err) =>
+        err.id.includes(id)
+      ).implicit;
+      return ["Insufficient_balance", address];
+    }
+    return undefined;
+  };
+  return parseInsufficientBalance(err) || ["Unknown", inspect(err)];
+};
+
 read((request) => {
   const { id, content } = request;
   onRequest(id, content)
     .catch((err) => {
       const status = "error";
-      const error = inspect(err);
+      const error = parseError(err);
       respond(id, { status, error });
     })
     .catch(failure);


### PR DESCRIPTION
# Problem:

- Wrong level of error from the js interop
- Errors from the interop are not explicit

# Solution:
 - Parsing the errors that come from the interop and apply a good log level on them

Is a screen of the new log in case a operation can't be submitted due to an insufficient balance:

<img width="695" alt="Capture d’écran 2022-11-16 à 12 17 05" src="https://user-images.githubusercontent.com/32832861/202168696-97480596-6698-44f1-9478-eec13b9c17ed.png">


