### PR TITLE
storage: use data encoding for API blocks table

### DIFF
--- a/deku-p/src/core/bin/api/deku_api.ml
+++ b/deku-p/src/core/bin/api/deku_api.ml
@@ -35,7 +35,9 @@ let make_dump_loop ~sw ~env ~data_folder =
   dump
 
 let save_block ~sw ~indexer ~block =
-  let on_error err = print_endline (Printexc.to_string err) in
+  let on_error err =
+    Format.eprintf "save_block.error: %s\n%!" (Printexc.to_string err)
+  in
   (* TODO: better logging *)
   Eio.Fiber.fork_sub ~sw ~on_error @@ fun _sw ->
   Block_storage.save_block ~block indexer

--- a/deku-p/src/core/block_storage/block_storage.ml
+++ b/deku-p/src/core/block_storage/block_storage.ml
@@ -50,13 +50,28 @@ let save_message ~message storage =
   let timestamp = Unix.gettimeofday () |> Timestamp.of_float in
   await_or_fail (Query.insert_message ~message ~timestamp pool)
 
+let binary_block_to_yojson ~block =
+  Parallel.parallel @@ fun () ->
+  match
+    let block = Data_encoding.Binary.of_string_exn Block.encoding block in
+    Block.yojson_of_t block
+  with
+  | json -> Some json
+  | exception _exn -> None
+
 let find_block_by_level ~level storage =
-  with_pool storage @@ fun pool ->
-  await_or_fail (Query.find_block_by_level ~level pool)
+  let block =
+    with_pool storage @@ fun pool ->
+    await_or_fail (Query.find_block_by_level ~level pool)
+  in
+  match block with Some block -> binary_block_to_yojson ~block | None -> None
 
 let find_block_by_hash ~block_hash storage =
-  with_pool storage @@ fun pool ->
-  await_or_fail (Query.find_block_by_hash ~hash:block_hash pool)
+  let block =
+    with_pool storage @@ fun pool ->
+    await_or_fail (Query.find_block_by_hash ~hash:block_hash pool)
+  in
+  match block with Some block -> binary_block_to_yojson ~block | None -> None
 
 let find_block_and_votes_by_level ~level storage =
   with_pool storage @@ fun pool ->

--- a/deku-p/src/core/block_storage/query.mli
+++ b/deku-p/src/core/block_storage/query.mli
@@ -26,11 +26,10 @@ val insert_message :
   pool ->
   unit result_promise
 
-val find_block_by_level :
-  level:Level.t -> pool -> Yojson.Safe.t option result_promise
+val find_block_by_level : level:Level.t -> pool -> string option result_promise
 
 val find_block_by_hash :
-  hash:Block_hash.t -> pool -> Yojson.Safe.t option result_promise
+  hash:Block_hash.t -> pool -> string option result_promise
 
 val find_block_and_votes_by_level :
   level:Level.t -> pool -> Message.Network.t option result_promise

--- a/deku-p/src/core/block_storage/types.ml
+++ b/deku-p/src/core/block_storage/types.ml
@@ -41,17 +41,14 @@ module Timestamp : Rapper.CUSTOM with type t = Timestamp.t = struct
     Caqti_type.(custom ~encode ~decode float)
 end
 
-module Block : Rapper.CUSTOM with type t = Yojson.Safe.t = struct
-  type t = Yojson.Safe.t
+module Block : Rapper.CUSTOM with type t = string = struct
+  type t = string
 
   let t =
-    let encode block =
-      block |> Yojson.Safe.to_string |> Ezgzip.compress |> Result.ok
-    in
+    let encode block = block |> Ezgzip.compress |> Result.ok in
     let decode json =
       try
         json |> Ezgzip.decompress
-        |> Result.map Yojson.Safe.from_string
         |> Result.map_error (fun _err -> "cannot decompress block")
       with exn ->
         Error


### PR DESCRIPTION
# Problem:

Not all the blocks are saved in the Block_storage

# Solution:
Removing yojson from the block_storage and use Data_encoding instead