### PR TITLE
handle set while parsing contract state

### DIFF
--- a/deku-c/client/package.json
+++ b/deku-c/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marigold-dev/deku",
-  "version": "0.1.4",
+  "version": "0.1.3",
   "description": "Toolkit to interact with Deku in front-end applications",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/deku-c/client/package.json
+++ b/deku-c/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marigold-dev/deku",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Toolkit to interact with Deku in front-end applications",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/deku-c/client/src/deku-c/contract.ts
+++ b/deku-c/client/src/deku-c/contract.ts
@@ -37,6 +37,10 @@ const parseContractState = (json: JSONType): JSONType => {
       const first = json[1] as Array<JSONType>;
       return first.map((json) => parseContractState(json));
     }
+    case "Set": {
+      const first = json[1] as Array<JSONType>;
+      return first.map((json) => parseContractState(json));
+    }
     case "Union": {
       const first = json[1] as Array<JSONType>;
       const type = first[0] as string;


### PR DESCRIPTION
## Problem

If the state of the contract contains a `set`, toolkit won't parse it correctly and return `null` value.

## Solution

Parse a `set` as a list.
 