### PR TITLE
Fix push bool primitives and NOW

### DIFF
--- a/deku-c/tunac/lib/compiler.ml
+++ b/deku-c/tunac/lib/compiler.ml
@@ -240,6 +240,10 @@ let rec compile_instruction ~ctx instruction =
         s
   | Prim (_, I_PUSH, [ _; Bytes (_, b) ], _) ->
       compile_constant ~ctx (Values.Bytes b)
+  | Prim (_, I_PUSH, [ _; Prim (_, D_False, _, _) ], _) ->
+      "(call $push (call $false))"
+  | Prim (_, I_PUSH, [ _; Prim (_, D_True, _, _) ], _) ->
+      "(call $push (call $true))"
   | Prim (_, I_LAMBDA, [ _; _; Seq (_, body) ], _) ->
       let name = gen_symbol ~ctx "$lambda" in
       let lambda = compile_lambda ~ctx ~unit:false name body in

--- a/deku-c/tunac/lib/template.ml
+++ b/deku-c/tunac/lib/template.ml
@@ -31,7 +31,8 @@ let import_list =
     func ref_ref__ref "compare";
     func ref__ref "car";
     func ref__ref "cdr";
-    func ref__ref "some" (* ; func const "now" *);
+    func ref__ref "some";
+    func const "now";
     func const "nil";
     func const "true";
     func ref_i32__unit "unpair_n";


### PR DESCRIPTION
<!---
  if some of the following sections doesn't apply,
  delete the section.

  Also feel free to delete the comments.
--->

## Problem

`PUSH bool True` and `PUSH bool False`  doesn't work. Also the `$now` import was previously removed.

## Solution

They needed to be implemented, also put `$now` back.

 