### PR TITLE
[deku-c-toolkit] Use bigint instead of number

### DIFF
--- a/deku-c/deku-c-toolkit/package.json
+++ b/deku-c/deku-c-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marigold-dev/deku-c-toolkit",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Deku typescript client to interact with deku-c",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/deku-c/deku-c-toolkit/src/contract.ts
+++ b/deku-c/deku-c-toolkit/src/contract.ts
@@ -1,8 +1,9 @@
 import { DekuToolkit } from "@marigold-dev/deku-toolkit";
+import { stringifyReplacer } from "./utils";
 
 export type JSONType =
   | string
-  | number
+  | bigint
   | boolean
   | { [x: string]: JSONType }
   | Array<JSONType>
@@ -15,7 +16,7 @@ const parseContractState = (json: JSONType): JSONType => {
   switch (type) {
     case "Int":
       const value = json[1] as string;
-      return Number.parseInt(value);
+      return BigInt(value);
     case "String": {
       const value = json[1] as string;
       return value;
@@ -144,8 +145,8 @@ export class Contract {
     this.fetchInterval = setInterval(() => {
       this.getState()
         .then((state) => {
-          const previousState = JSON.stringify(previous);
-          const nextState = JSON.stringify(state);
+          const previousState = JSON.stringify(previous, stringifyReplacer);
+          const nextState = JSON.stringify(state, stringifyReplacer);
           if (nextState === previousState) return null;
           callback(state);
           previous = state;

--- a/deku-c/deku-c-toolkit/src/utils.ts
+++ b/deku-c/deku-c-toolkit/src/utils.ts
@@ -45,3 +45,26 @@ export const operationHashToContractAddress = async (
   if (response.ok) return json.address;
   throw json;
 };
+
+
+/**
+ * Helper to correctly parse BigInt
+ * @param _key unused
+ * @param value can be e BigInt
+ * @returns 
+ */
+export const parseReviver = (_key: any, value: any) => {
+  const regex = new RegExp("^[0-9]+bigint$");
+  if (typeof value === 'string' && regex.test(value)) {
+    return BigInt(value.slice(0, -6));
+  }
+  return value;
+}
+
+export const stringifyReplacer = (_key: any, value: any) => {
+  if (typeof value === 'bigint') {
+    return value.toString() + 'bigint';
+  } else {
+    return value;
+  }
+}


### PR DESCRIPTION
## Problem

Using number in javascript to represent `Int` from WASM VM can lead to manipulate some `infinity` values...

## Solution

Toolkig v0.1.5

Use `bigint` in the deku-c-toolkit instead of number

## Tests

- [x] tested locally with decookies ✅ 