### PR TITLE
Add block_storage load block and votes test

### DIFF
--- a/deku-p/src/core/block_storage/tests/block_storage_tests.ml
+++ b/deku-p/src/core/block_storage/tests/block_storage_tests.ml
@@ -2,13 +2,21 @@ open Deku_stdlib
 open Deku_crypto
 open Deku_consensus
 open Deku_concepts
+open Deku_gossip
 
 let block_testable = Alcotest.testable Block.pp Block.equal
+
+let vote_testable =
+  Alcotest.testable Verified_signature.pp Verified_signature.equal
 
 let identity =
   let secret = Ed25519.Secret.generate () in
   let secret = Secret.Ed25519 secret in
   Identity.make secret
+
+let make_vote ~hash identity =
+  let hash = Block_hash.to_blake2b hash in
+  Verified_signature.sign hash identity
 
 let block ~default_block_size =
   let above = Genesis.block in
@@ -59,6 +67,47 @@ let test_empty_block_load env () =
     ~msg:"level loaded block is equal to saved block" ~expected:block
     ~actual:retrieved_block;
 
+  (* TODO: Fail the switch and capture the exception instead *)
+  let (Deku_block_storage.Block_storage.Storage { worker; _ }) =
+    block_storage
+  in
+  Parallel.Worker.teardown worker
+
+let test_empty_block_and_votes env () =
+  Eio.Switch.run @@ fun sw ->
+  let block_storage = make_block_storage env sw in
+  let (Block { hash; level; _ } as block) = block ~default_block_size:0 in
+  let vote = make_vote ~hash identity in
+  let votes = Verified_signature.Set.add vote Verified_signature.Set.empty in
+  let votes = Verified_signature.Set.elements votes in
+  let content = Deku_gossip.Message.Content.accepted ~block ~votes in
+  let (Deku_gossip.Message.Message { header = _; content = _; network }) =
+    Deku_gossip.Message.encode ~content
+  in
+  Deku_block_storage.Block_storage.save_block_and_votes ~level ~network
+    block_storage;
+
+  let retrieved_block_and_votes =
+    let default_return = (Genesis.block, []) in
+    match
+      Deku_block_storage.Block_storage.find_block_and_votes_by_level ~level
+        block_storage
+    with
+    | Some (Message.Network.Network_message { raw_header; raw_content }) -> (
+        let expected = Message.Header.decode ~raw_header in
+        let (Message.Message { content; _ }) =
+          Message.decode ~expected ~raw_content
+        in
+        match content with
+        | Content_accepted { block; votes } -> (block, votes)
+        | _ -> default_return)
+    | None -> default_return
+  in
+  Alcotest.(check' (pair block_testable (list vote_testable)))
+    ~msg:"retrieved empty block and one vote equal saved"
+    ~expected:(block, votes) ~actual:retrieved_block_and_votes;
+
+  (* TODO: Fail the switch and capture the exception instead *)
   let (Deku_block_storage.Block_storage.Storage { worker; _ }) =
     block_storage
   in
@@ -76,6 +125,8 @@ let run () =
         [
           test_case "empty_block is returned" `Quick
             (eio_test_case test_empty_block_load);
+          test_case "empty block and one vote is returned" `Quick
+            (eio_test_case test_empty_block_and_votes);
         ] );
     ]
 


### PR DESCRIPTION
## Depends

- [ ] #1010 

## Problem

We want to ensure that our block_storage can save and load block-votes pairs

## Solution

This PR saves and loads a block-votes pair. This involves encoding and decoding the block-votes pairs, which adds more entropy to the test. 