### PR TITLE
added eprintf for domains

### DIFF
--- a/deku-p/src/core/bin/benchmark/deku_benchmark.ml
+++ b/deku-p/src/core/bin/benchmark/deku_benchmark.ml
@@ -279,6 +279,7 @@ type params = { domains : int [@env "DEKU_DOMAINS"] [@default 16] }
 let main params =
   let { domains } = params in
   Eio_main.run @@ fun env ->
+  Format.eprintf "running with %d domains\n%!" domains;
   Format.printf "benchmark, items, duration\n%!";
   Parallel.Pool.run ~env ~domains @@ fun () ->
   List.iter (fun (module Bench : BENCH) -> run_benchmark (module Bench)) benches


### PR DESCRIPTION
## Problem

We want to know how many domains we're using in the deku-benchmark

## Solution

Add a printf that tells us so