### PR TITLE
[deku-c-toolkit] Expose cancelOnNewState function

### DIFF
--- a/deku-c/deku-c-toolkit/package.json
+++ b/deku-c/deku-c-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marigold-dev/deku-c-toolkit",
-  "version": "0.1.4",
+  "version": "0.1.6",
   "description": "Deku typescript client to interact with deku-c",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/deku-c/deku-c-toolkit/src/contract.ts
+++ b/deku-c/deku-c-toolkit/src/contract.ts
@@ -95,7 +95,7 @@ export class Contract {
   }
 
   /**
-   * Invoke a deku-c smart contrat
+   * Invoke a Deku-C smart contrat
    * @param parameter the parameter of the contract
    * @returns the hash of the operation
    */
@@ -113,8 +113,8 @@ export class Contract {
 
   /**
    * Returns the state of the contract
-   * Parses it to a readable javascript object
-   * @returns javascript object
+   * Parses it to a readable Javascript object
+   * @returns Javascript object
    */
   async getState(): Promise<any | null> {
     const state = await this.getRawState();
@@ -123,7 +123,7 @@ export class Contract {
   }
 
   /**
-   * Returns the state of the contract as a wasm-vm state object
+   * Returns the state of the contract as a WASM-VM state object
    * @returns an object representing the state of the contract
    */
   async getRawState(): Promise<JSONType | null> {
@@ -137,6 +137,11 @@ export class Contract {
     return json["state"];
   }
 
+  /**
+   * Fetch the WASM-VM state of the contract each second
+   * Returns it as an object if there is at least one difference
+   * @returns an object representing the state of the contract
+   */
   async onNewState(callback: (state: JSONType) => void): Promise<void> {
     // pull strategy
     let previous: JSONType = null;
@@ -155,6 +160,11 @@ export class Contract {
     }, 1000);
   }
 
+  /**
+   * Cancel the interval to fetch the new state each second
+   * Can be useful to disconnect your user from your application
+   * @returns an object representing the state of the contract
+   */
   cancelOnNewState(): void {
     if (this.fetchInterval) clearInterval(this.fetchInterval);
   }

--- a/deku-c/deku-c-toolkit/src/contract.ts
+++ b/deku-c/deku-c-toolkit/src/contract.ts
@@ -152,6 +152,10 @@ export class Contract {
           return null;
         })
         .catch(console.error);
-    }, 2000);
+    }, 1000);
+  }
+
+  cancelOnNewState(): void {
+    if (this.fetchInterval) clearInterval(this.fetchInterval);
   }
 }


### PR DESCRIPTION
## Depends

- [ ] #988 

## Problem

There is no function exposed by the toolkit to cancel the interval of `onNewState`.
Bump version to 0.1.6

## Solution

Add a `cancelOnNewState` function to clear the interval.
