### PR TITLE
chore: kubernetes wants entrypoint to be a string array

### DIFF
--- a/nix/deku-p/docker.nix
+++ b/nix/deku-p/docker.nix
@@ -41,6 +41,6 @@ in
         "NIX_SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
       ];
       WorkingDir = "/app";
-      Entrypoint = "${script}/bin/deku-node";
+      Entrypoint = [ "${script}/bin/deku-node" ];
     };
   }


### PR DESCRIPTION
## Problem

<!--- Restate the problem addressed by the PR here --->

Kubernetes will complain if EntryPoint is a string instead of string array

```
error: code = Unknown desc = failed to pull and unpack image "ghcr.io/marigold-dev/deku:latest": unmarshal image config: json: cannot unmarshal string into Go struct field ImageConfig.config.Entrypoint of type []string
```

## Solution

<!--- Restate the basic ideas behind your solution --->
<!--- Here it is also a good space to put details of your implementation --->

Make it into a array
 